### PR TITLE
Publish documents via show page

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -29,12 +29,8 @@ class SpecialistDocumentsController < ApplicationController
   def create
     document = services.create_document(self).call
 
-    if document.valid? && publish_document?
-      services.publish_document(document).call
-    end
-
     if document.valid?
-      redirect_to(specialist_documents_path)
+      redirect_to(specialist_document_path(document))
     else
       render(:new, locals: {document: document})
     end
@@ -43,15 +39,17 @@ class SpecialistDocumentsController < ApplicationController
   def update
     document = services.update_document(self).call
 
-    if document.valid? && publish_document?
-      services.publish_document(document).call
-    end
-
     if document.valid?
-      redirect_to(specialist_documents_path)
+      redirect_to(specialist_document_path(document))
     else
       render(:edit, locals: {document: document})
     end
+  end
+
+  def publish
+    services.publish_document(current_document).call
+
+    redirect_to(specialist_document_path(current_document))
   end
 
   def withdraw
@@ -65,10 +63,6 @@ class SpecialistDocumentsController < ApplicationController
   end
 
 protected
-
-  def publish_document?
-    params.has_key?("publish")
-  end
 
   def all_documents
     specialist_document_repository.all

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -13,6 +13,7 @@ class SpecialistDocument
       :slug,
       :summary,
       :body,
+      :document_type,
       :opened_date,
       :closed_date,
       :case_type,
@@ -188,6 +189,7 @@ protected
       .merge(
         version_number: current_version_number + 1,
         slug: slug,
+        document_type: document_type,
         attachments: attachments,
       )
 

--- a/app/views/specialist_documents/_form.html.erb
+++ b/app/views/specialist_documents/_form.html.erb
@@ -33,8 +33,7 @@
     <%= f.select :market_sector, facet_options(:market_sector) %>
     <%= f.select :outcome_type, facet_options(:outcome_type), include_blank: true %>
 
-    <button name='draft'>Save as draft</button>
-    <button name='publish'>Save and publish</button>
+    <button name='save'>Save as draft</button>
   <% end %>
 </div>
 

--- a/app/views/specialist_documents/index.html.erb
+++ b/app/views/specialist_documents/index.html.erb
@@ -8,7 +8,7 @@
     <ul class="document-list">
       <% documents.each do |document| %>
         <li class="document">
-          <%= link_to document.title, edit_specialist_document_path(document), class: 'document-title' %>
+          <%= link_to document.title, specialist_document_path(document), class: 'document-title' %>
           <ul class="metadata">
             <li>updated <%= time_ago_in_words(document.updated_at) %> ago</li>
             <li>

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -1,11 +1,20 @@
 <h1 class="page-header"><%= document.title %></h1>
 <h4><%= document.slug %></h4>
 
+<div class="row">
+  <%= form_tag(publish_specialist_document_path(document), method: :post) do %>
+    <button name='submit' class="btn btn-danger">Publish</button>
+  <% end -%>
+</div>
 
 <div class="row">
   <%= form_tag(withdraw_specialist_document_path(document), method: :post) do %>
     <button name='submit' class="btn btn-danger">Withdraw</button>
   <% end -%>
+</div>
+
+<div class="row">
+  <div><%= link_to("Edit", edit_specialist_document_path(document)) %></div>
 </div>
 
 <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ SpecialistPublisher::Application.routes.draw do
     resources :attachments, only: [:new, :create, :edit, :update]
     post :preview, on: :member
     post :withdraw, on: :member
+    post :publish, on: :member
   end
 
   resources :manuals, except: :destroy do

--- a/features/publishing-a-cma-case.feature
+++ b/features/publishing-a-cma-case.feature
@@ -14,7 +14,6 @@ Feature: Publishing a CMA case
     Given a draft CMA case exists
     When I publish the CMA case
     Then the CMA case should be published
-    And I should be returned to the list of documents
 
   Scenario: can create a new CMA case and publish immediately
     When I publish a new CMA case
@@ -24,7 +23,3 @@ Feature: Publishing a CMA case
     When I publish a new CMA case
     And I edit it and republish
     Then the amended CMA case should be published
-
-  Scenario: validation errors on publishing
-    When I attempt to publish a new CMA case without a title
-    Then I should see the editing form again with an error about the missing title

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -11,7 +11,7 @@ end
 
 When(/^I attach a file and give it a title$/) do
   @attachment_title = "My attachment"
-  add_attachment_to_case(@document_title, @attachment_title)
+  add_attachment_to_manual_document(@document_title, @attachment_title)
 end
 
 Then(/^I see the attachment on the case with its example markdown embed code$/) do

--- a/features/step_definitions/case_workflow_steps.rb
+++ b/features/step_definitions/case_workflow_steps.rb
@@ -5,7 +5,7 @@ Then(/^the CMA case should be in draft$/) do
 end
 
 When(/^I publish the CMA case$/) do
-  go_to_edit_page_for_most_recent_case
+  go_to_show_page_for_document(@document_title)
   publish_document
 end
 
@@ -13,29 +13,11 @@ Then(/^the CMA case should be published$/) do
   check_cma_case_is_published(@cma_fields.fetch(:title))
 end
 
-When(/^I attempt to publish a new CMA case without a title$/) do
-  @cma_fields = {
-    summary: 'Nullam quis risus eget urna mollis ornare vel eu leo.',
-    body: ('Praesent commodo cursus magna, vel scelerisque nisl consectetur et.' * 10),
-    opened_date: '2014-01-01'
-  }
-
-  create_cma_case(@cma_fields, publish: true)
-end
-
-Then(/^I should see the editing form again with an error about the missing title$/) do
-  check_for_missing_title_error
-end
-
 When(/^I edit it and republish$/) do
   @amended_document_attributes = {summary: "New summary", title: "My title"}
