### PR TITLE
Make sure version number is present on PublicationLog

### DIFF
--- a/app/models/publication_log.rb
+++ b/app/models/publication_log.rb
@@ -5,6 +5,10 @@ class PublicationLog
   field :slug, type: String
   field :title, typ: String
   field :change_note, type: String
+  field :version_number, type: Integer
+
+  validates :slug, presence: true
+  validates :version_number, presence: true
 
   alias_attribute :published_at, :created_at
 


### PR DESCRIPTION
When we interact with PublicationLog we should make sure we always have a version number amnd, for that matter, a slug as this will cause issues in the future.

This was being caught by Sidekiq when queueing publishing. It will also require migrations to be run in order to remove exisiting PublicationLogs again as there is some existing data we are aware of which currently breaks preview.
