### PR TITLE
Allow new format types for specialist documents

### DIFF
--- a/app/lib/aaib_report_artefact_formatter.rb
+++ b/app/lib/aaib_report_artefact_formatter.rb
@@ -7,7 +7,7 @@ class AaibReportArtefactFormatter < AbstractArtefactFormatter
   end
 
   def kind
-    "specialist-document"
+    "aaib_report"
   end
 
   def rendering_app

--- a/app/lib/cma_case_artefact_formatter.rb
+++ b/app/lib/cma_case_artefact_formatter.rb
@@ -1,13 +1,13 @@
 require "abstract_artefact_formatter"
 
-class DocumentArtefactFormatter < AbstractArtefactFormatter
+class CmaCaseArtefactFormatter < AbstractArtefactFormatter
 
   def state
     state_mapping.fetch(entity.publication_state)
   end
 
   def kind
-    "specialist-document"
+    "cma_case"
   end
 
   def rendering_app

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -31,7 +31,7 @@ SpecialistPublisherWiring = DependencyContainer.new do
       document_content_api_exporter: get(:cma_case_content_api_exporter),
       aaib_report_content_api_exporter: get(:aaib_report_content_api_exporter),
       finder_api_notifier: get(:finder_api_notifier),
-      document_panopticon_registerer: get(:document_panopticon_registerer),
+      cma_case_panopticon_registerer: get(:cma_case_panopticon_registerer),
       aaib_report_panopticon_registerer: get(:aaib_report_panopticon_registerer),
       manual_panopticon_registerer: get(:manual_panopticon_registerer),
       manual_document_panopticon_registerer: get(:manual_document_panopticon_registerer),
@@ -309,7 +309,7 @@ SpecialistPublisherWiring = DependencyContainer.new do
 
   define_singleton(:specialist_document_creation_observers) {
     [
-      get(:document_panopticon_registerer),
+      get(:cma_case_panopticon_registerer),
     ]
   }
 
@@ -323,7 +323,7 @@ SpecialistPublisherWiring = DependencyContainer.new do
     [
       get(:specialist_document_content_api_withdrawer),
       get(:finder_api_withdrawer),
-      get(:document_panopticon_registerer),
+      get(:cma_case_panopticon_registerer),
       get(:cma_case_rummager_deleter),
     ]
   }
@@ -338,10 +338,10 @@ SpecialistPublisherWiring = DependencyContainer.new do
     }
   }
 
-  define_factory(:document_panopticon_registerer) {
+  define_factory(:cma_case_panopticon_registerer) {
     ->(document) {
       get(:panopticon_registerer).call(
-        DocumentArtefactFormatter.new(document)
+        CmaCaseArtefactFormatter.new(document)
       )
     }
   }

--- a/app/models/panopticon_mapping.rb
+++ b/app/models/panopticon_mapping.rb
@@ -7,7 +7,7 @@ class PanopticonMapping
   field :panopticon_id, type: String
   field :slug, type: String
 
-  scope :documents, where(resource_type: "specialist-document")
+  scope :documents, where(:resource_type.in => %W(aaib_report cma_case specialist-document))
   scope :manuals, where(resource_type: "manuals")
 
   def self.all_document_ids

--- a/app/observers/observers_registry.rb
+++ b/app/observers/observers_registry.rb
@@ -6,7 +6,8 @@ class ObserversRegistry
     @document_content_api_exporter = dependencies.fetch(:document_content_api_exporter)
     @aaib_report_content_api_exporter = dependencies.fetch(:aaib_report_content_api_exporter)
     @finder_api_notifier = dependencies.fetch(:finder_api_notifier)
-    @document_panopticon_registerer = dependencies.fetch(:document_panopticon_registerer)
+    @cma_case_panopticon_registerer = dependencies.fetch(:cma_case_panopticon_registerer)
+    @aaib_report_panopticon_registerer = dependencies.fetch(:aaib_report_panopticon_registerer)
     @manual_panopticon_registerer = dependencies.fetch(:manual_panopticon_registerer)
     @manual_document_panopticon_registerer = dependencies.fetch(:manual_document_panopticon_registerer)
     @manual_content_api_exporter = dependencies.fetch(:manual_content_api_exporter)
@@ -17,7 +18,7 @@ class ObserversRegistry
     [
       document_content_api_exporter,
       finder_api_notifier,
-      document_panopticon_registerer,
+      cma_case_panopticon_registerer,
       cma_case_rummager_indexer,
     ]
   end
@@ -26,12 +27,13 @@ class ObserversRegistry
     [
       aaib_report_content_api_exporter,
       finder_api_notifier,
+      aaib_report_panopticon_registerer,
     ]
   end
 
   def document_update
     [
-      document_panopticon_registerer,
+      cma_case_panopticon_registerer,
     ]
   end
 
@@ -62,7 +64,8 @@ class ObserversRegistry
     :document_content_api_exporter,
     :aaib_report_content_api_exporter,
     :finder_api_notifier,
-    :document_panopticon_registerer,
+    :cma_case_panopticon_registerer,
+    :aaib_report_panopticon_registerer,
     :manual_panopticon_registerer,
     :manual_document_panopticon_registerer,
     :manual_content_api_exporter,


### PR DESCRIPTION
When formatting SpecialistDocuments for panopticon we now export them with specific formats so we access this information within the contentapi.

This branch relies on the following pull request or specialist-publisher will throw a validation error from panopticon.
https://github.com/alphagov/panopticon/pull/184

This will also require republishing of all AAIB reports and CMA cases in order for panopticon to register existing urls with the correct format.
