### PR TITLE
Add notice when publishing

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -53,7 +53,7 @@ class ManualsController < ApplicationController
   def publish
     manual = services.publish_manual(self).call
 
-    redirect_to(manual_path(manual))
+    redirect_to(manual_path(manual), flash: { notice: "Published #{manual.title}" })
   end
 
 private

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -54,13 +54,13 @@ class SpecialistDocumentsController < ApplicationController
   def publish
     document = services.publish_document(self).call
 
-    redirect_to(specialist_document_path(document))
+    redirect_to(specialist_document_path(document), flash: { notice: "Published #{document.title}" })
   end
 
   def withdraw
     document = services.withdraw_document(self).call
 
-    redirect_to(specialist_documents_path)
+    redirect_to(specialist_documents_path, flash: { error: "Withdrawn #{document.title}" })
   end
 
   def preview


### PR DESCRIPTION
When publishing or withdrawing a manual or a document, it wasn't clear to the user that anything has happened. This PR adds a notice or error when the page loads again.
