### PR TITLE
Fix typo in rummager stub and message reset

### DIFF
--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -22,7 +22,7 @@ module RummagerHelpers
   end
 
   def reset_rummager_stubs_and_messages
-    RSpec::Mocks.space.proxy_for(rummager_api).reset
+    RSpec::Mocks.space.proxy_for(fake_rummager).reset
     stub_rummager
   end
 


### PR DESCRIPTION
This did not fail or raise an error because:
1. `rummager_api` is a method in the wiring
2. The wiring is included in the entire cucumber World
3. The tests using this were then matching original requests.
