### PR TITLE
Fix for editing a manual with sections

### DIFF
--- a/app/forms/manual_form.rb
+++ b/app/forms/manual_form.rb
@@ -42,7 +42,7 @@ class ManualForm
   end
 
   def documents
-    []
+    manual && manual.documents || []
   end
 
 private

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -15,6 +15,13 @@ Feature: Creating and editing a manual
     When I edit a manual
     Then the manual should have been updated
 
+  @regression
+  Scenario: Create and edit a manual with documents
+    Given a draft manual exists
+    And a draft document exists for the manual
+    When I edit a manual
+    Then the manual's documents won't have changed
+
   Scenario: Try to create an invalid manual
     When I create a manual with an empty title
     Then I see errors for the title field
@@ -36,6 +43,7 @@ Feature: Creating and editing a manual
     When I attach a file and give it a title
     Then I see the attached file
 
+  @regression
   Scenario: Manual documents are not available as specialist documents
     Given a draft manual exists
     And a draft document exists for the manual

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -60,6 +60,10 @@ Then(/^I see the manual has the new page$/) do
   expect(page).to have_content(@document_fields.fetch(:title))
 end
 
+Then(/^I see the new page$/) do
+  expect(page).to have_content(@document_fields.fetch(:title))
+end
+
 Given(/^a draft document exists for the manual$/) do
   @document_title = 'Section 1'
 
@@ -96,4 +100,8 @@ end
 
 Then(/^the document is not found$/) do
   expect(page).to have_content("Document not found")
+end
+
+Then(/^the manual's documents won't have changed$/) do
+  expect(page).to have_content(@document_fields.fetch(:title))
 end


### PR DESCRIPTION
Previously, editing a manual would cause it to lose the sections that had already been created as they weren't being saved on a form update.
