### PR TITLE
Add missing require for ManualDocumentBuilder

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -15,6 +15,7 @@ require "finder_api"
 require "validators/slug_uniqueness_validator"
 require "validators/change_note_validator"
 require "marshallers/document_association_marshaller"
+require "builders/manual_document_builder"
 
 $LOAD_PATH.unshift(File.expand_path("../..", "app/services"))
 


### PR DESCRIPTION
After https://github.com/alphagov/specialist-publisher/commit/c55ae80ca20fa8d9d8246ddbae67bcf785f06e41, a require was needed when running the App.
