### PR TITLE
Fix pagination count

### DIFF
--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -66,7 +66,7 @@ class SpecialistDocumentRepository
   end
 
   def count
-    specialist_document_editions.count
+    specialist_document_editions.distinct(:document_id).count
   end
 
 private


### PR DESCRIPTION
The number of records in the system is the number of document_ids, not the number of editions.

This makes the publishing tool show 3 pages of CMA cases instead of 7 pages.
