### PR TITLE
Assure errors are raised when recoverable errors occur

### DIFF
--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -2,6 +2,7 @@ class PublishManualWorker
   include Sidekiq::Worker
 
   sidekiq_options(
+    # This is required to retry in the case of a FailedToPublishError
     retry: 25,
     backtrace: true,
   )

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -59,3 +59,10 @@ Feature: Publishing a manual
     And a draft document exists for the manual
     When I publish the manual
     Then the manual and its documents are queued for publishing
+
+  Scenario: Manual publication retries after recoverable error
+    Given a draft manual exists
+    And a draft document exists for the manual
+    And a recoverable error occurs
+    When I publish the manual expecting a recoverable error
+    Then the publication reattempted

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -308,10 +308,24 @@ Then(/^the manual and its documents are queued for publishing$/) do
   expect(page).to have_content("It should be published shortly.")
 end
 
-Given(/^a recoverable error occurs on the first attempt$/) do
-  mock_panopticon_http_error_once(500)
+Given(/^a recoverable error occurs$/) do
+  mock_panopticon_http_error(500)
 end
 
 Given(/^an unrecoverable error occurs$/) do
-  mock_panopticon_http_error_once(409)
+  mock_panopticon_http_error(409)
+end
+
+When(/^I publish the manual expecting a recoverable error$/) do
+  begin
+    publish_manual
+  rescue PublishManualWorker::FailedToPublishError => e
+    @error = e
+  end
+end
+
+Then(/^the publication reattempted$/) do
+  # This is merely to assure that the correct error type is raised forcing
+  # sidekiq to retry. This is the default behaviour of sidekiq in the case of a failure
+  expect(@error).to be_a(PublishManualWorker::FailedToPublishError)
 end

--- a/features/support/panopticon_helpers.rb
+++ b/features/support/panopticon_helpers.rb
@@ -46,9 +46,9 @@ module PanopticonHelpers
       .and_return(fake_panopticon)
   end
 
-  def mock_panopticon_http_error_once(error_code)
-    allow(fake_panopticon).to receive(:put_artefact!).and_raise(GdsApi::HTTPErrorResponse.new(error_code)).once
-    allow(fake_panopticon).to receive(:create_artefact!).and_raise(GdsApi::HTTPErrorResponse.new(error_code)).once
+  def mock_panopticon_http_error(error_code)
+    allow(fake_panopticon).to receive(:put_artefact!).and_raise(GdsApi::HTTPErrorResponse.new(error_code))
+    allow(fake_panopticon).to receive(:create_artefact!).and_raise(GdsApi::HTTPErrorResponse.new(error_code))
   end
 
   def mock_panopticon_timeout


### PR DESCRIPTION
Unfortunately sidekiq bypasses large chunks of functionality in test mode which means we do not run retries when running sidekiq 'inline!'. Instead we depend here on sidekiq's default functionality to retry in the case of a raised error and use this test to assert that a FailedToPublishError is raised causing this default sidekiq functionality.
