### PR TITLE
Fix bug with Preview

### DIFF
--- a/app/assets/javascripts/specialist_documents.js
+++ b/app/assets/javascripts/specialist_documents.js
@@ -35,11 +35,7 @@
       return $.ajax({
         url: args.url,
         context: document.body,
-        data: {
-          'specialist_document' : {
-            'body' : $('#specialist_document_body').val()
-          }
-        },
+        data: args.data_target.apply(),
         type: 'post',
         dataType: 'json'
       });

--- a/app/controllers/manual_documents_controller.rb
+++ b/app/controllers/manual_documents_controller.rb
@@ -52,6 +52,10 @@ class ManualDocumentsController < ApplicationController
     end
   end
 
+  def preview
+    render json: { preview_html: generate_preview }
+  end
+
 private
 
   def new_document
@@ -75,6 +79,16 @@ private
   end
 
   def document_params
-    params.fetch("document").merge(document_type: 'manual')
+    params.fetch("document", {}).merge(document_type: 'manual')
+  end
+
+  def generate_preview
+    if current_document
+      preview_document = current_document.update(document_params)
+    else
+      preview_document = specialist_document_builder.call(document_params)
+    end
+
+    specialist_document_renderer.call(preview_document).body
   end
 end

--- a/app/views/manual_documents/_form.html.erb
+++ b/app/views/manual_documents/_form.html.erb
@@ -48,8 +48,15 @@
 
 <%= content_for :document_ready do %>
   window.SpecialistDocument.addPreviewFeature({
-    'url'             : '<%= preview_specialist_document_path(document) %>',
+    'url'             : '<%= preview_manual_document_path(manual, document) %>',
     'insert_into'     : '.preview_container',
-    'render_to'       : '.preview .govspeak'
+    'render_to'       : '.preview .govspeak',
+    'data_target'     : function() {
+                          return {
+                            'document' : {
+                              'body' : $('#document_body').val()
+                            }
+                          };
+                        }
   });
 <% end -%>

--- a/app/views/specialist_documents/_form.html.erb
+++ b/app/views/specialist_documents/_form.html.erb
@@ -64,6 +64,13 @@
   window.SpecialistDocument.addPreviewFeature({
     'url'             : '<%= preview_specialist_document_path(document) %>',
     'insert_into'     : '.preview_container',
-    'render_to'       : '.preview .govspeak'
+    'render_to'       : '.preview .govspeak',
+    'data_target'     : function() {
+                          return {
+                            'specialist_document' : {
+                              'body' : $('#specialist_document_body').val()
+                            }
+                          };
+                        }
   });
 <% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ SpecialistPublisher::Application.routes.draw do
   resources :manuals, except: :destroy do
     resources :documents, except: :destroy, path: 'sections', controller: "ManualDocuments" do
       resources :attachments, controller: "ManualDocumentsAttachments", only: [:new, :create, :edit, :update]
+      post :preview, on: :member
     end
   end
 


### PR DESCRIPTION
The preview function had an issue with working on manuals and new specialist documents. With specialist documents, the preview would only render the body that had been saved so if you were making a new document the preview would be blank and if you were editing a document's body, the preview wouldn't render the changes you'd made. The preview function didn't work at all with manual sections.

This commit fixes the 2 preview bugs and refactors the preview code to be more reusable between different models.
