### PR TITLE
Bugfix: don't crash when attempting to publish new invalid doc

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -49,8 +49,8 @@ protected
   helper_method :documents
 
   def store(document, publish: false)
-    specialist_document_repository.store!(document).tap {
+    if specialist_document_repository.store!(document)
       specialist_document_repository.publish!(document) if publish
-    }
+    end
   end
 end

--- a/features/publishing-a-cma-case.feature
+++ b/features/publishing-a-cma-case.feature
@@ -18,3 +18,7 @@ Feature: Publishing a CMA case
   Scenario: can create a new CMA case and publish immediately
     When I publish a new CMA case
     Then the CMA case should be published
+
+  Scenario: validation errors on publishing
+    When I attempt to publish a new CMA case without a title
+    Then I should see the editing form again with an error about the missing title

--- a/features/step_definitions/case_workflow_steps.rb
+++ b/features/step_definitions/case_workflow_steps.rb
@@ -14,3 +14,17 @@ Then(/^the CMA case should be published$/) do
     specialist_document_repository.all.last
   ).to be_published
 end
+
+When(/^I attempt to publish a new CMA case without a title$/) do
+  @cma_fields = {
+    summary: 'Nullam quis risus eget urna mollis ornare vel eu leo.',
+    body: ('Praesent commodo cursus magna, vel scelerisque nisl consectetur et.' * 10),
+    opened_date: '2014-01-01'
+  }
+
+  create_cma_case(@cma_fields, publish: true)
+end
+
+Then(/^I should see the editing form again with an error about the missing title$/) do
+  check_for_missing_title_error
+end


### PR DESCRIPTION
Not sure what the thinking was behind `.tap`, it will always execute the
block.

Added a cucumber scenario for this as well, although that might be
better covered by a lower level test.
