### PR TITLE
Fix for re-editing of change notes

### DIFF
--- a/app/forms/manual_document_form.rb
+++ b/app/forms/manual_document_form.rb
@@ -10,7 +10,6 @@ class ManualDocumentForm
     :title,
     :summary,
     :body,
-    :change_note,
     :minor_update,
   ]
 
@@ -33,6 +32,14 @@ class ManualDocumentForm
 
   def persisted?
     document.updated_at || document.published?
+  end
+
+  def minor_update
+    document.draft? ? document.minor_update : false
+  end
+
+  def change_note
+    document.draft? ?  document.change_note : ""
   end
 
   def to_param


### PR DESCRIPTION
A change note can be edited until publication then a new change note
must be provided rather than showing the previous change note.
