### PR TITLE
Move logic from exporter to PublicationLog

### DIFF
--- a/app/models/publication_log.rb
+++ b/app/models/publication_log.rb
@@ -16,4 +16,12 @@ class PublicationLog
     where(slug: /^#{slug}.*/)
       .order(:created_at)
   end
+
+  def self.change_notes_for(slug)
+    with_slug_prefix(slug)
+      .sort_by(&:published_at)
+      .uniq { |publication|
+        [publication.slug, publication.version_number]
+      }
+  end
 end

--- a/lib/manual_change_note_database_exporter.rb
+++ b/lib/manual_change_note_database_exporter.rb
@@ -23,7 +23,7 @@ class ManualChangeNoteDatabaseExporter
   end
 
   def serialized_change_notes
-    relevant_entries.map { |publication|
+    publication_logs.change_notes_for(manual.slug).map { |publication|
       {
         slug: publication.slug,
         title: publication.title,
@@ -31,17 +31,5 @@ class ManualChangeNoteDatabaseExporter
         published_at: publication.published_at.utc,
       }
     }
-  end
-
-  def relevant_entries
-    publication_history
-      .sort_by(&:published_at)
-      .uniq { |publication|
-        [publication.slug, publication.version_number]
-      }
-  end
-
-  def publication_history
-    publication_logs.with_slug_prefix(manual.slug)
   end
 end

--- a/spec/manual_change_note_database_exporter_spec.rb
+++ b/spec/manual_change_note_database_exporter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ManualChangeNoteDatabaseExporter do
   let(:publication_log_timestamp)   { double(:publication_log_timestamp, utc: utc_publication_log_timestamp) }
 
   let(:publication_logs_collection) {
-    double(:publication_logs_collection, with_slug_prefix: [])
+    double(:publication_logs_collection)
   }
 
   let(:manual) {
@@ -53,14 +53,14 @@ RSpec.describe ManualChangeNoteDatabaseExporter do
 
   describe "#call" do
     before do
-      allow(publication_logs_collection).to receive(:with_slug_prefix)
+      allow(publication_logs_collection).to receive(:change_notes_for)
         .and_return(manual_publication_logs)
     end
 
     it "retrieves the publication history for the manual" do
       exporter.call
 
-      expect(publication_logs_collection).to have_received(:with_slug_prefix)
+      expect(publication_logs_collection).to have_received(:change_notes_for)
         .with(manual_slug)
     end
 


### PR DESCRIPTION
By encapsulating the logic for fetching change notes for a publication,
it's possible to reuse it with other exporters.
