### PR TITLE
Unset the document_id field on PanopticonMappings

### DIFF
--- a/db/migrate/20140630155209_remove_document_id.rb
+++ b/db/migrate/20140630155209_remove_document_id.rb
@@ -1,0 +1,16 @@
+class RemoveDocumentId < Mongoid::Migration
+  @mappings = Class.new do
+    include Mongoid::Document
+    store_in :panopticon_mappings
+  end
+
+  def self.up
+    @mappings.all.each do |mapping|
+      mapping.unset(:document_id)
+    end
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
We switched from document_id to resource_id and resource_type, so we no
longer use this information, but ~105 PanopticonMappings still have a
document_id attribute.

Nuke it from orbit.
