### PR TITLE
Remove recursive header metadata serialzation

### DIFF
--- a/lib/specialist_document_header_extractor.rb
+++ b/lib/specialist_document_header_extractor.rb
@@ -14,7 +14,7 @@ class SpecialistDocumentHeaderExtractor < SimpleDelegator
 
   def attributes
     {
-      headers: serialize_headers(headers)
+      headers: headers.map(&:to_h),
     }.merge(doc.attributes)
   end
 
@@ -26,14 +26,5 @@ private
 
   def doc
     __getobj__
-  end
-
-  def serialize_headers(headers)
-    # TODO: Push this recursive serialization into Govspeak::StructuredHeader
-    headers.map { |header|
-      header.to_h.symbolize_keys.merge(
-        headers: serialize_headers(header.headers)
-      )
-    }
   end
 end

--- a/spec/specialist_document_header_extractor_spec.rb
+++ b/spec/specialist_document_header_extractor_spec.rb
@@ -14,7 +14,7 @@ describe SpecialistDocumentHeaderExtractor do
   let(:doc_attributes)    { { body: doc_body } }
   let(:header_metadata)   { [header_metadatum] }
   let(:header_metadatum)  { double(:header_metadatum, headers: [], to_h: serialized_metadata) }
-  let(:serialized_metadata) { { text: "Header", headers: [] } }
+  let(:serialized_metadata) { double(:serialized_metadata) }
 
   it "is a true decorator" do
     expect(doc).to receive(:arbitrary_message)
@@ -37,45 +37,6 @@ describe SpecialistDocumentHeaderExtractor do
     it "returns the document attributes with header metadata added" do
       expect(header_extractor.attributes).to include(doc_attributes)
       expect(header_extractor.attributes).to include(headers: [serialized_metadata])
-    end
-
-    context "with nested header metadata" do
-      let(:header_class) { Struct.new(:text, :headers) }
-
-      let(:header_metadata) {
-        [
-          header_class.new("1", [
-            header_class.new("1.1", [
-              header_class.new("1.1.1", []),
-            ])
-          ])
-        ]
-      }
-
-      let(:serialized_metadata) {
-        [
-          {
-            text: "1",
-            headers: [
-              {
-                text: "1.1",
-                headers: [
-                  {
-                    text: "1.1.1",
-                    headers: [],
-                  },
-                ],
-              },
-            ],
-          },
-        ]
-      }
-
-      it "recursively serializes the header objects to hashes" do
-        expect(
-          header_extractor.attributes.fetch(:headers)
-        ).to eq(serialized_metadata)
-      end
     end
   end
 end


### PR DESCRIPTION
This feature has been available in Govspeak for some time.
