### PR TITLE
Add visibility option for dependency methods

### DIFF
--- a/lib/dependency_container.rb
+++ b/lib/dependency_container.rb
@@ -29,9 +29,12 @@ class DependencyContainer
     @definitions[name] || raise("Missing dependency #{name}")
   end
 
-  def inject_into(klass)
+  def inject_into(klass, visibility: :private)
     @definitions.each do |name, dependency|
-      klass.send(:define_method, name) { dependency.get } unless klass.method_defined?(name)
+      unless klass.method_defined?(name)
+        klass.send(:define_method, name) { dependency.get }
+        klass.send(visibility, name)
+      end
     end
   end
 

--- a/spec/dependency_container_spec.rb
+++ b/spec/dependency_container_spec.rb
@@ -45,14 +45,41 @@ describe DependencyContainer do
     expect(container.get(:example)).to be_a ExampleClass
   end
 
-  it "can inject helper methods for all defined dependencies" do
-    container = DependencyContainer.new
-    container.define_singleton(:example) { ExampleClass.new }
+  describe "#inject_into" do
+    let(:container) {
+      DependencyContainer.new.tap{ |c|
+        c.define_singleton(:example) { ExampleClass.new }
+      }
+    }
 
-    my_class = Class.new
-    container.inject_into(my_class)
+    let(:target_class) { Class.new }
 
-    expect(my_class.new.example).to be_a ExampleClass
+    context "without a visibity option" do
+      it "injects private helper methods for all defined dependencies" do
+        container.inject_into(target_class)
+
+        expect(target_class.private_instance_methods).to include(:example)
+        expect(target_class.new.send(:example)).to be_a ExampleClass
+      end
+    end
+
+    context "with visibility option set to public" do
+      it "injects private helper methods for all defined dependencies" do
+        container.inject_into(target_class, visibility: :public)
+
+        expect(target_class.public_instance_methods).to include(:example)
+        expect(target_class.new.send(:example)).to be_a ExampleClass
+      end
+    end
+
+    context "with visibility option set to protected" do
+      it "injects protected helper methods for all defined dependencies" do
+        container.inject_into(target_class, visibility: :protected)
+
+        expect(target_class.protected_instance_methods).to include(:example)
+        expect(target_class.new.send(:example)).to be_a ExampleClass
+      end
+    end
   end
 
   context "a class with a constructor dependency" do


### PR DESCRIPTION
Factory methods from DepenencyContainer are usually used in a private
or protected context so it makes sense for the visiblity to be
configurable and have a sensible default (private).
