### PR TITLE
Add extra fields to AAIB Reports

### DIFF
--- a/app/importers/aaib_import/mapper.rb
+++ b/app/importers/aaib_import/mapper.rb
@@ -43,6 +43,8 @@ module AaibImport
       data.merge({
         "title" => title_with_date_if_not_present(data),
         "aircraft_category" => aircraft_categories(data["aircraft_categories"]),
+        "registration" => data["registrations"],
+        "aircraft_type" => data["aircraft_types"],
         "report_type" => report_type(data),
         "body" => body_substitutions(data["body"]),
       })
@@ -117,12 +119,12 @@ module AaibImport
     def desired_keys
       %w(
         aircraft_category
-        aircraft_types
+        aircraft_type
         body
         date_of_occurrence
         location
         registration_string
-        registrations
+        registration
         report_type
         summary
         title

--- a/app/lib/aaib_report_indexable_formatter.rb
+++ b/app/lib/aaib_report_indexable_formatter.rb
@@ -11,6 +11,9 @@ private
       aircraft_category: entity.aircraft_category,
       report_type: entity.report_type,
       date_of_occurrence: entity.date_of_occurrence,
+      location: entity.location,
+      aircraft_type: entity.airccraft_type,
+      registration: entity.registration,
     }
   end
 

--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -2,12 +2,12 @@ require "document_metadata_decorator"
 
 class AaibReport < DocumentMetadataDecorator
   set_extra_field_names [
-    :registration_string,
     :date_of_occurrence,
-    :registrations,
     :aircraft_category,
     :report_type,
     :location,
-    :aircraft_types,
+    :aircraft_type,
+    :registration,
+    :registration_string,
   ]
 end

--- a/app/view_adapters/aaib_report_view_adapter.rb
+++ b/app/view_adapters/aaib_report_view_adapter.rb
@@ -6,6 +6,9 @@ class AaibReportViewAdapter < DocumentViewAdapter
     :date_of_occurrence,
     :aircraft_category,
     :report_type,
+    :aircraft_type,
+    :registration,
+    :location,
   ]
 
   def self.model_name

--- a/app/views/aaib_reports/_form.html.erb
+++ b/app/views/aaib_reports/_form.html.erb
@@ -21,6 +21,9 @@
     <div class="preview_container" style="display: none;"></div>
 
     <%= f.text_field :date_of_occurrence, placeholder: '2012-04-23' %>
+    <%= f.text_field :aircraft_type %>
+    <%= f.text_field :registration %>
+    <%= f.text_field :location %>
     <%= f.select :aircraft_category, f.object.facet_options(:aircraft_category), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select an Aircraft category'} } %>
     <%= f.select :report_type, f.object.facet_options(:report_type) %>
 

--- a/spec/importers/aaib_import/mapper_spec.rb
+++ b/spec/importers/aaib_import/mapper_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AaibImport::Mapper do
       title: "2/1981 Cessna 414, G-BAOZ, 23 March 1980",
       date_of_occurrence: "1980-03-23",
       registration_string: "G-BAOZ",
-      registrations: [
+      registration: [
         "G-BAOZ"
       ],
       aircraft_category: [
@@ -57,7 +57,7 @@ RSpec.describe AaibImport::Mapper do
       ],
       report_type: "special-bulletin",
       location: "Near Leeds Bradford Airport",
-      aircraft_types: "Cessna 414",
+      aircraft_type: "Cessna 414",
       body: "## Report No: 2/1981. Report on the accident to Cessna 414, G-BAOZ near Leeds\nBradford Airport, 23 March 1980\n\n**Date of occurrence: **23 March 1980\n\n**Location: **   \nNear Leeds Bradford Airport\n\n[ Click here to read full details of this incident](http://www.aaib.gov.uk/pub\nlications/formal_reports/2_1981_g_baoz.cfm)\n\n\n2/1981 Cessna 414, G-BAOZ\n\n\nG-BAOZ\n\n\nCessna 414\n\n\nNear Leeds Bradford Airport\n\n\n23 March 1980\n\n\nCommercial Air Transport - Fixed Wing\n\n\n[2-1981\nG-BAOZ.pdf](http://www.aaib.gov.uk/cms_resources/2-1981%20G-BAOZ.pdf)\n(2,357.43 kb)\n\n"
     }
   }

--- a/spec/importers/aaib_import_spec.rb
+++ b/spec/importers/aaib_import_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe "AAIB import" do
     {
       registration_string: "G-BAOZ",
       date_of_occurrence: "1980-03-23",
-      registrations: ["G-BAOZ"],
+      registration: ["G-BAOZ"],
       aircraft_category: ["commercial-fixed-wing"],
       report_type: "formal-report",
       location: "Near Leeds Bradford Airport",
-      aircraft_types: "Cessna 414",
+      aircraft_type: "Cessna 414",
     }
   }
 


### PR DESCRIPTION
This adds aircraft_type, registration and location to AAIB Reports. Requires https://github.com/alphagov/specialist-frontend/pull/32 to be merged too. [Ticket](https://trello.com/c/aqPo7Nww/236-add-extra-fields-into-aaib-specialist-publisher).
