### PR TITLE
Update panopticon when updating a case title

### DIFF
--- a/app/lib/manual_change_notes_artefact_formatter.rb
+++ b/app/lib/manual_change_notes_artefact_formatter.rb
@@ -1,6 +1,10 @@
 require "manual_artefact_formatter"
 
 class ManualChangeNotesArtefactFormatter < ManualArtefactFormatter
+  def resource_id
+    [super, "updates"].join("/")
+  end
+
   def slug
     [super, "updates"].join("/")
   end

--- a/app/lib/panopticon_registerer.rb
+++ b/app/lib/panopticon_registerer.rb
@@ -24,7 +24,9 @@ class PanopticonRegisterer
   end
 
   def notify_of_update
-    api.put_artefact!(mapping.panopticon_id, artefact_attributes)
+    response = api.put_artefact!(mapping.panopticon_id, artefact_attributes)
+
+    update_mapping_slug(response)
   end
 
   def save_new_mapping(response)
@@ -36,6 +38,10 @@ class PanopticonRegisterer
     )
   end
 
+  def update_mapping_slug(response)
+    mapping.update_attribute(:slug, artefact.slug)
+  end
+
   def artefact_attributes
     artefact.attributes.merge(
       owning_app: owning_app,
@@ -43,7 +49,7 @@ class PanopticonRegisterer
   end
 
   def mapping
-    @mapping ||= mappings.where(slug: artefact.slug).last
+    @mapping ||= mappings.where(resource_id: artefact.resource_id).last
   end
 
   def owning_app

--- a/app/observers/observers_registry.rb
+++ b/app/observers/observers_registry.rb
@@ -24,6 +24,11 @@ class ObserversRegistry
     [
       aaib_report_content_api_exporter,
       finder_api_notifier,
+    ]
+  end
+
+  def document_update
+    [
       document_panopticon_registerer,
     ]
   end

--- a/app/services/service_registry.rb
+++ b/app/services/service_registry.rb
@@ -129,7 +129,7 @@ class ServiceRegistry
   def update_document(document_id, attributes)
     UpdateDocumentService.new(
       repo: document_repository,
-      listeners: [],
+      listeners: observers.document_update,
       document_id: document_id,
       attributes: attributes,
     )

--- a/db/migrate/20140627125928_panopticon_mapping_updates_resource_id_fix.rb
+++ b/db/migrate/20140627125928_panopticon_mapping_updates_resource_id_fix.rb
@@ -1,0 +1,18 @@
+class PanopticonMappingUpdatesResourceIdFix < Mongoid::Migration
+  @mappings = Class.new do
+    include Mongoid::Document
+    store_in :panopticon_mappings
+  end
+
+  def self.up
+    @mappings.where(slug: /\/updates$/).each do |mapping|
+      mapping.update_attribute(:resource_id, "#{mapping.resource_id}/updates")
+    end
+  end
+
+  def self.down
+    @mappings.where(slug: /\/updates$/).each do |mapping|
+      mapping.update_attribute(:resource_id, mapping.resource_id.gsub(/\/updates$/, ""))
+    end
+  end
+end

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -35,6 +35,12 @@ Feature: Creating and editing a CMA case
     Then the title has been updated
     And the URL slug remains unchanged
 
+  @regression
+  Scenario: Changing the slug on a draft CMA case
+    Given a draft CMA case exists
+    When I change the title of the CMA case
+    Then the updated URL slug is registered
+
   @javascript
   Scenario: Previewing a draft CMA case
     Given a draft CMA case exists

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -70,6 +70,16 @@ Given(/^a draft CMA case exists$/) do
   create_cma_case(@cma_fields, publish: false)
 end
 
+When(/^I change the title of the CMA case$/) do
+  @new_document_title = "Updated CMA case title"
+  @new_slug = "cma-cases/updated-cma-case-title"
+  edit_document(@document_title, {title: @new_document_title})
+end
+
+Then(/^the updated URL slug is registered$/) do
+  check_slug_updated_with_panopticon(@slug, @new_slug)
+end
+
 Then(/^the CMA case has been created$/) do
   check_document_exists_with(@cma_fields)
   check_slug_registered_with_panopticon_with_correct_organisation(@slug, ["competition-and-markets-authority"])

--- a/features/support/cma_case_helpers.rb
+++ b/features/support/cma_case_helpers.rb
@@ -1,4 +1,9 @@
 module CmaCaseHelpers
+  def check_slug_updated_with_panopticon(old_slug, new_slug)
+    expect(fake_panopticon).to have_received(:put_artefact!)
+      .with(panopticon_id_for_slug(old_slug), hash_including(slug: new_slug))
+  end
+
   def go_to_edit_page_for_most_recent_case
     warn "DEPRECATED: use #go_to_edit_page_for_document and provide title"
     registry = SpecialistPublisherWiring.get(:specialist_document_repository)

--- a/features/support/panopticon_helpers.rb
+++ b/features/support/panopticon_helpers.rb
@@ -8,14 +8,18 @@ module PanopticonHelpers
     end
 
     def put_artefact!(id, attributes = {})
-      nil
+      raise "No artifact with id #{id} exists" unless slug_id_map.has_value?(id)
+
+      slug_id_map[attributes.fetch(:slug)] = id
+
+      {"id" => id, "slug" => attributes.fetch(:slug)}
     end
 
     def create_artefact!(attributes = {})
       new_artefact_id = "test-panopticon-id-#{SecureRandom.hex}"
       slug_id_map[attributes.fetch(:slug)] = new_artefact_id
 
-      {"id" => new_artefact_id}
+      {"id" => new_artefact_id, "slug" => attributes.fetch(:slug)}
     end
 
     def panopticon_id_for_slug(slug)


### PR DESCRIPTION
([Trello ticket](https://trello.com/c/phpPdi6D/172-bug-trying-to-publish-this-case-get-s-a-slug-already-taken-error))

When a user created a draft case, then changed the title of that draft
case, specialist-publisher's panopticon mappings would get out of date
with Panopticon as we'd send Panopticon a create for the new slug rather
than issuing an update for the existing mapping.

This resulted in a 500 error when publishing the case as Panopticon
would report the slug had already been taken.

By ensuring PanopticonMapping is kept up to date when a slug change
happens (by finding the existing mapping searching by resource ID, not
slug) we prevent this case.

In order to find the mapping by resource ID, we need to ensure that only
one mapping is described by one resource ID, therefore for
ManualChangeNotes, we generate a unique resource_id by building it from
the parent.

[+ @bestie]
