### PR TITLE
Improve display of long metadata value lists

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -40,11 +40,11 @@ p.no-content-message {
 
   dt {
     float: left;
-    clear: left;
+    clear: both;
     width:30%;
   }
   dd {
-    float: left;
+    float: right;
     width:70%;
   }
 }

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -22,9 +22,11 @@
   <div class=" col-md-8">
     <h2>Metadata</h2>
     <dl class='metadata-list'>
-      <% document.humanized_attributes.each_pair do |label, value| %>
+      <% document.humanized_attributes.each_pair do |label, values| %>
         <dt><%= label.to_s.humanize %></dt>
-        <dd><%= Array(value).join(" ") %></dd>
+        <% Array(values).each do |value| %>
+          <dd><%= value %></dd>
+        <% end %>
       <% end %>
       <dt>Publication state</dt>
       <dd><%= state(document) %></dd>


### PR DESCRIPTION
For metadata that can have multiple values (eg `therapeutic_area` for a `drug_safety_update` document) place each value into a separate `dd`.
### Screenshots

Before:

![screen shot 2014-09-25 at 15 08 49](https://cloud.githubusercontent.com/assets/74812/4405762/fa792696-44bd-11e4-85c7-131fd430d409.png)

After:

![screen shot 2014-09-25 at 15 08 32](https://cloud.githubusercontent.com/assets/74812/4405764/fe8c7eb8-44bd-11e4-8b8b-6b59dbc3a3ad.png)
