### PR TITLE
Add attachment to specialist-publisher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "unicorn", "4.8.2"
 if ENV["CONTENT_MODELS_DEV"]
   gem "govuk_content_models", :path => "../govuk_content_models"
 else
-  gem "govuk_content_models", "12.2.0"
+  gem "govuk_content_models", "14.0.0"
 end
 
 if ENV["API_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       bootstrap-sass (= 3.1.0)
       jquery-rails (= 3.0.4)
       rails (>= 3.2.0)
-    govuk_content_models (12.2.0)
+    govuk_content_models (14.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -309,7 +309,7 @@ DEPENDENCIES
   generic_form_builder (= 0.8.0)
   govspeak (= 1.6.2)
   govuk_admin_template (= 1.0.0)
-  govuk_content_models (= 12.2.0)
+  govuk_content_models (= 14.0.0)
   govuk_frontend_toolkit (= 0.44.0)
   jasmine-rails
   launchy

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,0 +1,19 @@
+require "attachable"
+
+class Attachment
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Attachable
+
+  field :title
+  field :filename
+  attaches :file, with_url_field: true, update_existing: true
+
+  embedded_in :specialist_document_edition
+
+  validates_with SafeHtml
+
+  def snippet
+    "[InlineAttachment:#{filename}]"
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,15 @@
+require "fast_spec_helper"
+require "attachment"
+
+describe Attachment do
+  subject(:attachment) do
+    Attachment.new(
+      title: "Supporting attachment",
+      filename: "document.pdf",
+    )
+  end
+
+  it "generates a snippet" do
+    expect(attachment.snippet).to eq("[InlineAttachment:document.pdf]")
+  end
+end


### PR DESCRIPTION
As it's only used in specialist-publisher, let's have attachment here. See alphagov/govuk_content_models#190
