### PR TITLE
Bugfix/manual publish task ordering

### DIFF
--- a/app/models/manual_publish_task.rb
+++ b/app/models/manual_publish_task.rb
@@ -9,8 +9,11 @@ class ManualPublishTask
   field :state, type: String
   field :error, type: String
 
-  scope :for_manual, ->(manual) { where(manual_id: manual.id) }
-  scope :by_newest_version_number, order_by([:version_number, :desc])
+  scope :for_manual, ->(manual) {
+    all
+      .where(manual_id: manual.id)
+      .order_by([:version_number, :desc])
+  }
 
   state_machine initial: :queued do
     event :start! do

--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -5,7 +5,7 @@ class ManualPublishTaskAssociationMarshaller
   end
 
   def load(manual, _record)
-    tasks = collection.for_manual(manual).by_newest_version_number
+    tasks = collection.for_manual(manual)
 
     decorator.call(manual, publish_tasks: tasks)
   end


### PR DESCRIPTION
The bugfix:
Everyone be good and read your mongoid docs :)

Refactor:
As the scope is "for_manual" and the use case of these task logs is such that
they must be in newest first order, this scope now implicitly orders the
returned records.

The separate ordering scope has been removed.

This change makes the API smaller and more testable as chaining is no longer
necessary.
