### PR TITLE
Add issued date to Medical Safety Alerts

### DIFF
--- a/app/lib/medical_safety_alert_indexable_formatter.rb
+++ b/app/lib/medical_safety_alert_indexable_formatter.rb
@@ -10,6 +10,7 @@ private
     {
       alert_type: entity.alert_type,
       medical_specialism: entity.medical_specialism,
+      issued_date: entity.issued_date,
     }
   end
 

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -3,6 +3,7 @@ require "document_metadata_decorator"
 class MedicalSafetyAlert < DocumentMetadataDecorator
   set_extra_field_names [
     :alert_type,
+    :issued_date,
     :medical_specialism,
   ]
 end

--- a/app/models/validators/medical_safety_alert_validator.rb
+++ b/app/models/validators/medical_safety_alert_validator.rb
@@ -9,4 +9,5 @@ class MedicalSafetyAlertValidator < SimpleDelegator
   validates :body, presence: true, safe_html: true
 
   validates :alert_type, presence: true
+  validates :issued_date, presence: true, date: true
 end

--- a/app/view_adapters/medical_safety_alert_view_adapter.rb
+++ b/app/view_adapters/medical_safety_alert_view_adapter.rb
@@ -1,7 +1,8 @@
 class MedicalSafetyAlertViewAdapter < DocumentViewAdapter
   attributes = [
     :alert_type,
-    :medical_specialism
+    :medical_specialism,
+    :issued_date,
   ]
 
   attributes.each do |attribute_name|

--- a/app/views/medical_safety_alerts/_form.html.erb
+++ b/app/views/medical_safety_alerts/_form.html.erb
@@ -11,6 +11,7 @@
 
     <%= f.select :alert_type, f.object.facet_options(:alert_type), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select an Alert type'} } %>
     <%= f.select :medical_specialism, f.object.facet_options(:medical_specialism), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select a Medical specialism'} } %>
+    <%= f.text_field :issued_date, placeholder: '2012-04-23' %>
 
     <div class="actions">
       <button name="save" class="btn btn-success">Save as draft</button>

--- a/features/step_definitions/medical_safety_alert_steps.rb
+++ b/features/step_definitions/medical_safety_alert_steps.rb
@@ -1,14 +1,7 @@
 When(/^I create a Medical Safety Alert$/) do
   @slug = "drug-device-alerts/example-medical-safety-alert"
-  @msa_fields = {
-    title: "Example Medical Safety Alert",
-    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
-    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
-    alert_type: ["Drug Alert"],
-  }
-  @msa_metadata_values = {
-    alert_type: ["drugs"],
-  }
+  @msa_fields = msa_fields
+  @msa_metadata_values = msa_metadata_fields
 
   create_medical_safety_alert(@msa_fields)
 end
@@ -30,15 +23,8 @@ end
 
 Given(/^a draft Medical Safety Alert exists$/) do
   @slug = "drug-device-alerts/example-medical-safety-alert"
-  @msa_fields = {
-    title: "Example Medical Safety Alert",
-    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
-    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
-    alert_type: ["Drug Alert"],
-  }
-  @msa_metadata_values = {
-    alert_type: ["drugs"],
-  }
+  @msa_fields = msa_fields
+  @msa_metadata_values = msa_metadata_fields
 
   create_medical_safety_alert(@msa_fields)
 end
@@ -52,27 +38,15 @@ Then(/^the Medical Safety Alert should not have been updated$/) do
 end
 
 Given(/^two Medical Safety Alerts exist$/) do
-  @msa_fields = {
-    title: "Example Medical Safety Alert 1",
-    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
-    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
-    alert_type: ["Drug Alert"],
-  }
-  @msa_metadata_values = {
-    alert_type: ["drugs"],
-  }
+  @msa_fields = msa_fields
+  @msa_metadata_values = msa_metadata_fields
 
   create_medical_safety_alert(@msa_fields)
 
-  @msa_fields = {
+  @msa_fields = msa_fields.merge({
     title: "Example Medical Safety Alert 2",
-    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
-    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
-    alert_type: ["Drug Alert"],
-  }
-  @msa_metadata_values = {
-    alert_type: ["drugs"],
-  }
+  })
+  @msa_metadata_values = msa_metadata_fields
 
   create_medical_safety_alert(@msa_fields)
 end
@@ -80,7 +54,7 @@ end
 Then(/^the Medical Safety Alerts should be in the publisher MSA index in the correct order$/) do
   visit medical_safety_alerts_path
 
-  check_for_documents("Example Medical Safety Alert 1", "Example Medical Safety Alert 2")
+  check_for_documents("Example Medical Safety Alert", "Example Medical Safety Alert 2")
 end
 
 When(/^I edit a Medical Safety Alert$/) do
@@ -107,15 +81,8 @@ end
 
 When(/^I publish a new Medical Safety Alert$/) do
   @slug = "drug-device-alerts/example-medical-safety-alert"
-  @msa_fields = {
-    title: "Example Medical Safety Alert",
-    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
-    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
-    alert_type: ["Drug Alert"],
-  }
-  @msa_metadata_values = {
-    alert_type: ["drugs"],
-  }
+  @msa_fields = msa_fields
+  @msa_metadata_values = msa_metadata_fields
 
   create_medical_safety_alert(@msa_fields, publish: true)
 end
@@ -127,15 +94,8 @@ end
 
 Given(/^a published Medical Safety Alert exists$/) do
   @slug = "drug-device-alerts/example-medical-safety-alert"
-  @msa_fields = {
-    title: "Example Medical Safety Alert",
-    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
-    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
-    alert_type: ["Drug Alert"],
-  }
-  @msa_metadata_values = {
-    alert_type: ["drugs"],
-  }
+  @msa_fields = msa_fields
+  @msa_metadata_values = msa_metadata_fields
 
   create_medical_safety_alert(@msa_fields, publish: true)
 end
@@ -146,4 +106,20 @@ end
 
 Then(/^the Medical Safety Alert should be withdrawn$/) do
   check_document_is_withdrawn(@slug, @msa_fields.fetch(:title))
+end
+
+def msa_fields
+  {
+    title: "Example Medical Safety Alert",
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+    body: "## Header" + ("\n\nPraesent commodo cursus magna, vel scelerisque nisl consectetur et." * 10),
+    alert_type: ["Drug Alert"],
+    issued_date: "2014-01-01",
+  }
+end
+
+def msa_metadata_fields
+  {
+    alert_type: ["drugs"],
+  }
 end

--- a/schemas/medical-safety-alerts.json
+++ b/schemas/medical-safety-alerts.json
@@ -44,6 +44,12 @@
         {"label": "Urology", "value": "urology" },
         {"label": "Vascular and cardiac surgery", "value": "vascular-cardiac-surgery" }
       ]
+    },
+    {
+      "key": "issued_date",
+      "name": "Issued",
+      "type": "date",
+      "preposition": "issued"
     }
   ]
 }


### PR DESCRIPTION
Adds issued date to medical safety alerts as a required fields and exports it to the relevant APIS (Rummager, Content API) in order for it to be displayed on Finder Frontend and Specialist Frontend as metadata

Trello ticket: https://trello.com/c/QFE3nYlc/361-add-issued-date-to-medical-safety-alerts-2
