### PR TITLE
Fix for ManualDocuments Preview not working

### DIFF
--- a/app/controllers/manual_documents_controller.rb
+++ b/app/controllers/manual_documents_controller.rb
@@ -52,4 +52,10 @@ class ManualDocumentsController < ApplicationController
       })
     end
   end
+
+  def preview
+    preview_html = services.preview_manual_document(self).call
+
+    render json: { preview_html: preview_html }
+  end
 end

--- a/app/services/preview_manual_document_service.rb
+++ b/app/services/preview_manual_document_service.rb
@@ -1,0 +1,53 @@
+class PreviewManualDocumentService
+  def initialize(manual_repository, document_builder, document_renderer, context)
+    @manual_repository = manual_repository
+    @document_builder = document_builder
+    @document_renderer = document_renderer
+    @context = context
+  end
+
+  def call
+    document.update(document_params)
+
+    document_renderer.call(document).body
+  end
+
+  private
+
+  attr_reader(
+    :manual_repository,
+    :document_builder,
+    :document_renderer,
+    :context,
+  )
+
+  def document
+    document_id ? existing_document : ephemeral_document
+  end
+
+  def manual
+    manual_repository.fetch(manual_id)
+  end
+
+  def ephemeral_document
+    document_builder.call(document_params)
+  end
+
+  def existing_document
+    @existing_document ||= manual.documents.find { |document|
+      document.id == document_id
+    }
+  end
+
+  def document_params
+    context.params.fetch("document")
+  end
+
+  def document_id
+    context.params.fetch("id", nil)
+  end
+
+  def manual_id
+    context.params.fetch("manual_id", nil)
+  end
+end

--- a/app/services/service_registry.rb
+++ b/app/services/service_registry.rb
@@ -60,6 +60,15 @@ class ServiceRegistry
     )
   end
 
+  def preview_manual_document(context)
+    PreviewManualDocumentService.new(
+      manual_repository(context),
+      document_builder,
+      document_renderer,
+      context,
+    )
+  end
+
   def publish_document(context)
     PublishDocumentService.new(
       document_repository,

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -12,6 +12,7 @@ Feature: Attachments
     When I attach a file and give it a title
     Then I see the attachment on the case with its example markdown embed code
     When I copy+paste the embed code into the body of the case
+    And I preview the document
     Then I can see a link to the file with the title in the document preview
     When I edit it and republish
     Then the attachments from the previous edition remain

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -68,3 +68,20 @@ Feature: Creating and editing a manual
     And a draft document exists for the manual
     When I visit the specialist documents path for the manual document
     Then the document is not found
+
+  @javascript
+  Scenario: Previewing a draft manual document with an attachment
+    Given a draft manual exists
+    And a draft document exists for the manual
+    When I attach a file and give it a title
+    Then I see the attached file
+    When I copy+paste the embed code into the body of the document
+    And I preview the document
+    Then I can see a link to the file with the title in the document preview
+
+  @javascript
+  Scenario: Previewing a new manual document
+    Given a draft manual exists
+    When I create a document to preview
+    And I preview the document
+    Then I see the document body preview

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -23,7 +23,6 @@ When(/^I copy\+paste the embed code into the body of the case$/) do
 end
 
 Then(/^I can see a link to the file with the title in the document preview$/) do
-  generate_preview
   check_preview_contains_attachment_link(@attachment_title)
 end
 

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -176,3 +176,40 @@ When(/^I edit the manual's documents$/) do
 
   edit_manual_document(@manual_title, @document_title, @updated_document_fields)
 end
+
+When(/^I start creating a new manual document$/) do
+  @document_fields = {
+    title: "Section 1",
+    summary: "Section 1 summary",
+    body: "Section 1 body",
+  }
+
+  create_manual_document_for_preview(
+    @document_fields.fetch(:title),
+    @document_fields,
+  )
+end
+
+When(/^I preview the document$/) do
+  generate_preview
+end
+
+When(/^I create a document to preview$/) do
+  @document_fields = {
+    title: "Section 1",
+    summary: "Section 1 summary",
+    body: "Section 1 body",
+  }
+
+  go_to_manual_page(@manual_fields[:title])
+  click_on "Add Section"
+  fill_in_fields(@document_fields)
+end
+
+Then(/^I see the document body preview$/) do
+  check_for_document_body_preview("Section 1 body")
+end
+
+When(/^I copy\+paste the embed code into the body of the document$/) do
+  copy_embed_code_for_attachment_and_paste_into_manual_document_body("My attachment")
+end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -144,4 +144,29 @@ module ManualHelpers
     check_manual_is_published_to_content_api(manual_slug, manual_attrs, document_slug, document_attrs)
     check_manual_document_is_published_to_content_api(document_attrs)
   end
+
+  def create_manual_document_for_preview(manual_title, fields)
+    go_to_manual_page(manual_title)
+    click_on "Add Section"
+    fill_in_fields(fields)
+  end
+
+  def check_for_document_body_preview(text)
+    within(".preview") do
+      expect(page).to have_css("p", text: text)
+    end
+  end
+
+  def copy_embed_code_for_attachment_and_paste_into_manual_document_body(title)
+    snippet = within(".attachments") do
+      page
+        .find("li", text: /#{title}/)
+        .find("span.snippet")
+        .text
+    end
+
+    body_text = find("#document_body").value
+    fill_in("Body", with: body_text + snippet)
+  end
+
 end


### PR DESCRIPTION
We were missing an action which wasn't needed until some previous refactoring changed how the Preview worked. I've added some tests to make sure this doesn't happen again along with adding a service for previewing manual documents.
