### PR TITLE
Fix for attachment link visible on invalid manual

### DIFF
--- a/app/forms/manual_document_form.rb
+++ b/app/forms/manual_document_form.rb
@@ -75,7 +75,7 @@ class ManualDocumentForm
   end
 
   def persisted?
-    document.present?
+    document && document.persisted?
   end
 
   def to_param

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -26,6 +26,11 @@ Feature: Creating and editing a manual
     When I create a manual with an empty title
     Then I see errors for the title field
 
+  Scenario: Try to create an invalid manual document
+    Given a draft manual exists
+    When I create a document with empty fields
+    Then I see errors for the document fields
+
   Scenario: Add a document to a manual
     Given a draft manual exists
     When I create a document for the manual

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -105,3 +105,14 @@ end
 Then(/^the manual's documents won't have changed$/) do
   expect(page).to have_content(@document_fields.fetch(:title))
 end
+
+When(/^I create a document with empty fields$/) do
+  create_manual_document(@manual_fields.fetch(:title), {})
+end
+
+Then(/^I see errors for the document fields$/) do
+  ['Title', 'Summary', 'Body'].each do |field|
+    expect(page).to have_content("#{field} can't be blank")
+  end
+  expect(page).not_to have_content('Add attachment')
+end


### PR DESCRIPTION
When creating an invalid manual, after trying to save as a draft, the "Add attachment" link was visible. Now, it's correctly hidden.
