### PR TITLE
Update help text for legislative list govspeak

### DIFF
--- a/app/views/shared/_govspeak-help.html.erb
+++ b/app/views/shared/_govspeak-help.html.erb
@@ -92,6 +92,7 @@ Don't use a single # - this is H1 and is for the title only</pre>
     * i. Item 2 b i
     * ii. Item 2 b ii
 * 3. Item 3
+$EndLegislativeList
 (to indent, add 2 spaces)</pre>
 </div>
 


### PR DESCRIPTION
LegislativeList now behaves slightly differently in the newer version of Govspeak that's being used.
