### PR TITLE
Move html rendering to erb template

### DIFF
--- a/app/controllers/abstract_documents_controller.rb
+++ b/app/controllers/abstract_documents_controller.rb
@@ -70,9 +70,23 @@ class AbstractDocumentsController < ApplicationController
   end
 
   def preview
-    preview_html = services.preview(params["id"], document_params).call
+    document = services.preview(params["id"], document_params).call
 
-    render json: { preview_html: preview_html }
+    document.valid? # Force validation check or errors will be empty
+
+    if document.errors[:body].nil?
+      render json: { preview_html: document.body }
+    else
+      render json: {
+        preview_html: render_to_string(
+          "specialist_documents/_preview_errors",
+          layout: false,
+          locals: {
+            errors: document.errors[:body]
+          }
+        )
+      }
+    end
   end
 
 private

--- a/app/services/preview_document_service.rb
+++ b/app/services/preview_document_service.rb
@@ -9,15 +9,8 @@ class PreviewDocumentService
 
   def call
     document.update(document_params)
-    document.valid? # Force validation check or errors will be empty
 
-    if document.errors[:body].nil?
-      document_renderer.call(document).body
-    else
-      document.errors[:body].map { |m|
-        content_tag(:p, "Body #{m}")
-      }
-    end
+    document_renderer.call(document)
   end
 
   private

--- a/app/views/specialist_documents/_preview_errors.html.erb
+++ b/app/views/specialist_documents/_preview_errors.html.erb
@@ -1,0 +1,3 @@
+<% errors.each do |error| %>
+ <p>Body <%= error %>
+<% end %>

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -54,3 +54,10 @@ Feature: Creating and editing a CMA case
     When I start creating a new CMA case
     And I preview the case
     Then I see the case body preview
+
+  @javascript
+  Scenario: Previewing a CMA case with a body containing javascript
+    When I start creating a new CMA case with embedded javascript
+    And I preview the case
+    Then I should see an error message about a "Body" field containing javascript
+

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -143,6 +143,14 @@ When(/^I start creating a new CMA case$/) do
   create_cma_case(@cma_fields, save: false)
 end
 
+When(/^I start creating a new CMA case with embedded javascript$/) do
+  @cma_fields = {
+    body: "<script>alert('Oh noes!)</script>",
+  }
+
+  create_cma_case(@cma_fields, save: false)
+end
+
 When(/^I preview the case$/) do
   generate_preview
 end


### PR DESCRIPTION
Fix a bug where we were calling content_tag in the service layer. Instead allow the service to pass the document down to the controller. The controller can now decide which html to render (either the document renderer body or the error html) rather than the service making this decision.

This also means the service no longer needs access to content_tag and ActionView methods.
