### PR TITLE
Send manual slug to to rummager for manual sections

### DIFF
--- a/app/lib/manual_section_indexable_formatter.rb
+++ b/app/lib/manual_section_indexable_formatter.rb
@@ -19,6 +19,7 @@ class ManualSectionIndexableFormatter
       link: link,
       indexable_content: section.body,
       organisations: [manual.organisation_slug],
+      manual: manual.slug,
     }
   end
 


### PR DESCRIPTION
So that search results can be scoped to sections within a manual.

Depends on https://github.com/alphagov/rummager/pull/282
