### PR TITLE
Make Jenkins test merge result of branches

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -30,6 +30,11 @@ function error_handler {
 trap "error_handler ${LINENO}" ERR
 github_status "$REPO_NAME" pending "is running on Jenkins"
 
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
 RAILS_ENV=test bundle exec rake
 


### PR DESCRIPTION
Almost all of the time we are writing code to be merged into master sooner rather than later. Rather than testing the HEAD of the branch in Jenkins this makes the script merge the branch with master before building it.
