### PR TITLE
Unify titles

### DIFF
--- a/app/views/attachments/edit.html.erb
+++ b/app/views/attachments/edit.html.erb
@@ -4,6 +4,8 @@
   <li class='active'>Edit attachment</li>
 <% end %>
 
+<h1 class="page-header">Edit attachment</h1>
+
 <%= render(partial: "form", locals: {
   document: document,
   attachment: attachment,

--- a/app/views/attachments/new.html.erb
+++ b/app/views/attachments/new.html.erb
@@ -4,6 +4,8 @@
   <li class='active'>Add attachment</li>
 <% end %>
 
+<h1 class="page-header">Add attachment</h1>
+
 <%= render(partial: "form", locals: {
   document: document,
   attachment: attachment,

--- a/app/views/manual_documents/edit.html.erb
+++ b/app/views/manual_documents/edit.html.erb
@@ -5,7 +5,7 @@
   <li class='active'>Edit section</li>
 <% end %>
 
-<h1 class="page-header">Edit document</h1>
+<h1 class="page-header">Edit section</h1>
 
 <div class="row">
 <%= render partial: "form", locals: { document: document, manual: manual} %>

--- a/app/views/manual_documents/new.html.erb
+++ b/app/views/manual_documents/new.html.erb
@@ -4,6 +4,6 @@
   <li class='active'>Add section</li>
 <% end %>
 
-<h1 class='page-header'>Add a new section</h1>
+<h1 class='page-header'>Add section</h1>
 
 <%= render "form", manual: manual, document: document %>

--- a/app/views/manual_documents/show.html.erb
+++ b/app/views/manual_documents/show.html.erb
@@ -4,10 +4,7 @@
   <li class='active'><%= document.title %></li>
 <% end %>
 
-<h3><%= link_to "&larr; #{manual.title}".html_safe, manual_path(manual) %></h3>
-
 <div class="manual-header">
-  <p>Section title</p>
   <h1 class="page-header">
     <%= document.title %>
   </h1>

--- a/app/views/manual_documents_attachments/edit.html.erb
+++ b/app/views/manual_documents_attachments/edit.html.erb
@@ -5,6 +5,8 @@
   <li class='active'>Edit attachment</li>
 <% end %>
 
+<h1 class="page-header">Edit attachment</h1>
+
 <%= render(partial: "form", locals: {
   manual: manual,
   document: document,

--- a/app/views/manual_documents_attachments/new.html.erb
+++ b/app/views/manual_documents_attachments/new.html.erb
@@ -5,6 +5,8 @@
   <li class='active'>Add attachment</li>
 <% end %>
 
+<h1 class="page-header">Edit attachment</h1>
+
 <%= render(partial: "form", locals: {
   manual: manual,
   document: document,

--- a/app/views/manuals/edit.html.erb
+++ b/app/views/manuals/edit.html.erb
@@ -4,6 +4,6 @@
   <li class='active'>Edit manual</li>
 <% end %>
 
-<h1 class="page-header">Edit a manual</h1>
+<h1 class="page-header">Edit manual</h1>
 
 <%= render 'form', manual: manual %>

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="manual-header">
   <h1 class="page-header">
-    Manuals <small>(<%= manuals.count %>)</small>
+    Your manuals <small>(<%= manuals.count %>)</small>
   </h1>
 
   <div class="actions">

--- a/app/views/manuals/new.html.erb
+++ b/app/views/manuals/new.html.erb
@@ -3,6 +3,6 @@
   <li class='active'>Create new manual</li>
 <% end %>
 
-<h1 class="page-header">Create new manual</h1>
+<h1 class="page-header">New manual</h1>
 
 <%= render 'form', manual: manual %>


### PR DESCRIPTION
This PR makes the page titles wording internally consistent. We now have:
- Your manuals / Your documents on index pages
- New manual / New document on new documents or manuals pages
- Add section / Add attachment on new attachments or sections pages
- The document / manual / section titles are used on their respective show pages.
