### PR TITLE
Allow never published manual documents to be deleted through the UI

### DIFF
--- a/app/controllers/manual_documents_controller.rb
+++ b/app/controllers/manual_documents_controller.rb
@@ -1,3 +1,5 @@
+require "destroy_manual_document_service"
+
 class ManualDocumentsController < ApplicationController
   def show
     manual, document = services.show(self).call
@@ -28,6 +30,15 @@ class ManualDocumentsController < ApplicationController
         document: ManualDocumentViewAdapter.new(manual, document),
       })
     end
+  end
+
+  def destroy
+    manual, document = services.destroy(self).call
+    flash[:notice] = "Manual document deleted successfully"
+    redirect_to(manual_path(manual))
+  rescue AlreadyPublishedError => e
+    flash[:error] = e.message
+    redirect_to(manual_document_path(e.manual, e.document))
   end
 
   def edit

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -12,6 +12,10 @@ class ManualWithDocuments < SimpleDelegator
     @documents.to_enum
   end
 
+  def remove_document(document)
+    @documents = @documents.reject { |d| d == document }
+  end
+
   def build_document(attributes)
     document = document_builder.call(
       self,

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -34,6 +34,10 @@ class SpecialistDocument
     @latest_edition = @editions.last
   end
 
+  def destroy_latest_edition
+    latest_edition.destroy
+  end
+
   def minor_update?
     !!minor_update
   end
@@ -131,13 +135,13 @@ class SpecialistDocument
     end
   end
 
-protected
-
-  attr_reader :slug_generator, :edition_factory
-
   def never_published?
     !published?
   end
+
+protected
+
+  attr_reader :slug_generator, :edition_factory
 
   def new_edition_defaults
     {

--- a/app/services/destroy_manual_document_service.rb
+++ b/app/services/destroy_manual_document_service.rb
@@ -1,0 +1,50 @@
+class AlreadyPublishedError < StandardError
+  attr_reader :manual, :document
+
+  def initialize(manual, document)
+    @manual = manual
+    @document = document
+  end
+
+  def message
+    "This document cannot be deleted as it has already been published"
+  end
+end
+
+class DestroyManualDocumentService
+  def initialize(dependencies)
+    @manual_repository = dependencies.fetch(:manual_repository)
+    @manual_id = dependencies.fetch(:manual_id)
+    @document_id = dependencies.fetch(:document_id)
+  end
+
+  def call
+    if document_destroyable?
+      destroy_document
+      [manual, nil]
+    else
+      raise AlreadyPublishedError.new(manual, document)
+    end
+  end
+
+private
+  attr_reader :manual_repository, :document_id, :manual_id
+
+  def document_destroyable?
+    manual.draft? && document.never_published? && document.editions.size == 1
+  end
+
+  def destroy_document
+    manual.remove_document(document)
+    manual_repository.store(manual)
+    document.destroy_latest_edition
+  end
+
+  def document
+    @document ||= manual.documents.find { |d| d.id == document_id }
+  end
+
+  def manual
+    @manual ||= manual_repository.fetch(manual_id)
+  end
+end

--- a/app/services/manual_document_service_registry.rb
+++ b/app/services/manual_document_service_registry.rb
@@ -1,5 +1,6 @@
 require "preview_manual_document_service"
 require "create_manual_document_service"
+require "destroy_manual_document_service"
 require "update_manual_document_service"
 require "show_manual_document_service"
 require "new_manual_document_service"
@@ -19,6 +20,14 @@ class ManualDocumentServiceRegistry
       manual_repository: manual_repository(context),
       listeners: [],
       context: context,
+    )
+  end
+
+  def destroy(context)
+    DestroyManualDocumentService.new(
+      manual_repository: manual_repository(context),
+      manual_id: context.params.fetch("manual_id"),
+      document_id: context.params.fetch("id"),
     )
   end
 
@@ -56,6 +65,9 @@ private
     SpecialistPublisherWiring.get(:manual_document_builder)
   end
 
+  # XXX This is far too tied to a controller context. If it depends on knowing
+  # about an organisation slug, let's pass that in rather than the entire
+  # context.
   def manual_repository(context)
     manual_repository_factory.call(context.current_organisation_slug)
   end

--- a/app/views/manual_documents/show.html.erb
+++ b/app/views/manual_documents/show.html.erb
@@ -17,4 +17,9 @@
 
 <div class="actions">
   <%= link_to("Edit section", edit_manual_document_path(manual, document), class: 'action-link') %>
+  <% if document.never_published? %>
+    <%= form_tag(manual_document_path(manual, document), method: :delete) do %>
+      <button name='submit' class="btn btn-danger">Delete</button>
+    <% end -%>
+  <% end -%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ SpecialistPublisher::Application.routes.draw do
   get "/specialist-documents/(*path)", to: redirect { |params, _| "/cma-cases/#{params[:path]}" }
 
   resources :manuals, except: :destroy do
-    resources :documents, except: :destroy, path: "sections", controller: "ManualDocuments" do
+    resources :documents, path: "sections", controller: "ManualDocuments" do
       resources :attachments, controller: :manual_document_attachments, only: [:new, :create, :edit, :update]
 
       # This is for persisted manual documents

--- a/features/deleting-a-manual-section.feature
+++ b/features/deleting-a-manual-section.feature
@@ -1,0 +1,19 @@
+Feature: Ability to delete a manual section
+  As a developer
+  Because the rails console sucks
+  I want to delete manual sections
+
+  Background:
+    Given I am logged in as a "CMA" editor
+
+  Scenario: Deleting a manual document
+    Given a draft manual exists
+    And a draft document exists for the manual
+    When I delete the document
+    Then the document is deleted
+
+  Scenario: Deleting a published manual document
+    Given a published manual exists
+    When I delete the document
+    Then an error is raised
+    And the document is not deleted

--- a/features/step_definitions/manual_document_steps.rb
+++ b/features/step_definitions/manual_document_steps.rb
@@ -1,0 +1,15 @@
+When(/^I delete the document$/) do
+  pending # express the regexp above with the code you wish you had
+end
+
+Then(/^the document is deleted$/) do
+  pending # express the regexp above with the code you wish you had
+end
+
+Then(/^an error is raised$/) do
+  pending # express the regexp above with the code you wish you had
+end
+
+Then(/^the document is not deleted$/) do
+  pending # express the regexp above with the code you wish you had
+end


### PR DESCRIPTION
Opened for discussion. TODO:
- [ ] Unpendingize cucumber tests (I thought I'd done them. Guess not).

I figure it's worth having the wider discussion about wether we want to do this and what protections we want to add round this before going any further.

Add a delete button which only displays for Manual Documents that have never been published.

This also guards against deletion of published documents, showing a flash message if so. However, the button isn't shown in this case so that error shouldn't be encountered.

This will delete the manual document entirely -- without confirmation at the moment. Attempting to use 'confirm: true' on a button asks for confirmation but doesn't continue if the user chooses OK -- also alerts twice. The rails ujs isn't attaching properly or it'd work.
