### PR TITLE
Set artefact path for router registration

### DIFF
--- a/app/models/specialist_document_registry.rb
+++ b/app/models/specialist_document_registry.rb
@@ -110,6 +110,7 @@ protected
       kind: 'specialist-document',
       owning_app: 'specialist-publisher',
       rendering_app: 'specialist-frontend',
+      paths: ["/#{document.slug}"],
       state: state
     }
   end

--- a/spec/models/specialist_document_registry_spec.rb
+++ b/spec/models/specialist_document_registry_spec.rb
@@ -59,6 +59,7 @@ describe SpecialistDocumentRegistry do
         artefact.name.should == @document.title
         artefact.owning_app.should == "specialist-publisher"
         artefact.rendering_app.should == "specialist-frontend"
+        artefact.paths.should == ["/#{@document.slug}"]
         artefact.state.should == "draft"
 
         editions.count.should == 1


### PR DESCRIPTION
If a path is present in the artefact then panopticon will register the
artefact with the router upon publication. Note that specifiying 'path'
causes an exact path route to be registered (as opposed to a prefix
route).
