### PR TITLE
Tag repository KeyError to distinguish from regular KeyErrors

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -2,7 +2,7 @@ class SpecialistDocumentsController < ApplicationController
 
   before_filter :authorize_user_org
 
-  rescue_from(KeyError) do
+  rescue_from("SpecialistDocumentRepository::NotFoundError") do
     # TODO: Remove use of exceptions for flow control.
     redirect_to(manuals_path, flash: { error: "Document not found" })
   end

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -3,6 +3,14 @@ require "fetchable"
 class SpecialistDocumentRepository
   include Fetchable
 
+  NotFoundError = Module.new
+
+  def fetch(*args, &block)
+    super
+  rescue KeyError => e
+    raise e.extend(NotFoundError)
+  end
+
   def initialize(panopticon_mappings,
     specialist_document_editions,
     specialist_document_factory)


### PR DESCRIPTION
This is a quick fix that allows us to retain use of exceptions for
flow control.
