### PR TITLE
Silence log output in tests

### DIFF
--- a/bin/cma_importer
+++ b/bin/cma_importer
@@ -9,10 +9,13 @@ content_directory = Pathname.new(ARGV.first)
 
 require 'uri'
 require 'cma_importer'
+require 'logger'
+
+logger = Logger.new(STDOUT)
 
 Pathname.glob("#{content_directory}/*.json").each do |case_file|
   puts "Processing #{case_file}"
   case_data = JSON.parse(case_file.read)
 
-  CMAImporter::DocumentImporter.new(content_directory, case_data, case_file.realpath).import
+  CMAImporter::DocumentImporter.new(content_directory, case_data, case_file.realpath, logger).import
 end


### PR DESCRIPTION
We don't want the importer printing log output when running tests.

This gives it a logger parameter which defaults to using the nil logger.
