### PR TITLE
Move attachments to after govspeak help

### DIFF
--- a/app/views/specialist_documents/_form.html.erb
+++ b/app/views/specialist_documents/_form.html.erb
@@ -42,14 +42,9 @@
 </div>
 
 <div class="col-md-4">
+  <%= render partial: 'govspeak-help' %>
 
   <h2>Attachments</h2>
-
-  <ul class="attachments">
-    <% document.attachments.each do |attachment| %>
-      <li class="attachment"><span class="title"><%= attachment.title %></span> <span class="snippet"><%= attachment.snippet %></span></li>
-    <% end %>
-  </ul>
 
   <% if document.persisted? %>
     <%= link_to "Add attachment", new_specialist_document_attachment_path(document) %>
@@ -57,7 +52,11 @@
     <p>To add an attachment, please save the draft first.</p>
   <% end %>
 
-  <%= render partial: 'govspeak-help' %>
+  <ul class="attachments">
+    <% document.attachments.each do |attachment| %>
+      <li class="attachment"><span class="title"><%= attachment.title %></span> <span class="snippet"><%= attachment.snippet %></span></li>
+    <% end %>
+  </ul>
 </div>
 
 <%= content_for :document_ready do %>


### PR DESCRIPTION
So that if there is a very long list of attachments you can still get at
the help. Also moved the add new attachment button to the top of the
attachments list so you can add a new attachment without having to
scroll all the way to the bottom.

https://www.pivotaltracker.com/story/show/67980148
