### PR TITLE
Bump generic_form_builder to 0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'gds-sso', '9.2.1'
 
 gem 'mongoid', '2.5.2'
 
-gem 'generic_form_builder', git: 'https://github.com/alphagov/generic_form_builder', ref: '827d941b0ea0285a48daadb7573de1381a3829b5'
+gem 'generic_form_builder', '0.8.0'
 
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', :path => '../govuk_content_models'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/generic_form_builder
-  revision: 827d941b0ea0285a48daadb7573de1381a3829b5
-  ref: 827d941b0ea0285a48daadb7573de1381a3829b5
-  specs:
-    generic_form_builder (0.7.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -89,6 +82,7 @@ GEM
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
+    generic_form_builder (0.8.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     govspeak (1.3.0)
@@ -242,7 +236,7 @@ DEPENDENCIES
   debugger
   factory_girl (= 4.3.0)
   gds-sso (= 9.2.1)
-  generic_form_builder!
+  generic_form_builder (= 0.8.0)
   govuk_content_models (= 6.4.0)
   govuk_frontend_toolkit (= 0.43.0)
   launchy


### PR DESCRIPTION
Introduces more markup from @edds around inline error messaging.
