### PR TITLE
Cleanup work on new observers

### DIFF
--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -2,28 +2,30 @@ class AaibReportObserversRegistry
   def publication
     [
       content_api_exporter,
-      finder_api_notifier,
-      panopticon_registerer,
-      rummager_indexer,
+      finder_api_exporter,
+      panopticon_exporter,
+      rummager_exporter,
     ]
   end
 
   def update
-    []
+    [
+      panopticon_exporter,
+    ]
   end
 
   def creation
     [
-      panopticon_registerer,
+      panopticon_exporter,
     ]
   end
 
   def withdrawal
     [
-      specialist_document_content_api_withdrawer,
+      content_api_withdrawer,
       finder_api_withdrawer,
-      panopticon_registerer,
-      rummager_deleter,
+      panopticon_exporter,
+      rummager_withdrawer,
     ]
   end
 
@@ -32,19 +34,19 @@ private
     SpecialistPublisherWiring.get(:aaib_report_content_api_exporter)
   end
 
-  def panopticon_registerer
+  def panopticon_exporter
     SpecialistPublisherWiring.get(:aaib_report_panopticon_registerer)
   end
 
-  def rummager_deleter
+  def rummager_withdrawer
     SpecialistPublisherWiring.get(:aaib_report_rummager_deleter)
   end
 
-  def rummager_indexer
+  def rummager_exporter
     SpecialistPublisherWiring.get(:aaib_report_rummager_indexer)
   end
 
-  def finder_api_notifier
+  def finder_api_exporter
     SpecialistPublisherWiring.get(:finder_api_notifier)
   end
 
@@ -52,7 +54,7 @@ private
     SpecialistPublisherWiring.get(:finder_api_withdrawer)
   end
 
-  def specialist_document_content_api_withdrawer
+  def content_api_withdrawer
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 end

--- a/app/observers/manual_document_observers_registry.rb
+++ b/app/observers/manual_document_observers_registry.rb
@@ -1,12 +1,12 @@
 class ManualDocumentObserversRegistry
   def creation
     [
-      panopticon_registerer,
+      panopticon_exporter,
     ]
   end
 
 private
-  def panopticon_registerer
+  def panopticon_exporter
     SpecialistPublisherWiring.get(:manual_document_panopticon_registerer)
   end
 end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -4,7 +4,7 @@ class ManualObserversRegistry
   def publication
     [
       publication_logger,
-      panopticon_registerer,
+      panopticon_exporter,
       content_api_exporter,
       change_note_content_api_exporter,
     ]
@@ -12,7 +12,7 @@ class ManualObserversRegistry
 
   def creation
     [
-      panopticon_registerer,
+      panopticon_exporter,
     ]
   end
 
@@ -39,7 +39,7 @@ private
     }
   end
 
-  def panopticon_registerer
+  def panopticon_exporter
     SpecialistPublisherWiring.get(:manual_panopticon_registerer)
   end
 

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -57,7 +57,6 @@ private
   end
 
   def observers
-    # TODO Get a set of manual-specific observers
     @observers ||= ManualObserversRegistry.new
   end
 end


### PR DESCRIPTION
Change the naming of methods within the observers to match what's used already for CMA cases and IDF's.

Fix a (supposed) bug where we didn't notify panopticon on update of an aaib report.

Remove legacy TODO.
