### PR TITLE
Stop JS from rendering outside of head tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,13 +24,13 @@
   <% end -%>
   <%= render(:partial => 'shared/breadcrumbs') %>
   <%= yield %>
+  <script>
+    $(document).ready(function() {
+      <%= yield :document_ready %>
+    });
+  </script>
 <% end %>
-<%= javascript_include_tag "application" %>
-<script>
-  $(document).ready(function() {
-    <%= yield :document_ready %>
-  });
-</script>
+
 <%# use the govuk_admin_foundation layout %>
 <%= render :template => 'layouts/govuk_admin_template' %>
 


### PR DESCRIPTION
When I moved to the govuk_admin_template I accidentally left some things outside of content_for tags which meant that there were a whole bunch of script tags at the top of the page before the <head> this caused ie^ and 7 to get very confused, naturally.

Before
![before](https://cloud.githubusercontent.com/assets/68009/3387468/8f4f9a6c-fc7e-11e3-8486-feb3bd576dbf.png)

After
![after](https://cloud.githubusercontent.com/assets/68009/3387469/91226cca-fc7e-11e3-8ee6-431f9ff058f3.png)
