### PR TITLE
Allow User to select multiple aircraft categories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :assets do
   gem "sass-rails", "3.2.6"
   gem "uglifier", ">= 1.3.0"
   gem "govuk_frontend_toolkit", "0.44.0"
+  gem "select2-rails",  "3.5.9"
 end
 
 gem "byebug", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    select2-rails (3.5.9)
+      thor (~> 0.14)
     slop (3.4.7)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -323,6 +325,7 @@ DEPENDENCIES
   rspec-rails (= 2.14.1)
   rubocop
   sass-rails (= 3.2.6)
+  select2-rails (= 3.5.9)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)
   webmock (~> 1.17.4)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,6 +5,7 @@
 //= require length_counter
 //= require specialist_documents
 //= require toggle_hide_with_check_box
+//= require select2
 
 function initPrimaryLinks(){
   GOVUK.primaryLinks.init('.primary-item');
@@ -13,6 +14,10 @@ $(initPrimaryLinks);
 $(window).on('displayPreviewDone', initPrimaryLinks);
 
 jQuery(function($) {
+  $(".select2").select2({
+    placeholder: $(this).data('placeholder')
+  });
+
   $(".js-length-counter").each(function(){
     new GOVUK.LengthCounter({$el:$(this)});
   })

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -8,6 +8,9 @@ form {
     width: 100%;
     border:1px solid #555;
   }
+  .select2-container {
+    width: 100%;
+  }
   .short-textarea {
     height: 50px;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,4 +1,6 @@
 /*
  *= require vendor/bootstrap.scss
+ *= require select2
+ *= require select2-bootstrap
  *= require base.scss
  */

--- a/app/controllers/aaib_reports_controller.rb
+++ b/app/controllers/aaib_reports_controller.rb
@@ -86,6 +86,16 @@ protected
   end
 
   def document_params
-    params.fetch("aaib_report", {})
+    filter_blank_multi_selects(
+      params.fetch("aaib_report", {})
+    ).with_indifferent_access
+  end
+
+  # See http://stackoverflow.com/questions/8929230/why-is-the-first-element-always-blank-in-my-rails-multi-select
+  def filter_blank_multi_selects(values)
+    values.reduce({}) { |filtered_params, (key, value)|
+      filtered_value = value.is_a?(Array) ? value.reject(&:blank?) : value
+      filtered_params.merge(key => filtered_value)
+    }
   end
 end

--- a/app/views/aaib_reports/_aaib_report_form_extra_fields.html.erb
+++ b/app/views/aaib_reports/_aaib_report_form_extra_fields.html.erb
@@ -1,3 +1,0 @@
-<%= f.text_field :date_of_occurrence, placeholder: '2012-04-23' %>
-<%= f.select :aircraft_category, f.object.facet_options(:aircraft_category) %>
-<%= f.select :report_type, f.object.facet_options(:report_type) %>

--- a/app/views/aaib_reports/_form.html.erb
+++ b/app/views/aaib_reports/_form.html.erb
@@ -20,7 +20,10 @@
     <div class="preview_button"></div>
     <div class="preview_container" style="display: none;"></div>
 
-    <%= render partial: "aaib_report_form_extra_fields", locals: { f: f } %>
+    <%= f.text_field :date_of_occurrence, placeholder: '2012-04-23' %>
+    <%= f.select :aircraft_category, f.object.facet_options(:aircraft_category), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select an Aircraft category'} } %>
+    <%= f.select :report_type, f.object.facet_options(:report_type) %>
+
 
     <div class="actions">
       <button name="save" class="btn btn-success">Save as draft</button>

--- a/app/views/aaib_reports/show.html.erb
+++ b/app/views/aaib_reports/show.html.erb
@@ -24,7 +24,7 @@
     <dl class='metadata-list'>
       <% document.extra_fields.each_pair do |label, value| %>
         <dt><%= label.to_s.humanize %></dt>
-        <dd><%= value %></dd>
+        <dd><%= Array(value).join(" ") %></dd>
       <% end %>
       <dt>Publication state</dt>
       <dd><%= state(document) %></dd>

--- a/app/views/cma_cases/_aaib_report_form_extra_fields.html.erb
+++ b/app/views/cma_cases/_aaib_report_form_extra_fields.html.erb
@@ -1,3 +1,0 @@
-<%= f.text_field :date_of_occurrence, placeholder: '2012-04-23' %>
-<%= f.select :aircraft_category, f.object.facet_options(:aircraft_category) %>
-<%= f.select :report_type, f.object.facet_options(:report_type) %>

--- a/app/views/cma_cases/_cma_case_form_extra_fields.html.erb
+++ b/app/views/cma_cases/_cma_case_form_extra_fields.html.erb
@@ -1,6 +1,0 @@
-<%= f.text_field :opened_date, placeholder: '2012-04-23' %>
-<%= f.text_field :closed_date, placeholder: '2013-10-19' %>
-<%= f.select :case_type, f.object.facet_options(:case_type) %>
-<%= f.select :case_state, f.object.facet_options(:case_state) %>
-<%= f.select :market_sector, f.object.facet_options(:market_sector) %>
-<%= f.select :outcome_type, f.object.facet_options(:outcome_type), include_blank: true %>

--- a/schemas/aaib-reports.json
+++ b/schemas/aaib-reports.json
@@ -6,8 +6,8 @@
     {
       "key": "aircraft_category",
       "name": "Aircraft category",
-      "type": "single-select",
-      "include_blank": false,
+      "type": "multi-select",
+      "include_blank": true,
       "allowed_values": [
         {"label": "Commercial - fixed wing", "value": "commercial-fixed-wing"},
         {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},


### PR DESCRIPTION
This PR adds multiple selection for aircraft categories:
- adding select2 gem for doing nice multi selects
- removing partialised extra form fields that were left in

The `filter_blank_multi_select` is to fix a [known Rails issue](http://stackoverflow.com/questions/8929230/why-is-the-first-element-always-blank-in-my-rails-multi-select).

[Trello Ticket](https://trello.com/c/erWWpMKd/201-specialist-publisher-allow-editors-to-add-multiple-tags-make-it-publish-properly-to-rummager-and-content-api-3)
