### PR TITLE
Add script to publish all draft AAIB reports.

### DIFF
--- a/app/services/abstract_document_service_registry.rb
+++ b/app/services/abstract_document_service_registry.rb
@@ -71,6 +71,14 @@ class AbstractDocumentServiceRegistry
     )
   end
 
+  def republish(document_id)
+    PublishDocumentService.new(
+      document_repository,
+      observers.republication,
+      document_id,
+    )
+  end
+
   def withdraw(document_id)
     WithdrawDocumentService.new(
       document_repository,

--- a/bin/publish_aaib_reports
+++ b/bin/publish_aaib_reports
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+# We need the repository separately to grab all the documents
+repository = SpecialistPublisherWiring.get(:repository_registry).aaib_report_repository
+service = SpecialistPublisher.document_services("aaib_report")
+
+$stdout.sync = true
+
+puts "Loading all draft AAIB reports. This could take some time..."
+repository.all.lazy.select(&:draft?).each do |document|
+  print "Publishing draft document #{document.slug}..."
+  $stdout.flush
+  begin
+    service.republish(document.id).call
+    puts "SUCCESS"
+  rescue RuntimeError => e
+    puts "FAILED"
+    puts "  #{e.message}"
+  end
+  $stdout.flush
+end


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/G1SEv3PD/363-script-to-change-the-state-in-preview-for-aaib-reports-from-draft-to-published-1)

This script uses $stdout.flush and $stdout.sync = true liberally in
order to make sure the console output is legible and useful for whoever
in 2nd-line ends up running this script.

It takes around a second a time to run but is idempotent so can be run again and again.
