### PR TITLE
GdsApiProxy for "tell don't ask" no raise APIs

### DIFF
--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -7,6 +7,7 @@ require "cma_case_indexable_formatter"
 require "dependency_container"
 require "finder_api"
 require "finder_api_notifier"
+require "gds_api_proxy"
 require "gds_api/rummager"
 require "id_generator"
 require "manual_database_exporter"
@@ -285,8 +286,19 @@ SpecialistPublisherWiring = DependencyContainer.new do
       PanopticonRegisterer.new(
         mappings: PanopticonMapping,
         artefact: artefact,
+        api: get(:panopticon_api),
+        error_logger: Airbrake.method(:notify),
       ).call
     }
+  }
+
+  define_factory(:panopticon_api) {
+    GdsApiProxy.new(
+      GdsApi::Panopticon.new(
+        Plek.current.find("panopticon"),
+        PANOPTICON_API_CREDENTIALS
+      )
+    )
   }
 
   define_factory(:aaib_report_panopticon_registerer) {

--- a/features/creating-and-editing-a-cma-case.feature
+++ b/features/creating-and-editing-a-cma-case.feature
@@ -37,6 +37,12 @@ Feature: Creating and editing a CMA case
     Then the title has been updated
     And the URL slug remains unchanged
 
+  Scenario: Panopticon timeout
+    Given a draft CMA case exists
+    And Panopticon is timing out
+    When I edit a CMA case
+    Then I should not see an error
+
   @regression
   Scenario: Changing the slug on a draft CMA case
     Given a draft CMA case exists

--- a/features/step_definitions/creating_a_cma_case_steps.rb
+++ b/features/step_definitions/creating_a_cma_case_steps.rb
@@ -155,3 +155,11 @@ end
 When(/^I preview the case$/) do
   generate_preview
 end
+
+Given(/^Panopticon is timing out$/) do
+  mock_panopticon_timeout
+end
+
+Then(/^I should not see an error$/) do
+  check_publication_has_not_raised_error
+end

--- a/features/support/cma_case_helpers.rb
+++ b/features/support/cma_case_helpers.rb
@@ -88,4 +88,8 @@ module CmaCaseHelpers
     check_for_new_document_title(:cma_case, *args)
   end
 
+  def check_publication_has_not_raised_error
+    expect(page).not_to have_content("error")
+    expect(current_path).to match(%r{^/cma-cases/[a-f0-9\-]{36}$})
+  end
 end

--- a/features/support/panopticon_helpers.rb
+++ b/features/support/panopticon_helpers.rb
@@ -51,6 +51,11 @@ module PanopticonHelpers
       .and_return(fake_panopticon)
   end
 
+  def mock_panopticon_timeout
+    allow(fake_panopticon).to receive(:put_artefact!).and_raise(GdsApi::TimedOutException)
+    allow(fake_panopticon).to receive(:create_artefact!).and_raise(GdsApi::TimedOutException)
+  end
+
   def panopticon_id_for_slug(slug)
     fake_panopticon.panopticon_id_for_slug(slug)
   end

--- a/lib/gds_api_proxy.rb
+++ b/lib/gds_api_proxy.rb
@@ -1,0 +1,58 @@
+class GdsApiProxy
+  def initialize(api)
+    @api = api
+  end
+
+  def respond_to_missing?(method_id)
+    api.respond_to?(method_id)
+  end
+
+  def method_missing(method_id, *args, &block)
+    return super unless respond_to_missing?(method_id)
+
+    response = api.public_send(method_id, *args, &block)
+
+    SuccessResponseProxy.new(response)
+  rescue GdsApi::BaseError => e
+    ErrorResponseProxy.new(e, *args)
+  end
+
+private
+  attr_reader :api
+
+  module ResponseProxy
+    def on_success(&block)
+      self
+    end
+
+    def on_error(&block)
+      self
+    end
+  end
+
+  class SuccessResponseProxy
+    include ResponseProxy
+
+    def initialize(response)
+      @response = response
+    end
+
+    def on_success(&block)
+      block.call(@response)
+      self
+    end
+  end
+
+  class ErrorResponseProxy
+    include ResponseProxy
+
+    def initialize(*args)
+      @args = args
+    end
+
+    def on_error(&block)
+      block.call(*@args)
+      self
+    end
+  end
+end

--- a/spec/gds_api_proxy_spec.rb
+++ b/spec/gds_api_proxy_spec.rb
@@ -1,0 +1,111 @@
+require "fast_spec_helper"
+
+require "gds_api_proxy"
+
+module GdsApi
+  class BaseError < StandardError; end
+end
+
+RSpec.describe GdsApiProxy do
+  subject(:api_proxy) {
+    GdsApiProxy.new(gds_api)
+  }
+
+  let(:gds_api) {
+    double(
+      :gds_api,
+      put_a_thing: response,
+    )
+  }
+
+  let(:response) { double(:response) }
+  let(:success_spy) { double(:success_spy, call: "not nil") }
+  let(:error_spy) { double(:error_spy, call: "not nil") }
+
+  describe "calling an api method" do
+    let(:id_of_thing) { double(:id_of_thing) }
+    let(:attributes_of_thing) { { foo: "bar" } }
+
+    it "delegates to the GDS API object" do
+      api_proxy.put_a_thing(
+        id_of_thing,
+        attributes_of_thing,
+      )
+
+      expect(gds_api).to have_received(:put_a_thing)
+        .with(id_of_thing, attributes_of_thing)
+    end
+
+    it "returns a repsonse proxy" do
+      expect(
+        api_proxy.put_a_thing(
+          id_of_thing,
+          attributes_of_thing,
+        )
+      ).to be_a(GdsApiProxy::ResponseProxy)
+    end
+
+    context "when the request is successful" do
+      it "calls the success callback with the response" do
+        api_proxy.put_a_thing(
+          id_of_thing,
+          attributes_of_thing,
+        )
+        .on_success { |*args| success_spy.call(*args) }
+        .on_error { |*args| error_spy.call(*args) }
+
+        expect(success_spy).to have_received(:call).with(response)
+      end
+
+      it "does not call the error callback" do
+        api_proxy.put_a_thing(
+          id_of_thing,
+          attributes_of_thing,
+        )
+        .on_success { |*args| success_spy.call(*args) }
+        .on_error { |*args| error_spy.call(*args) }
+
+        expect(error_spy).not_to have_received(:call)
+      end
+    end
+
+    context "when an error is raised" do
+      let(:error) { GdsApi::BaseError.new("Wat?") }
+
+      before do
+        allow(gds_api).to receive(:put_a_thing).and_raise(error)
+      end
+
+      it "calls the error callback with the exception and api arguments" do
+        api_proxy.put_a_thing(
+          id_of_thing,
+          attributes_of_thing,
+        )
+        .on_success { |*args| success_spy.call(*args) }
+        .on_error { |*args| error_spy.call(*args) }
+
+        expect(error_spy).to have_received(:call)
+          .with(error, id_of_thing, attributes_of_thing)
+      end
+
+      it "does not call the success callback" do
+        api_proxy.put_a_thing(
+          id_of_thing,
+          attributes_of_thing,
+        )
+        .on_success { |*args| success_spy.call(*args) }
+        .on_error { |*args| error_spy.call(*args) }
+
+        expect(success_spy).not_to have_received(:call)
+      end
+    end
+  end
+
+  context "when the api does not respond to the message" do
+    it "does not delegate" do
+      expect {
+        api_proxy.definitely_not_an_api_method
+      }.to raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
Proxy object for wrapping GdsApiAdpaters.
Presents a promise-like interface with success and error callbacks.
