### PR TITLE
Add help for collapsibles

### DIFF
--- a/app/views/manual_documents/_form.html.erb
+++ b/app/views/manual_documents/_form.html.erb
@@ -23,6 +23,15 @@
 </div>
 
 <div class="col-md-4">
+
+<% content_for :format_specific_help do %>
+  <h3><a data-toggle="collapse" data-target="#govspeak-collapsible">Collapsible</a></h3>
+  <div class="collapse" id="govspeak-collapsible">
+    <pre>## Section title
+body content to be collapsed.</pre>
+  </div>
+<% end %>
+
   <%= render partial: 'shared/govspeak-help' %>
 
   <h2>Attachments</h2>

--- a/app/views/shared/_govspeak-help.html.erb
+++ b/app/views/shared/_govspeak-help.html.erb
@@ -4,7 +4,7 @@
 <p>For style, see the <a href="https://www.gov.uk/designprinciples/styleguide">style guide</a></p>
 
 <h2>Formatting help</h2>
-
+<%= yield :format_specific_help %>
 <h3><a data-toggle="collapse" data-target="#govspeak-headings">Headings</a></h3>
 <div class="collapse" id="govspeak-headings">
   <pre>## Top level heading - H2


### PR DESCRIPTION
This help is only required for collapsible sections on manuals so add in a yield to format specific help and pass in the help from the manuals edit page
