### PR TITLE
Add gds_editor role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 require "specialist_publisher_wiring"
 require "forwardable"
+require "permission_checker"
 
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
@@ -24,16 +25,24 @@ class ApplicationController < ActionController::Base
   end
 
   def user_can_edit_cma_cases?
-    current_organisation_slug == "competition-and-markets-authority"
+    current_user_can_edit?("cma_case")
   end
   helper_method :user_can_edit_cma_cases?
 
   def user_can_edit_aaib_reports?
-    current_organisation_slug == "air-accidents-investigation-branch"
+    current_user_can_edit?("aaib_report")
   end
   helper_method :user_can_edit_aaib_reports?
 
+  def current_user_can_edit?(format)
+    permission_checker.can_edit?(format)
+  end
+
   def current_organisation_slug
     current_user.organisation_slug
+  end
+
+  def permission_checker
+    @permission_checker ||= PermissionChecker.new(current_user)
   end
 end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -1,0 +1,31 @@
+class PermissionChecker
+  GDS_EDITOR_PERMISSION = "gds_editor"
+
+  def initialize(user)
+    @user = user
+  end
+
+  def can_edit?(format)
+    is_gds_editor? || user_organisation_owns_format?(format)
+  end
+
+private
+  attr_reader :user
+
+  def is_gds_editor?
+    user.has_permission?(GDS_EDITOR_PERMISSION)
+  end
+
+  def user_organisation_owns_format?(format)
+    user.organisation_slug == owning_organisation_for_format(format)
+  end
+
+  def owning_organisation_for_format(format)
+    case format
+    when "cma_case"
+      "competition-and-markets-authority"
+    when "aaib_report"
+      "air-accidents-investigation-branch"
+    end
+  end
+end


### PR DESCRIPTION
GDS Editors are able to see documents of all formats without belonging to the owning organisation.
