### PR TITLE
Fix registrations on AAIB reports

### DIFF
--- a/app/models/aaib_report.rb
+++ b/app/models/aaib_report.rb
@@ -8,6 +8,5 @@ class AaibReport < DocumentMetadataDecorator
     :location,
     :aircraft_type,
     :registration,
-    :registration_string,
   ]
 end

--- a/bin/fix_registration_fields
+++ b/bin/fix_registration_fields
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+SpecialistDocumentEdition.where(document_type: "aaib_report").each do |edition|
+  puts "Updating: #{edition.slug}"
+  begin
+    registration_string = edition.extra_fields.delete("registration_string")
+    if edition.extra_fields["registration"].kind_of?(Array) && registration_string
+      edition.extra_fields["registration"] = registration_string
+    else
+      puts "Already converted: #{edition.slug}"
+    end
+    edition.save
+  rescue StandardError => e
+    puts "!!! Failed #{e.message}"
+  end
+end


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/idhIrT04/367-investigate-registration-and-or-registration-string-on-aaib-reports-2)

The import script added both registration (an array) and registration
string (as string) to extra fields. Desired behaviour was to just use
string.
Removed registration array, and renamed registration string to
registration.
