### PR TITLE
Optimize document edition loading

### DIFF
--- a/app/models/panopticon_mapping.rb
+++ b/app/models/panopticon_mapping.rb
@@ -5,4 +5,8 @@ class PanopticonMapping
   field :document_id, type: String
   field :panopticon_id, type: String
   field :slug, type: String
+
+  def self.all_document_ids
+    all.lazy.map(&:document_id)
+  end
 end

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -32,7 +32,7 @@ class SpecialistDocument
     @slug_generator = slug_generator
     @edition_factory = edition_factory
     @id = id
-    @editions = editions.sort_by(&:version_number)
+    @editions = editions
     @editions.push(create_first_edition) if @editions.empty?
     @exposed_edition = if version_number
       @editions.find { |e| e.version_number == version_number }

--- a/app/models/specialist_document_repository.rb
+++ b/app/models/specialist_document_repository.rb
@@ -15,14 +15,21 @@ class SpecialistDocumentRepository
   end
 
   def all
-    document_ids = specialist_document_editions.all.distinct(:document_id)
+    # TODO: add a method on PanopticonMapping to handle this
+    document_ids = panopticon_mappings.all_document_ids
     documents = document_ids.map { |id| fetch(id) }
 
     documents.sort_by(&:updated_at).reverse
   end
 
   def fetch(id)
-    editions = specialist_document_editions.where(document_id: id).to_a
+    # TODO: add a method on SpecialistDocumentEdition to handle this
+    editions = specialist_document_editions
+      .where(document_id: id)
+      .order_by([:version_number, :desc])
+      .limit(2)
+      .to_a
+      .reverse
 
     if editions.empty?
        nil


### PR DESCRIPTION
Document IDs can be more efficiently queried from the Panopticon
mappings.

A document only ever needs a reference to the latest, potentially draft
edition and the previous published version.

Rather than loading all editions we can provide just the previous two.
