### PR TITLE
Hide primary links in document preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 group :assets do
   gem "sass-rails", "3.2.6"
   gem "uglifier", ">= 1.3.0"
-  gem "govuk_frontend_toolkit", "0.43.0"
+  gem "govuk_frontend_toolkit", "0.44.0"
 end
 
 gem "byebug", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       mongoid (~> 2.5)
       plek
       state_machine
-    govuk_frontend_toolkit (0.43.0)
+    govuk_frontend_toolkit (0.44.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hashie (2.0.5)
@@ -259,7 +259,7 @@ DEPENDENCIES
   generic_form_builder (= 0.8.0)
   govspeak (= 1.5.1)
   govuk_content_models (= 8.6.0)
-  govuk_frontend_toolkit (= 0.43.0)
+  govuk_frontend_toolkit (= 0.44.0)
   launchy
   mongoid (= 2.5.2)
   multi_json (= 1.9.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,11 @@
 //= require vendor/jquery-1.11.0.min
 //= require vendor/bootstrap
+//= require govuk_toolkit
 //= require ajax_setup
 //= require specialist_documents
+
+function initPrimaryLinks(){
+  GOVUK.primaryLinks.init('.primary-item');
+}
+$(initPrimaryLinks);
+$(window).on('displayPreviewDone', initPrimaryLinks);

--- a/app/assets/javascripts/specialist_documents.js
+++ b/app/assets/javascripts/specialist_documents.js
@@ -14,6 +14,7 @@
 
     function displayPreview(previewHtml) {
       $(args.render_to).html(previewHtml);
+      $(window).trigger('displayPreviewDone');
     }
 
     function getPreview(){

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -40,6 +40,11 @@ form {
   .preview {
     border: 1px solid $border-colour;
     padding: $gutter-half;
+
+    .visuallyhidden {
+      position: absolute;
+      left: -9999em;
+    }
   }
 }
 


### PR DESCRIPTION
Using the JavaScript from the frontend toolkit hide the non-primary
links in the preview.

https://www.pivotaltracker.com/story/show/67553858
