### PR TITLE
Fix typo in republish script

### DIFF
--- a/bin/republish_documents
+++ b/bin/republish_documents
@@ -13,7 +13,7 @@ observers = wiring(:observers)
 # manuals. Aaib reports should work (but is untested), manuals is awaiting a
 # sane method of accessing all of them through a repository.
 repository_listeners_map = [
-  [wiring(:cma_cases_repository), CmaCaseObserversRegistry.new.publication],
+  [wiring(:cma_case_repository), CmaCaseObserversRegistry.new.publication],
   #[wiring(:aaib_report_repository), observers.aaib_report_publication],
   #[wiring(:manuals_repository), observers.manual_publication],
 ]


### PR DESCRIPTION
I'll also cherry-pick this commit into `release_209_hotfix` so that we can get that version deployed before we have confidence in `release_210`.
