### PR TITLE
Fix timezone of publication queue notification

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,8 @@ module ApplicationHelper
   end
 
   def publication_task_state(task)
-    formatted_time = nice_time_format(task.updated_at)
+    zoned_time = time_with_local_zone(task.updated_at)
+    formatted_time = nice_time_format(zoned_time)
 
     output =  case task.state
               when "queued", "processing"

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,5 +1,9 @@
 module DateTimeHelper
 
+  def time_with_local_zone(time)
+    ActiveSupport::TimeZone.new("London").at(time)
+  end
+
   def nice_time_format(time)
     content_tag :time, datetime: time.iso8601 do
       time.strftime("%l:%M%P on %-d %B %Y")


### PR DESCRIPTION
The server appears to be set perpetually in UTC so the app is unaware of the
switchover to BST. The addition of the view helper gives us a convenient way
of finding the local time for London from the UTC times in the database without
getting into timezone hell.
