### PR TITLE
Add missing require for a new validator.

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -13,6 +13,7 @@ require "specialist_document_header_extractor"
 require "finder_api_notifier"
 require "finder_api"
 require "validators/slug_uniqueness_validator"
+require "validators/change_note_validator"
 require "marshallers/document_association_marshaller"
 
 $LOAD_PATH.unshift(File.expand_path("../..", "app/services"))


### PR DESCRIPTION
This prevents loading specialist publisher from 500'ing.