-  edit_cma_case(@amended_document_attributes, publish: true)
+  edit_cma_case(@document_title, @amended_document_attributes, publish: true)
 end
 
 Then(/^the amended CMA case should be published$/) do
-  published_doc = RenderedSpecialistDocument.where(title: @amended_document_attributes.fetch(:title)).last
-
-  @amended_document_attributes.each do |attribute, expected_value|
-    expect(published_doc.public_send(attribute)).to eq(expected_value)
-  end
+  check_for_published_document_with(@amended_document_attributes)
 end

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -7,8 +7,9 @@ Given(/^I am logged in as a CMA editor$/) do
 end
 
 When(/^I create a CMA case$/) do
+  @document_title = 'Example CMA Case'
   @cma_fields = {
-    title: 'Example CMA Case',
+    title: @document_title,
     summary: 'Nullam quis risus eget urna mollis ornare vel eu leo.',
     body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
     opened_date: '2014-01-01'
@@ -29,8 +30,10 @@ When(/^I create a CMA case without one of the required fields$/) do
 end
 
 When(/^I publish a new CMA case$/) do
+  @document_title = 'Example CMA Case'
+
   @cma_fields = {
-    title: 'Example CMA Case',
+    title: @document_title,
     summary: 'Nullam quis risus eget urna mollis ornare vel eu leo.',
     body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
     opened_date: '2014-01-01'
@@ -41,7 +44,7 @@ end
 
 When(/^I edit a CMA case$/) do
   @new_title = 'Edited Example CMA Case'
-  edit_cma_case(title: @new_title)
+  edit_cma_case(@document_title, title: @new_title)
 end
 
 Then(/^the CMA case should have been updated$/) do
@@ -53,8 +56,10 @@ Given(/^two CMA cases exist$/) do
 end
 
 Given(/^a draft CMA case exists$/) do
+  @document_title = 'Example CMA Case'
+
   @cma_fields = {
-    title: 'Example CMA Case',
+    title: @document_title,
     summary: 'Nullam quis risus eget urna mollis ornare vel eu leo.',
     body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
     opened_date: '2014-01-01'
@@ -99,8 +104,10 @@ Then(/^I see the case body preview$/) do
 end
 
 Given(/^a published CMA case exists$/) do
+  @document_title = "Original CMA case title"
+
   @cma_fields = {
-    title: "Original CMA case title",
+    title: @document_title,
     summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
     body: ("Praesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
     opened_date: "2014-01-01",
@@ -112,7 +119,8 @@ Given(/^a published CMA case exists$/) do
 end
 
 When(/^I change the CMA case title and re-publish$/) do
-  update_title_and_republish(to: "Updated CMA case title")
+  @updated_title = "Updated CMA case title"
+  update_title_and_republish(@document_title, to: @updated_title)
 end
 
 Then(/^the title has been updated$/) do
@@ -120,7 +128,7 @@ Then(/^the title has been updated$/) do
 end
 
 Then(/^the URL slug remains unchanged$/) do
-  check_for_unchanged_slug(@slug)
+  check_for_unchanged_slug(@updated_title, @slug)
 end
 
 When(/^I create another case with the same slug$/) do

--- a/features/support/attachment_helpers.rb
+++ b/features/support/attachment_helpers.rb
@@ -3,11 +3,19 @@ module AttachmentHelpers
     Plek.current.find("asset-manager")
   end
 
-  def add_attachment_to_case(document_title, attachment_title)
-    click_on(document_title)
+  def add_attachment_to_manual_document(document_title, attachment_title)
+    if page.has_css?("a", text: document_title)
+      click_on(document_title)
+    elsif page.has_css?("a", text: "Edit")
+      click_on("Edit")
+    end
 
+    add_attachment_to_case(document_title, attachment_title)
+  end
+
+  def add_attachment_to_case(document_title, attachment_title)
     unless current_path.include?("edit")
-      click_on "Edit"
+      click_link "Edit"
     end
 
     click_on "Add attachment"

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -9,6 +9,7 @@ describe SpecialistDocument do
   }
 
   let(:document_id)         { "a-document-id" }
+  let(:document_type)       { "cma_case" }
   let(:slug)                { double(:slug) }
   let(:published_slug)      { double(:published_slug) }
   let(:slug_generator)      { double(:slug_generator, call: slug) }
@@ -37,6 +38,7 @@ describe SpecialistDocument do
         published?: false,
         archived?: false,
         version_number: 1,
+        document_type: document_type,
       )
     )
   }
@@ -50,6 +52,7 @@ describe SpecialistDocument do
         published?: false,
         archived?: false,
         version_number: 2,
+        document_type: document_type,
       )
     )
   }
@@ -64,6 +67,7 @@ describe SpecialistDocument do
         archived?: false,
         slug: published_slug,
         version_number: 1,
+        document_type: document_type,
       )
     )
   }
@@ -78,6 +82,7 @@ describe SpecialistDocument do
         archived?: true,
         slug: published_slug,
         version_number: 2,
+        document_type: document_type,
       )
     )
   }


### PR DESCRIPTION
Remove the "Save and Publish" button from the document edit page and add a publish button to the show page.

This gives us consistency with withdraw and less complex controller actions.
