### PR TITLE
Make mongo instead of ruby get all document ids

### DIFF
--- a/app/models/specialist_document_repository.rb
+++ b/app/models/specialist_document_repository.rb
@@ -15,8 +15,7 @@ class SpecialistDocumentRepository
   end
 
   def all
-    editions = specialist_document_editions.all
-    document_ids = editions.map(&:document_id).uniq
+    document_ids = specialist_document_editions.all.distinct(:document_id)
     documents = document_ids.map { |id| fetch(id) }
 
     documents.sort_by(&:updated_at).reverse


### PR DESCRIPTION
With 385 editions in the database this speeds it up from taking around
10 seconds to taking less than 0.01 seconds.
