### PR TITLE
Allow DFID User to select multiple fund values

### DIFF
--- a/app/views/international_development_funds/_form.html.erb
+++ b/app/views/international_development_funds/_form.html.erb
@@ -24,7 +24,7 @@
     <%= f.select :location, f.object.facet_options(:location), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select a location'} } %>
     <%= f.select :development_sector, f.object.facet_options(:development_sector), { label: 'Sector'}, { class: 'select2', multiple: true, data: {placeholder: 'Select a Sector'} } %>
     <%= f.select :eligible_entities, f.object.facet_options(:eligible_entities), { label: 'Eligible Organisations'}, { class: 'select2', multiple: true, data: {placeholder: 'Select an eligible organisation'} } %>
-    <%= f.select :value_of_fund, f.object.facet_options(:value_of_fund) %>
+    <%= f.select :value_of_fund, f.object.facet_options(:value_of_fund), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select a Value'} } %>
 
 
     <div class="actions">


### PR DESCRIPTION
This commit changes the value_of_fund input to be a multi-select. We don't need to change this anywhere else as the rest of the Finder stack always treats metadata as arrays.
