### PR TITLE
Fix #update bug in DocumentMetadataDecorator

### DIFF
--- a/app/models/document_metadata_decorator.rb
+++ b/app/models/document_metadata_decorator.rb
@@ -9,7 +9,7 @@ class DocumentMetadataDecorator < SimpleDelegator
 
     data = attrs
       .except(*extra_field_names)
-      .merge(extra_fields: extra_attrs)
+      .merge(extra_fields: document.extra_fields.merge(extra_attrs))
 
     document.update(data)
   end


### PR DESCRIPTION
The extra attributes hash was completely replaced
on update with whatever was in the given hash.

This required the caller to provide all the
key/value pairs for the extra attributes or have
them wiped out. This was inconsistent with the
update behaviour of the other fields.
