### PR TITLE
Handle documents without editions

### DIFF
--- a/app/models/specialist_document_repository.rb
+++ b/app/models/specialist_document_repository.rb
@@ -17,7 +17,7 @@ class SpecialistDocumentRepository
   def all
     # TODO: add a method on PanopticonMapping to handle this
     document_ids = panopticon_mappings.all_document_ids
-    documents = document_ids.map { |id| fetch(id) }
+    documents = document_ids.map { |id| fetch(id) }.to_a.compact
 
     documents.sort_by(&:updated_at).reverse
   end


### PR DESCRIPTION
If a document has no editions then
SpecialistDocumentRepository#fetch(document_id) will return nil. That's
no use, and causes an error when sorting, so compact the collection of
documents after building it.
