### PR TITLE
Allow explicit not relative paths to import content

### DIFF
--- a/app/importers/dfid_import/attachment_mapper.rb
+++ b/app/importers/dfid_import/attachment_mapper.rb
@@ -4,11 +4,10 @@ module DfidImport
   class AttachmentMapper
     include ::DocumentImport::AttachmentHelpers
 
-    def initialize(import_mapper, repo, logger, base_path = ".")
+    def initialize(import_mapper, repo, logger)
       @import_mapper = import_mapper
       @repo = repo
       @logger = logger
-      @base_path = base_path
     end
 
     def call(data)
@@ -27,23 +26,24 @@ module DfidImport
     end
 
   private
-    attr_accessor :import_mapper, :repo, :logger, :base_path
+    attr_accessor :import_mapper, :repo, :logger
 
     def attach_asset(document, asset_data, data)
       begin
-        asset_path = File.join(base_path, data.fetch("import_source"))
+        asset_path = data.fetch("import_source")
 
         attachment = document.add_attachment(
           attachable_file_attributes(asset_path, asset_data)
         )
 
         replace_whitehall_snippet_with_snippet(document, attachment, asset_data)
-      rescue Errno::ENOENT
+      rescue Errno::ENOENT => e
         # Some files on whitehall aren't available bc they're stuck in
         # 'Virus scanning'.
         logger.warn("Couldn't attach document", {
           filename: asset_data.fetch("filename"),
           source: data.fetch("import_source"),
+          error: e.message,
         })
       end
     end

--- a/spec/importers/dfid_import/attachment_mapper_spec.rb
+++ b/spec/importers/dfid_import/attachment_mapper_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe DfidImport::AttachmentMapper do
   subject(:mapper) do
     DfidImport::AttachmentMapper.new(dfid_import_mapper,
       repo,
-      logger,
-      "spec/fixtures/dfid_import",
+      logger
     )
   end
 
@@ -30,7 +29,7 @@ RSpec.describe DfidImport::AttachmentMapper do
       "title" =>  expected_title,
       "summary" => "International development report summary",
       "body" => raw_body,
-      "import_source" => "100100",
+      "import_source" => "./spec/fixtures/dfid_import/100100",
       "attachments" => [
         {
           "title" => expected_title,

--- a/spec/importers/dfid_import_spec.rb
+++ b/spec/importers/dfid_import_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "DFID import" do
     DfidImport.call(data_dir)
   end
 
-  let(:data_dir)            { "spec/fixtures/dfid_import" }
+  let(:data_dir) { "./spec/fixtures/dfid_import" }
 
   let(:repo) {
     SpecialistPublisherWiring.get(:international_development_fund_repository)


### PR DESCRIPTION
When importing content we use explicit paths, not relative ones. 

The test suite should do the same.

Also provide the error message in the output to ease diagnosis in future when files aren't able to be imported (to show the full path to the file it's attempting to import).
