### PR TITLE
Arrayify manual documents before mapping

### DIFF
--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -5,7 +5,7 @@ class DocumentAssociationMarshaller
   end
 
   def load(entity, record)
-    docs = record.document_ids.map { |doc_id|
+    docs = Array(record.document_ids).map { |doc_id|
       document_repository.fetch(doc_id)
     }
 


### PR DESCRIPTION
Existing manuals won't have a documents attribute yet. Rather than set
documents on all existing data we just arrayify the input to turn nil
into an empty array.
