### PR TITLE
Rename SpecialistDocumentRegistry to ...Repository

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -29,7 +29,7 @@ protected
   def document
     @document ||= begin
       if params[:id]
-        current_document = specialist_document_registry.fetch(params[:id])
+        current_document = specialist_document_repository.fetch(params[:id])
 
         if current_document && params[:specialist_document]
           current_document.update(params[:specialist_document])
@@ -44,13 +44,13 @@ protected
   helper_method :document
 
   def documents
-    @documents ||= specialist_document_registry.all
+    @documents ||= specialist_document_repository.all
   end
   helper_method :documents
 
   def store(document, publish: false)
-    specialist_document_registry.store!(document).tap {
-      specialist_document_registry.publish!(document) if publish
+    specialist_document_repository.store!(document).tap {
+      specialist_document_repository.publish!(document) if publish
     }
   end
 end

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -14,8 +14,8 @@ SpecialistPublisherWiring = DependencyContainer.new do
     }
   }
 
-  define_singleton(:specialist_document_registry) do
-    build_with_dependencies(SpecialistDocumentRegistry)
+  define_singleton(:specialist_document_repository) do
+    build_with_dependencies(SpecialistDocumentRepository)
   end
 
   define_singleton(:id_generator) { SecureRandom.method(:uuid) }

--- a/app/models/specialist_document_repository.rb
+++ b/app/models/specialist_document_repository.rb
@@ -1,6 +1,6 @@
 require "gds_api/panopticon"
 
-class SpecialistDocumentRegistry
+class SpecialistDocumentRepository
 
   def initialize(panopticon_mappings, specialist_document_editions, panopticon_api, specialist_document_factory)
     @panopticon_mappings = panopticon_mappings

--- a/features/step_definitions/case_workflow_steps.rb
+++ b/features/step_definitions/case_workflow_steps.rb
@@ -1,6 +1,6 @@
 Then(/^the CMA case should be in draft$/) do
   expect(
-    specialist_document_registry.all.last
+    specialist_document_repository.all.last
   ).to be_draft
 end
 
@@ -11,6 +11,6 @@ end
 
 Then(/^the CMA case should be published$/) do
   expect(
-    specialist_document_registry.all.last
+    specialist_document_repository.all.last
   ).to be_published
 end

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -66,7 +66,7 @@ def create_cases(number_of_cases, state: 'draft')
       state: state,
     )
 
-    specialist_document_registry.store!(doc)
+    specialist_document_repository.store!(doc)
 
     Timecop.travel(10.minutes.from_now)
   end

--- a/features/support/cma_cases.rb
+++ b/features/support/cma_cases.rb
@@ -55,7 +55,7 @@ def check_for_cma_cases(*titles)
 end
 
 def go_to_edit_page_for_most_recent_case
-  registry = SpecialistPublisherWiring.get(:specialist_document_registry)
+  registry = SpecialistPublisherWiring.get(:specialist_document_repository)
   document = registry.all.last
 
   visit edit_specialist_document_path(document.id)

--- a/spec/models/specialist_document_repository_spec.rb
+++ b/spec/models/specialist_document_repository_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SpecialistDocumentRegistry do
+describe SpecialistDocumentRepository do
 
   let(:panopticon) do
     double(:panopticon_api, create_artefact!: {'id' => panopticon_id}, put_artefact!: nil)
@@ -8,8 +8,8 @@ describe SpecialistDocumentRegistry do
 
   let(:panopticon_id) { 'example-panopticon-id' }
 
-  let(:specialist_document_registry) do
-    SpecialistDocumentRegistry.new(PanopticonMapping, SpecialistDocumentEdition, panopticon, document_factory)
+  let(:specialist_document_repository) do
+    SpecialistDocumentRepository.new(PanopticonMapping, SpecialistDocumentEdition, panopticon, document_factory)
   end
 
   let(:document_factory) { double(:document_factory, call: document) }
@@ -68,7 +68,7 @@ describe SpecialistDocumentRegistry do
     end
 
     it "returns all documents by date updated desc" do
-      specialist_document_registry.all.map(&:title).should == [@edition_2, @edition_1].map(&:title)
+      specialist_document_repository.all.map(&:title).should == [@edition_2, @edition_1].map(&:title)
     end
   end
 
