### PR TITLE
Rescue errors when creating a topic in GovukDelivery

### DIFF
--- a/app/exporters/email_alert_exporter.rb
+++ b/app/exporters/email_alert_exporter.rb
@@ -22,6 +22,8 @@ private
       formatter.identifier,
       formatter.name,
     )
+  rescue GdsApi::HTTPClientError => e
+    Rails.logger.warn "Error creating topic #{formatter.identifier} in GovDelivery. Already exists?"
   end
 
   def send_notification_to_delivery_api


### PR DESCRIPTION
When we notify Govdelivery to send an e-mail on publish, we first ensure the topic exists in the govuk_delivery API.

However, when doing this, govuk_delivery first checks its local mongo store to check if that topic already exists in GovDelivery. If not, it attempts to create it.

On preview, development and staging environments, the mongo store is nuked periodically to sync data with production. This means that staging and preview lose knowledge of which topics have already been created in
GovDelivery, meaning govuk_delivery attempts to create topics which already exist.

govuk_delivery therefore attempts to create this topic with GovDelivery, and then fails.

We rescue this at this level rather than adjusting the function of govuk_delivery because we're intending to replace this with [alphagov/email-alert-api](https://github.com/alphagov/email-alert-api).

This fixes 500 errors experienced when publishing non-manual Specialist Documents.
