### PR TITLE
Make the document exporter render option labels

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -102,6 +102,7 @@ SpecialistPublisherWiring = DependencyContainer.new do
       SpecialistDocumentExporter.new(
         RenderedSpecialistDocument,
         get(:specialist_document_renderer),
+        get(:finder_schema),
         doc,
       ).call
     }

--- a/spec/specialist_document_exporter_spec.rb
+++ b/spec/specialist_document_exporter_spec.rb
@@ -7,31 +7,30 @@ describe SpecialistDocumentExporter do
     SpecialistDocumentExporter.new(
       export_recipent,
       document_renderer,
+      finder_schema,
       document,
     )
   }
 
   let(:export_recipent) { double(:export_recipent, create_or_update_by_slug!: nil) }
-  let(:document) { double(:document) }
-  let(:document_id) { double(:document_id) }
-
-  let(:document_renderer) {
-    double(:document_renderer, call: rendered_document)
+  let(:document_renderer) { double(:document_renderer, call: rendered_document) }
+  let(:finder_schema) {
+    double(:finder_schema, facets: [:case_type]).tap do |f|
+      allow(f).to receive(:options_for).with(:case_type).and_return([["CA98 and civil cartels", "ca98-and-civil-cartels"]])
+    end
   }
+  let(:document) { double(:document) }
 
   let(:rendered_document) {
     double(:rendered_document, attributes: rendered_attributes)
   }
 
+  let(:document_id) { double(:document_id) }
+
   let(:rendered_attributes) {
     {
       id: document_id,
-    }.merge(exportable_attributes)
-  }
-
-  let(:exportable_attributes) {
-    {
-      a_field: "a value",
+      case_type: "ca98-and-civil-cartels"
     }
   }
 
@@ -45,7 +44,18 @@ describe SpecialistDocumentExporter do
     exporter.call
 
     expect(export_recipent).to have_received(:create_or_update_by_slug!).with(
-      hash_including(exportable_attributes)
+      hash_including(case_type: "ca98-and-civil-cartels")
+    )
+  end
+
+  it "exports both labels and values for filterable options" do
+    exporter.call
+
+    expect(export_recipent).to have_received(:create_or_update_by_slug!).with(
+      hash_including(
+        case_type: "ca98-and-civil-cartels",
+        case_type_label: "CA98 and civil cartels"
+      )
     )
   end
 


### PR DESCRIPTION
We need the option labels to be included in the artefact presented by
the content api to the specialist-frontend so that the correct labels
appear in the page.

Rather than making the content api communicate with the finder api,
introducing an additional dependency for the finder api, we keep that
knowledge encapsulated in the specialist publisher by rendering the
option labels as well as the option values into the rendered document.
