### PR TITLE
Remove global wiring injection into Cucumber World

### DIFF
--- a/features/step_definitions/case_workflow_steps.rb
+++ b/features/step_definitions/case_workflow_steps.rb
@@ -1,7 +1,5 @@
 Then(/^the CMA case should be in draft$/) do
-  expect(
-    cma_case_repository.all.last
-  ).to be_draft
+  expect(page).to have_content("Publication state draft")
 end
 
 When(/^I publish the CMA case$/) do

--- a/features/step_definitions/drug_safety_update_steps.rb
+++ b/features/step_definitions/drug_safety_update_steps.rb
@@ -92,9 +92,7 @@ Then(/^the Drug Safety Update should have been updated$/) do
 end
 
 Then(/^the Drug Safety Update should be in draft$/) do
-  expect(
-    drug_safety_update_repository.all.last
-  ).to be_draft
+  expect(page).to have_content("Publication state draft")
 end
 
 When(/^I publish the Drug Safety Update$/) do

--- a/features/step_definitions/international_development_fund_steps.rb
+++ b/features/step_definitions/international_development_fund_steps.rb
@@ -77,9 +77,7 @@ Then(/^the International Development Fund should have been updated$/) do
 end
 
 Then(/^the International Development Fund should be in draft$/) do
-  expect(
-    international_development_fund_repository.all.last
-  ).to be_draft
+  expect(page).to have_content("Publication state draft")
 end
 
 When(/^I publish the International Development Fund$/) do

--- a/features/step_definitions/medical_safety_alert_steps.rb
+++ b/features/step_definitions/medical_safety_alert_steps.rb
@@ -93,9 +93,7 @@ Then(/^the Medical Safety Alert should have been updated$/) do
 end
 
 Then(/^the Medical Safety Alert should be in draft$/) do
-  expect(
-    medical_safety_alert_repository.all.last
-  ).to be_draft
+  expect(page).to have_content("Publication state draft")
 end
 
 When(/^I publish the Medical Safety Alert$/) do

--- a/features/step_definitions/report_workflow_steps.rb
+++ b/features/step_definitions/report_workflow_steps.rb
@@ -1,7 +1,5 @@
 Then(/^the AAIB report should be in draft$/) do
-  expect(
-    aaib_report_repository.all.last
-  ).to be_draft
+  expect(page).to have_content("Publication state draft")
 end
 
 When(/^I publish the AAIB report$/) do

--- a/features/step_definitions/republish_documents_steps.rb
+++ b/features/step_definitions/republish_documents_steps.rb
@@ -20,7 +20,7 @@ end
 When(/^I republish published documents$/) do
   repositories_and_listeners = [
     OpenStruct.new(
-      repository: cma_case_repository,
+      repository: SpecialistPublisherWiring.get(:repository_registry).cma_case_repository,
       observers: CmaCaseObserversRegistry.new.republication,
     )
   ]

--- a/features/support/delivery_api_helpers.rb
+++ b/features/support/delivery_api_helpers.rb
@@ -21,7 +21,7 @@ module DeliveryAPIHelpers
   end
 
   def reset_delivery_api_stubs_and_messages
-    RSpec::Mocks.space.proxy_for(delivery_api).reset
+    RSpec::Mocks.space.proxy_for(fake_delivery_api).reset
     stub_delivery_api
   end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -87,12 +87,6 @@ end
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
-module DependencyContainerMethods
-  SpecialistPublisherWiring.inject_into(self)
-end
-
-World(DependencyContainerMethods)
-
 require "panopticon_helpers"
 require "rummager_helpers"
 require "publishing_api_helpers"

--- a/features/support/rerendering_helpers.rb
+++ b/features/support/rerendering_helpers.rb
@@ -4,7 +4,14 @@ module RerenderingHelpers
   end
 
   def check_all_published_documents_have_valid_rendered_specialist_documents
-    published_slugs = cma_case_repository.all.select(&:published?).map(&:slug).sort
+    published_slugs = SpecialistPublisherWiring
+      .get(:repository_registry)
+      .cma_case_repository
+      .all
+      .select(&:published?)
+      .map(&:slug)
+      .sort
+
     rendered_slugs = RenderedSpecialistDocument.all.map(&:slug).sort
 
     expect(published_slugs).to eq(rendered_slugs)


### PR DESCRIPTION
Replace a couple of naughty repository references with explicit calls to the
registry.