@@ -84,13 +84,13 @@ describe SpecialistDocumentRegistry do
     end
 
     it "populates the document with all editions for that document id" do
-      specialist_document_registry.fetch(document_id)
+      specialist_document_repository.fetch(document_id)
 
       expect(document_factory).to have_received(:call).with(document_id, editions)
     end
 
     it "returns the document" do
-      expect(specialist_document_registry.fetch(document_id)).to eq(document)
+      expect(specialist_document_repository.fetch(document_id)).to eq(document)
     end
 
     context "when there are no editions" do
@@ -101,7 +101,7 @@ describe SpecialistDocumentRegistry do
       end
 
       it "returns nil" do
-        expect(specialist_document_registry.fetch(document_id)).to be(nil)
+        expect(specialist_document_repository.fetch(document_id)).to be(nil)
       end
     end
   end
@@ -121,7 +121,7 @@ describe SpecialistDocumentRegistry do
           )
         )
 
-        specialist_document_registry.store!(@document)
+        specialist_document_repository.store!(@document)
       end
 
       it "creates a draft artefact" do
@@ -133,11 +133,11 @@ describe SpecialistDocumentRegistry do
           )
         )
 
-        specialist_document_registry.store!(@document)
+        specialist_document_repository.store!(@document)
       end
 
       it "stores a mapping of document id to panopticon id" do
-        specialist_document_registry.store!(@document)
+        specialist_document_repository.store!(@document)
 
         assert PanopticonMapping.exists?(conditions: {document_id: @document.id, panopticon_id: panopticon_id})
       end
@@ -145,7 +145,7 @@ describe SpecialistDocumentRegistry do
 
     describe "#publish!(document)" do
       it "raises an InvalidDocumentError" do
-        expect { specialist_document_registry.publish!(@document) }.to raise_error(SpecialistDocumentRegistry::InvalidDocumentError)
+        expect { specialist_document_repository.publish!(@document) }.to raise_error(SpecialistDocumentRepository::InvalidDocumentError)
       end
     end
   end
@@ -157,7 +157,7 @@ describe "#store!(document)" do
     end
 
     it "returns false" do
-      expect(specialist_document_registry.store!(document)).to be false
+      expect(specialist_document_repository.store!(document)).to be false
     end
   end
 
@@ -172,11 +172,11 @@ describe "#store!(document)" do
     let(:editions) { [previous_edition, latest_edition] }
 
     it "returns true" do
-      expect(specialist_document_registry.store!(document)).to be true
+      expect(specialist_document_repository.store!(document)).to be true
     end
 
     it "only saves the latest edition" do
-      specialist_document_registry.store!(document)
+      specialist_document_repository.store!(document)
 
       expect(latest_edition).to have_received(:save)
       expect(previous_edition).not_to have_received(:save)
@@ -193,13 +193,13 @@ end
 
     describe "#publish!(document)" do
       it "the document becomes published" do
-        specialist_document_registry.publish!(@document)
+        specialist_document_repository.publish!(@document)
         @document.should be_published
       end
 
       it "notifies panopticon of the update" do
         panopticon.should_receive(:put_artefact!).with(@mapping.panopticon_id, anything)
-        specialist_document_registry.publish!(@document)
+        specialist_document_repository.publish!(@document)
       end
     end
   end
@@ -213,7 +213,7 @@ end
     describe "#publish!(document)" do
       it "does not notify panopticon of the update" do
         panopticon.should_not_receive(:put_artefact!)
-        specialist_document_registry.publish!(@document)
+        specialist_document_repository.publish!(@document)
       end
     end
   end
@@ -229,11 +229,11 @@ end
 
       it "sets error messages on the document" do
         new_draft_edition.should_receive(:add_error).with(:slug, include('already taken'))
-        specialist_document_registry.store!(document)
+        specialist_document_repository.store!(document)
       end
 
       it "returns false" do
-        specialist_document_registry.store!(document).should == false
+        specialist_document_repository.store!(document).should == false
       end
     end
   end


### PR DESCRIPTION
It should have been called a repository as that's the pattern we're
following:

http://martinfowler.com/eaaCatalog/repository.html
