### PR TITLE
Fix editing attachments on manuals

### DIFF
--- a/app/forms/manual_document_form.rb
+++ b/app/forms/manual_document_form.rb
@@ -5,7 +5,7 @@ class ManualDocumentForm
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
-  def_delegators :document, :exposed_edition, :add_attachment, :attachments
+  def_delegators :document, :exposed_edition, :add_attachment, :attachments, :find_attachment_by_id
 
   def errors
     if document
@@ -75,7 +75,7 @@ class ManualDocumentForm
   end
 
   def persisted?
-    document.present?
+    document && document.persisted?
   end
 
   def to_param

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -20,3 +20,12 @@ Feature: Attachments
     Given there is a published case with an attachment
     When I edit the attachment
     Then I see the updated attachment on the document edit page
+
+  @regression
+  Scenario: CMA editor can add and replace attachment to manual
+    Given a draft manual exists
+    And a draft document exists for the manual
+    When I attach a file and give it a title
+    Then I see the attached file
+    When I edit the attachment
+    Then I see the updated attachment on the document edit page

--- a/features/support/attachment_helpers.rb
+++ b/features/support/attachment_helpers.rb
@@ -83,8 +83,6 @@ module AttachmentHelpers
   end
 
   def edit_attachment(document_title, attachment_title, new_attachment_title, new_attachment_file_name)
-    go_to_edit_page_for_most_recent_case
-
     attachment_li = page.find(".attachments li", text: attachment_title)
     attachment_edit_link = attachment_li.find("a", text: "edit")
 
@@ -105,8 +103,6 @@ module AttachmentHelpers
   end
 
   def check_for_attachment_update(document_title, attachment_title, attachment_file_name)
-    go_to_edit_page_for_most_recent_case
-
     expect(page).to have_css(".attachments li", text: @new_attachment_title)
     expect(page).to have_css(".attachments li", text: @new_attachment_file_name)
   end


### PR DESCRIPTION
This commit fixes the 500 error the user would see if trying to edit an attachment from a manual document edit page.

https://trello.com/c/nDSnaoym/95-manual-editing-an-attachment-displays-500
