### PR TITLE
Manual must publish its documents everytime

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -43,10 +43,8 @@ class Manual
   end
 
   def publish(&block)
-    if @state == "draft"
-      @state = "published"
-      block.call if block
-    end
+    @state = "published"
+    block.call if block
 
     self
   end

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -18,6 +18,12 @@ Feature: Publishing a manual
     And I publish the manual
     Then the manual and its documents are published
 
+  Scenario: Add a section to a published manual
+    Given a published manual exists
+    When I add another section to the manual
+    And I publish the manual
+    Then the manual and its documents are published
+
   Scenario: Add a change note
     Given a published manual exists
     When I create a new draft of a section with a change note

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -265,3 +265,15 @@ Then(/^the document is updated without a change note$/) do
     summary: @updated_document_fields.fetch(:summary),
   )
 end
+
+When(/^I add another section to the manual$/) do
+  @document_title = "Section 2"
+  @document_slug = [@manual_slug, "section-2"].join("/")
+  @document_fields = {
+    title: @document_title,
+    summary: "Section 2 summary",
+    body: "Section 2 body",
+  }
+
+  create_manual_document(@manual_title, @document_fields)
+end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -34,36 +34,18 @@ describe Manual do
       expect(manual.publish).to be(manual)
     end
 
-    context "when the state is draft" do
-      let(:state) { "draft" }
+    let(:state) { "draft" }
 
-      it "sets the state to 'published'" do
-        manual.publish
+    it "sets the state to 'published'" do
+      manual.publish
 
-        expect(manual.state).to eq("published")
-      end
-
-      it "yields to the block" do
-        expect { |block|
-          manual.publish(&block)
-        }.to yield_with_no_args
-      end
+      expect(manual.state).to eq("published")
     end
 
-    context "with the state is not draft" do
-      let(:state) { "anything else" }
-
-      it "does not change state" do
-        manual.publish
-
-        expect(manual.state).to eq(state)
-      end
-
-      it "does not yield to the block" do
-        expect { |block|
-          manual.publish(&block)
-        }.not_to yield_with_no_args
-      end
+    it "yields to the block" do
+      expect { |block|
+        manual.publish(&block)
+      }.to yield_with_no_args
     end
   end
 


### PR DESCRIPTION
Manuals were only publishing fully on the first publication due to an erroneous `state == "draft"` check which is removed here.
