### PR TITLE
Export to rummager whenever a manual is published

### DIFF
--- a/app/lib/manual_indexable_formatter.rb
+++ b/app/lib/manual_indexable_formatter.rb
@@ -1,0 +1,16 @@
+require "abstract_indexable_formatter"
+
+class ManualIndexableFormatter < AbstractIndexableFormatter
+  def type
+    "manual"
+  end
+
+private
+  def indexable_content
+    entity.summary # Manuals don't have a body
+  end
+
+  def organisation_slugs
+    [entity.organisation_slug]
+  end
+end

--- a/app/lib/manual_section_indexable_formatter.rb
+++ b/app/lib/manual_section_indexable_formatter.rb
@@ -1,0 +1,31 @@
+class ManualSectionIndexableFormatter
+  def initialize(section, manual)
+    @section = section
+    @manual = manual
+  end
+
+  def type
+    "manual_section"
+  end
+
+  def id
+    link
+  end
+
+  def indexable_attributes
+    {
+      title: "#{manual.title}: #{section.title}",
+      description: section.summary,
+      link: link,
+      indexable_content: section.body,
+      organisations: [manual.organisation_slug],
+    }
+  end
+
+private
+  attr_reader :section, :manual
+
+  def link
+    section.slug
+  end
+end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -7,6 +7,7 @@ class ManualObserversRegistry
       panopticon_exporter,
       content_api_exporter,
       change_note_content_api_exporter,
+      rummager_exporter,
     ]
   end
 
@@ -34,6 +35,25 @@ private
           title: doc.title,
           slug: doc.slug,
           change_note: doc.change_note,
+        )
+      end
+    }
+  end
+
+  def rummager_exporter
+    ->(manual) {
+      indexer = RummagerIndexer.new
+
+      indexer.add(
+        ManualIndexableFormatter.new(manual)
+      )
+
+      manual.documents.each do |section|
+        indexer.add(
+          ManualSectionIndexableFormatter.new(
+            SpecialistDocumentAttachmentProcessor.new(section),
+            manual,
+          )
         )
       end
     }

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -144,6 +144,35 @@ module ManualHelpers
     check_manual_is_published_to_content_api(manual_slug, manual_attrs, document_slug, document_attrs)
     check_manual_document_is_published_to_content_api(document_attrs)
     check_manual_change_note_is_set_to_default(manual_slug)
+
+    check_manual_is_published_to_rummager(manual_slug, manual_attrs)
+    check_manual_section_is_published_to_rummager(document_slug, document_attrs, manual_attrs)
+  end
+
+  def check_manual_is_published_to_rummager(slug, attrs)
+    expect(fake_rummager).to have_received(:add_document)
+      .with(
+        "manual",
+        slug,
+        hash_including(
+          title: attrs.fetch(:title),
+          link: slug,
+          indexable_content: attrs.fetch(:summary),
+        )
+      ).at_least(:once)
+  end
+
+  def check_manual_section_is_published_to_rummager(slug, attrs, manual_attrs)
+    expect(fake_rummager).to have_received(:add_document)
+      .with(
+        "manual_section",
+        slug,
+        hash_including(
+          title: "#{manual_attrs.fetch(:title)}: #{attrs.fetch(:title)}",
+          link: slug,
+          indexable_content: attrs.fetch(:body),
+        )
+      ).at_least(:once)
   end
 
   def create_manual_document_for_preview(manual_title, fields)


### PR DESCRIPTION
When a manual is published, tell rummager about both the manual and its sections.

Rummager then adds them to the elasticsearch index, so that we can make them appear in search results.
