### PR TITLE
Implementation of string replace without regex

### DIFF
--- a/lib/specialist_document_attachment_processor.rb
+++ b/lib/specialist_document_attachment_processor.rb
@@ -4,7 +4,9 @@ class SpecialistDocumentAttachmentProcessor < SimpleDelegator
 
   def body
     attachments.reduce(doc.body) { |body, attachment|
-      body.gsub(attachment.snippet, attachment_markdown(attachment))
+      body.gsub(attachment.snippet) {
+        attachment_markdown(attachment)
+      }
     }
   end
 

--- a/spec/specialist_document_attachment_processor_spec.rb
+++ b/spec/specialist_document_attachment_processor_spec.rb
@@ -50,6 +50,38 @@ this is my attachment [#{title}](#{file_url}) 28 Feb 2014
     it "replaces inline attachment tags with link" do
       expect(renderer.body).to eq(processed_body)
     end
+
+    context "when the title has some regex characters in it" do
+      let(:title) { "Some people have crazy titles \\' \\1 \\2" }
+
+      it "does multiple replacements" do
+        expect(renderer.body).to eq(processed_body)
+      end
+    end
+
+    context "when the attachment link appears more than once" do
+  let(:unprocessed_body) {
+%{
+# Hi
+
+this is my attachment [InlineAttachment:rofl.gif] 28 Feb 2014
+my attachment again [InlineAttachment:rofl.gif] 28 Feb 2014
+}
+  }
+
+  let(:processed_body) {
+%{
+# Hi
+
+this is my attachment [#{title}](#{file_url}) 28 Feb 2014
+my attachment again [#{title}](#{file_url}) 28 Feb 2014
+}
+  }
+
+      it "does multiple replacements" do
+        expect(renderer.body).to eq(processed_body)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
As far as I can tell this is the only way to do string replacement without getting the Regex engine involved.

Motivation is that the attachment title could possibly contain `\\'` which has the following effect when used with `gsub`

```
pry(main)> "all of the things".gsub("all of", "most \\' of")
=> "most  the things of the things"
```

`Regexp.escape` isn't a great option as it escapes spaces.

The other options I can see are
- Use `Regexp.escape` and unescape the spaces (another layer of gsubbing)
- Don't allow `\\'` in the attachment title

The last option raises the question what else shouldn't we allow?
