### PR TITLE
Fix for preview redirecting on new documents

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,4 +37,20 @@ module ApplicationHelper
       content_tag(:div, Govspeak::Document.new(text).to_sanitized_html.html_safe, class: "govspeak")
     end
   end
+
+  def preview_path_for_specialist_document(document)
+    if document.persisted?
+      preview_specialist_document_path(document)
+    else
+      preview_new_specialist_document_path
+    end
+  end
+
+  def preview_path_for_manual_document(manual, document)
+    if document.persisted?
+      preview_manual_document_path(manual, document)
+    else
+      preview_new_manual_document_path(manual)
+    end
+  end
 end

--- a/app/views/manual_documents/_form.html.erb
+++ b/app/views/manual_documents/_form.html.erb
@@ -52,7 +52,7 @@
 
 <%= content_for :document_ready do %>
   window.SpecialistDocument.addPreviewFeature({
-    'url'             : '<%= preview_manual_document_path(manual, document) %>',
+    'url'             : '<%= preview_path_for_manual_document(manual, document) %>',
     'insert_into'     : '.preview_container',
     'insert_button'   : '.preview_button',
     'render_to'       : '.preview .govspeak',

--- a/app/views/specialist_documents/_form.html.erb
+++ b/app/views/specialist_documents/_form.html.erb
@@ -64,7 +64,7 @@
 
 <%= content_for :document_ready do %>
   window.SpecialistDocument.addPreviewFeature({
-    'url'             : '<%= preview_specialist_document_path(document) %>',
+    'url'             : '<%= preview_path_for_specialist_document(document) %>',
     'insert_into'     : '.preview_container',
     'insert_button'   : '.preview_button',
     'render_to'       : '.preview .govspeak',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,17 +3,27 @@ SpecialistPublisher::Application.routes.draw do
 
   resources :specialist_documents, except: :destroy, path: 'specialist-documents' do
     resources :attachments, only: [:new, :create, :edit, :update]
-    post :preview, on: :member
     post :withdraw, on: :member
     post :publish, on: :member
+
+    # This is for persisted documents
+    post :preview, on: :member
   end
+
+  # This is for new documents
+  post 'specialist-documents/preview' => 'specialist_documents#preview', as: 'preview_new_specialist_document'
 
   resources :manuals, except: :destroy do
     resources :documents, except: :destroy, path: 'sections', controller: "ManualDocuments" do
       resources :attachments, controller: "ManualDocumentsAttachments", only: [:new, :create, :edit, :update]
+
+      # This is for persisted manual documents
       post :preview, on: :member
     end
   end
+
+  # This is for new manual documents
+  post 'manuals/:manual_id/sections/preview' => 'ManualDocuments#preview', as: 'preview_new_manual_document'
 
   root to: redirect('/manuals')
 end

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -42,3 +42,9 @@ Feature: Creating and editing a CMA case
     Given a draft CMA case exists
     When I make changes and preview the CMA case
     Then I see the case body preview
+
+  @javascript
+  Scenario: Previewing a new CMA case
+    When I start creating a new CMA case
+    And I preview the case
+    Then I see the case body preview

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -142,3 +142,20 @@ end
 When(/^I visit the specialist documents page$/) do
   visit specialist_documents_path
 end
+
+When(/^I start creating a new CMA case$/) do
+  @document_title = "Original CMA case title"
+
+  @cma_fields = {
+    title: @document_title,
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: "Body for preview",
+    opened_date: "2014-01-01",
+  }
+
+  create_cma_case(@cma_fields, save: false)
+end
+
+When(/^I preview the case$/) do
+  generate_preview
+end

--- a/features/support/cma_case_helpers.rb
+++ b/features/support/cma_case_helpers.rb
@@ -1,11 +1,13 @@
 module CmaCaseHelpers
-  def create_cma_case(fields, publish: false)
+  def create_cma_case(fields, save: true, publish: false)
     visit new_specialist_document_path
     fill_in_fields(fields)
 
-    save_document
+    if save
+      save_document
+    end
 
-    if publish
+    if save && publish
       publish_document
     end
   end
@@ -112,7 +114,7 @@ module CmaCaseHelpers
   end
 
   def check_for_cma_case_body_preview
-    expect(current_path).to match(%r{/specialist-documents/[0-9a-f-]+})
+    expect(current_path).to match(%r{/specialist-documents/([0-9a-f-]+|new)})
     within('.preview') do
       expect(page).to have_css('p', text: 'Body for preview')
     end


### PR DESCRIPTION
There was an issue again where #preview wouldn't work with new documents because it was passing an id which didn't exist, so it was 404ing and redirected by the rescue in the application_controller. In order to fix this, we've added another route which the preview button uses for new documents instead. Also added a test to stop this regressing again.
