### PR TITLE
Fix bug where editing an invalid AAIB report 500'd

### DIFF
--- a/app/controllers/abstract_documents_controller.rb
+++ b/app/controllers/abstract_documents_controller.rb
@@ -45,7 +45,7 @@ class AbstractDocumentsController < ApplicationController
     if document.valid?
       redirect_to(show_path(document))
     else
-      render(:edit, locals: { document: document })
+      render(:edit, locals: { document: view_adapter(document) })
     end
   end
 

--- a/features/creating-and-editing-an-aaib-report.feature
+++ b/features/creating-and-editing-an-aaib-report.feature
@@ -16,6 +16,11 @@ Feature: Creating and editing an AAIB Report
     Then I should see an error message about an invalid date field "Date of occurrence"
     And the AAIB report should not have been created
 
+  Scenario: Cannot edit an AAIB report without entering required fields
+    Given a draft AAIB report exists
+    When I edit an AAIB report and remove required fields
+    Then the AAIB report should not have been updated
+
   Scenario: Can view a list of all AAIB reports in the publisher
     Given two AAIB reports exist
     Then the AAIB reports should be in the publisher report index in the correct order

--- a/features/step_definitions/aaib_report_steps.rb
+++ b/features/step_definitions/aaib_report_steps.rb
@@ -70,6 +70,14 @@ When(/^I edit a AAIB report$/) do
   edit_aaib_report(@document_title, title: @new_title)
 end
 
+When(/^I edit an AAIB report and remove required fields$/) do
+  edit_aaib_report(@document_title, summary: "")
+end
+
+Then(/^the AAIB report should not have been updated$/) do
+  expect(page).to have_content("Summary can't be blank")
+end
+
 Then(/^the AAIB report should have been updated$/) do
   check_for_new_aaib_report_title(@new_title)
 end


### PR DESCRIPTION
All pages which rerender a form need the model to be wrapped in a view adapter, otherwise on validation failure we attempt to redisplay the form, which then 500's.
