### PR TITLE
Fix slug bug

### DIFF
--- a/app/lib/slug_generator.rb
+++ b/app/lib/slug_generator.rb
@@ -1,6 +1,10 @@
 class SlugGenerator
   def self.generate_slug(document)
-    document_slug = document.title.downcase.gsub(/[^a-zA-Z0-9]+/, '-')
+    document_slug = document.title
+      .downcase
+      .gsub(/[^a-zA-Z0-9]+/, '-')
+      .gsub(/-+$/, '')
+
     "cma-cases/#{document_slug}"
   end
 end

--- a/spec/lib/slug_generator_spec.rb
+++ b/spec/lib/slug_generator_spec.rb
@@ -16,4 +16,12 @@ describe SlugGenerator do
 
     expect(generated_slug).to eq("cma-cases/test-document-1")
   end
+
+  it "removes non-word-character—hyphens from the end of the slug" do
+    document = double("document", title: 'Test Document ')
+
+    generated_slug = SlugGenerator.generate_slug(document)
+
+    expect(generated_slug).to eq("cma-cases/test-document")
+  end
 end


### PR DESCRIPTION
Slugs with trailing hyphens fail validations (and are a bit ugly).
