### PR TITLE
Fetchable interface for repositories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "3.2.17"
 # Alphabetical order please :)
 gem "airbrake", "3.1.15"
 gem "faraday", "0.9.0"
+gem "fetchable", "1.0.0"
 gem "gds-sso", "9.2.4"
 gem "generic_form_builder", "0.8.0"
 gem "govspeak", "1.5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    fetchable (1.0.0)
     gds-api-adapters (10.9.0)
       link_header
       lrucache (~> 0.1.1)
@@ -267,6 +268,7 @@ DEPENDENCIES
   database_cleaner (= 1.2.0)
   factory_girl (= 4.3.0)
   faraday (= 0.9.0)
+  fetchable (= 1.0.0)
   gds-sso (= 9.2.4)
   generic_form_builder (= 0.8.0)
   govspeak (= 1.5.1)

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -6,7 +6,7 @@ class SpecialistDocumentsController < ApplicationController
 
   before_filter :authorize_user_org
 
-  rescue_from(SpecialistDocumentRepository::NotFound) do
+  rescue_from(KeyError) do
     redirect_to(manuals_path, flash: { error: "Document not found" })
   end
 

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -1,4 +1,8 @@
+require "fetchable"
+
 class ManualRepository
+  include Fetchable
+
   def initialize(dependencies = {})
     @collection = dependencies.fetch(:collection)
     @factory = dependencies.fetch(:factory)
@@ -18,7 +22,7 @@ class ManualRepository
     manual_record.save!
   end
 
-  def fetch(manual_id)
+  def [](manual_id)
     manual_record = collection.find_by(manual_id: manual_id)
 
     build_manual_for(manual_record)

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -1,6 +1,8 @@
 require "gds_api/panopticon"
+require "fetchable"
 
 class SpecialistDocumentRepository
+  include Fetchable
 
   def initialize(panopticon_mappings,
     specialist_document_editions,
@@ -13,12 +15,12 @@ class SpecialistDocumentRepository
   def all
     # TODO: add a method on PanopticonMapping to handle this
     document_ids = panopticon_mappings.all_document_ids
-    documents = document_ids.map { |id| fetch(id) {} }.to_a.compact
+    documents = document_ids.map { |id| self[id] }.to_a.compact
 
     documents.sort_by(&:updated_at).reverse
   end
 
-  def fetch(id, &block)
+  def [](id)
     # TODO: add a method on SpecialistDocumentEdition to handle this
     editions = specialist_document_editions
       .where(document_id: id)
@@ -28,11 +30,7 @@ class SpecialistDocumentRepository
       .reverse
 
     if editions.empty?
-      if block_given?
-        yield(id)
-      else
-        raise NotFound
-      end
+      nil
     else
       document_factory.call(id, editions)
     end

--- a/spec/repositories/manual_repository_spec.rb
+++ b/spec/repositories/manual_repository_spec.rb
@@ -60,6 +60,10 @@ describe ManualRepository do
     }
   }
 
+  it "supports the fetch interface" do
+    expect(repo).to be_a_kind_of(Fetchable)
+  end
+
   describe "#store" do
     let(:draft_edition) { double(:draft_edition, :attributes= => nil) }
 
@@ -118,7 +122,7 @@ describe ManualRepository do
     end
   end
 
-  describe "#fetch" do
+  describe "#[]" do
     before do
       allow(record_collection).to receive(:find_by).and_return(manual_record)
       allow(manual_record).to receive(:latest_edition).and_return(edition)
@@ -126,14 +130,14 @@ describe ManualRepository do
     end
 
     it "finds the manual record by manual id" do
-      repo.fetch(manual_id)
+      repo[manual_id]
 
       expect(record_collection).to have_received(:find_by)
         .with(manual_id: manual_id)
     end
 
     it "builds a new manual from the latest edition" do
-      repo.fetch(manual_id)
+      repo[manual_id]
 
       factory_arguments = edition_attributes.merge(id: manual_id)
 
@@ -142,7 +146,7 @@ describe ManualRepository do
     end
 
     it "returns the built manual" do
-      expect(repo.fetch(manual_id)).to be(manual)
+      expect(repo[manual_id]).to be(manual)
     end
 
     context "with an association_marshaller" do
@@ -155,13 +159,13 @@ describe ManualRepository do
       let(:unmarshalled_manual) { double(:unmarshalled_manual) }
 
       it "calls load on each marshaller with the manual domain object and edition" do
-        repo.fetch(manual_id)
+        repo[manual_id]
 
         expect(association_marshaller).to have_received(:load).with(manual, edition)
       end
 
       it "returns the result of the marshaller" do
-        expect(repo.fetch(manual_id)).to eq(unmarshalled_manual)
+        expect(repo[manual_id]).to eq(unmarshalled_manual)
       end
     end
   end

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -63,6 +63,10 @@ describe SpecialistDocumentRepository do
 
   let(:published_edition) { build_published_edition }
 
+  it "supports the fetch interface" do
+    expect(specialist_document_repository).to be_a_kind_of(Fetchable)
+  end
+
   describe "#all" do
     before do
       @edition_1, @edition_2 = [2, 1].map do |n|
@@ -88,7 +92,7 @@ describe SpecialistDocumentRepository do
     end
   end
 
-  describe "#fetch" do
+  describe "#[]" do
     let(:editions_proxy) { double(:editions_proxy, to_a: editions).as_null_object }
     let(:editions)       { [ published_edition ] }
 
@@ -100,13 +104,13 @@ describe SpecialistDocumentRepository do
     end
 
     it "populates the document with all editions for that document id" do
-      specialist_document_repository.fetch(document_id)
+      specialist_document_repository[document_id]
 
       expect(document_factory).to have_received(:call).with(document_id, editions)
     end
 
     it "returns the document" do
-      expect(specialist_document_repository.fetch(document_id)).to eq(document)
+      expect(specialist_document_repository[document_id]).to eq(document)
     end
 
     context "when there are no editions" do
@@ -114,10 +118,8 @@ describe SpecialistDocumentRepository do
         allow(editions_proxy).to receive(:to_a).and_return([])
       end
 
-      it "raises NotFound" do
-        expect {
-          specialist_document_repository.fetch(document_id)
-        }.to raise_error(SpecialistDocumentRepository::NotFound)
+      it "returns nil" do
+        expect(specialist_document_repository[document_id]).to be_nil
       end
     end
   end


### PR DESCRIPTION
The `Hash#fetch` interface is a standard interface in Ruby so it makes sense that our repositories should implement a a proper implementation of it.

The Fetchable mixin adds this interface and delegates to `#[]` which can simply return nil.
