### PR TITLE
Remove validation of therapeutic_area from DSU

### DIFF
--- a/app/models/validators/drug_safety_update_validator.rb
+++ b/app/models/validators/drug_safety_update_validator.rb
@@ -7,6 +7,4 @@ class DrugSafetyUpdateValidator < SimpleDelegator
   validates :title, presence: true
   validates :summary, presence: true
   validates :body, presence: true, safe_html: true
-
-  validates :therapeutic_area, presence: true
 end


### PR DESCRIPTION
This field isn't always relevant or available for Drug Safety Update documents.
### TODO
- [x] Holly to confirm whether this validation should be removed
