### PR TITLE
Use more sensible redirects on NotFoundError

### DIFF
--- a/app/controllers/aaib_reports_controller.rb
+++ b/app/controllers/aaib_reports_controller.rb
@@ -3,8 +3,7 @@ class AaibReportsController < ApplicationController
   before_filter :authorize_user
 
   rescue_from("SpecialistDocumentRepository::NotFoundError") do
-    # TODO: Remove use of exceptions for flow control.
-    redirect_to(manuals_path, flash: { error: "Document not found" })
+    redirect_to(aaib_reports_path, flash: { error: "Document not found" })
   end
 
   def index

--- a/app/controllers/cma_cases_controller.rb
+++ b/app/controllers/cma_cases_controller.rb
@@ -5,8 +5,7 @@ class CmaCasesController < ApplicationController
   before_filter :authorize_user
 
   rescue_from("SpecialistDocumentRepository::NotFoundError") do
-    # TODO: Remove use of exceptions for flow control.
-    redirect_to(manuals_path, flash: { error: "Document not found" })
+    redirect_to(cma_cases_path, flash: { error: "Document not found" })
   end
 
   def index


### PR DESCRIPTION
It's weird to redirect to `manuals_path` when rescuing from a `NotFoundError` — it's a hangover from when we didn't have any permission handling.
