### PR TITLE
Remove `IdGenerator` class and object-constant-based calls of it

### DIFF
--- a/app/lib/id_generator.rb
+++ b/app/lib/id_generator.rb
@@ -1,7 +1,0 @@
-require "securerandom"
-
-class IdGenerator
-  def self.call
-    SecureRandom.uuid
-  end
-end

--- a/app/lib/specialist_publisher_wiring.rb
+++ b/app/lib/specialist_publisher_wiring.rb
@@ -14,7 +14,6 @@ require "footnotes_section_heading_renderer"
 require "gds_api/gov_uk_delivery"
 require "gds_api/rummager"
 require "gds_api_proxy"
-require "id_generator"
 require "manual_database_exporter"
 require "marshallers/document_association_marshaller"
 require "marshallers/manual_publish_task_association_marshaller"
@@ -39,7 +38,6 @@ SpecialistPublisherWiring = DependencyContainer.new do
   define_factory(:manual_builder) {
     ManualBuilder.new(
       slug_generator: SlugGenerator.new(prefix: "guidance"),
-      id_generator: IdGenerator,
       factory: get(:validatable_manual_with_sections_factory),
     )
   }
@@ -93,38 +91,24 @@ SpecialistPublisherWiring = DependencyContainer.new do
   define_singleton(:edition_factory) { SpecialistDocumentEdition.method(:new) }
 
   define_factory(:cma_case_builder) {
-    CmaCaseBuilder.new(
-      get(:validatable_entity_factories).cma_case_factory,
-      IdGenerator,
-    )
+    CmaCaseBuilder.new(get(:validatable_entity_factories).cma_case_factory)
   }
 
   define_factory(:aaib_report_builder) {
-    AaibReportBuilder.new(
-      get(:validatable_entity_factories).aaib_report_factory,
-      IdGenerator,
-    )
+    AaibReportBuilder.new(get(:validatable_entity_factories).aaib_report_factory)
   }
 
   define_factory(:drug_safety_update_builder) {
-    DrugSafetyUpdateBuilder.new(
-      get(:validatable_entity_factories).drug_safety_update_factory,
-      IdGenerator,
-    )
+    DrugSafetyUpdateBuilder.new(get(:validatable_entity_factories).drug_safety_update_factory)
   }
 
   define_factory(:medical_safety_alert_builder) {
-    MedicalSafetyAlertBuilder.new(
-      get(:validatable_entity_factories).medical_safety_alert_factory,
-      IdGenerator,
-    )
+    MedicalSafetyAlertBuilder.new(get(:validatable_entity_factories).medical_safety_alert_factory)
   }
 
   define_factory(:international_development_fund_builder) {
     InternationalDevelopmentFundBuilder.new(
-      get(:validatable_entity_factories).international_development_fund_factory,
-      IdGenerator,
-    )
+      get(:validatable_entity_factories).international_development_fund_factory)
   }
 
   define_factory(:manual_publish_task_builder) {

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -1,7 +1,8 @@
+require "securerandom"
+
 class ManualBuilder
   def initialize(dependencies)
     @slug_generator = dependencies.fetch(:slug_generator)
-    @id_generator = dependencies.fetch(:id_generator)
     @factory = dependencies.fetch(:factory)
   end
 
@@ -13,11 +14,11 @@ class ManualBuilder
 
   private
 
-  attr_reader :slug_generator, :id_generator, :factory, :attrs
+  attr_reader :slug_generator, :factory, :attrs
 
   def defaults
     {
-      id: id,
+      id: SecureRandom.uuid,
       slug: slug,
       summary: "",
       body: "",
@@ -25,10 +26,6 @@ class ManualBuilder
       organisation_slug: "",
       updated_at: "",
     }
-  end
-
-  def id
-    id_generator.call
   end
 
   def slug

--- a/app/models/builders/manual_document_builder.rb
+++ b/app/models/builders/manual_document_builder.rb
@@ -1,16 +1,14 @@
+require "securerandom"
+
 class ManualDocumentBuilder
   def initialize(dependencies)
     @factory_factory = dependencies.fetch(:factory_factory)
-    @id_generator = dependencies.fetch(:id_generator)
   end
 
   def call(manual, attrs)
     document = @factory_factory
       .call(manual)
-      .call(
-        @id_generator.call,
-        [],
-      )
+      .call(SecureRandom.uuid, [])
 
     document.update(attrs.reverse_merge(defaults))
 

--- a/app/models/builders/specialist_document_builder.rb
+++ b/app/models/builders/specialist_document_builder.rb
@@ -1,24 +1,17 @@
+require "securerandom"
+
 class SpecialistDocumentBuilder
-  def initialize(specialist_document_factory, id_generator)
+  def initialize(specialist_document_factory)
     @document_factory = specialist_document_factory
-    @id_generator = id_generator
   end
 
   def call(attrs)
-    document_factory
-      .call(new_document_id, editions)
-      .tap { |d|
-        d.update(attrs)
-      }
+    document_factory.call(SecureRandom.uuid, editions).tap { |d| d.update(attrs) }
   end
 
   private
 
-  attr_reader :document_factory, :id_generator
-
-  def new_document_id
-    id_generator.call
-  end
+  attr_reader :document_factory
 
   def editions
     []

--- a/app/models/validatable_entity_factory_registry.rb
+++ b/app/models/validatable_entity_factory_registry.rb
@@ -9,7 +9,6 @@ require "validators/medical_safety_alert_validator"
 require "validators/null_validator"
 
 # TODO: remove these dependencies
-require "id_generator"
 require "builders/manual_document_builder"
 require "manual_with_documents"
 require "slug_generator"
@@ -75,10 +74,7 @@ class ValidatableEntityFactoryRegistry
   end
 
   def manual_document_builder
-    ManualDocumentBuilder.new(
-      factory_factory: manual_document_factory_factory,
-      id_generator: IdGenerator,
-    )
+    ManualDocumentBuilder.new(factory_factory: manual_document_factory_factory)
   end
 
   def manual_document_factory_factory

--- a/spec/models/builders/specialist_document_builder_spec.rb
+++ b/spec/models/builders/specialist_document_builder_spec.rb
@@ -2,36 +2,17 @@ require "spec_helper"
 
 describe SpecialistDocumentBuilder do
   subject(:builder) {
-    SpecialistDocumentBuilder.new(
-      document_factory,
-      id_generator,
-    )
+    SpecialistDocumentBuilder.new(document_factory)
   }
 
   let(:document_factory)  { double(:document_factory, call: document) }
-  let(:id_generator)      { double(:id_generator, call: document_id) }
-
   let(:document_id)       { double(:document_id) }
   let(:attrs)             { double(:attrs) }
   let(:document)          { double(:document, update: nil) }
 
   describe "#call" do
-    it "generates an id" do
-      builder.call(attrs)
-
-      expect(id_generator).to have_received(:call)
-    end
-
     it "creates a new document" do
-      builder.call(attrs)
-
-      expect(document_factory).to have_received(:call)
-        .with(document_id, [])
-    end
-
-    it "updates the document with the attributes" do
-      builder.call(attrs)
-
+      expect(builder.call(attrs)).to eq(document)
       expect(document).to have_received(:update).with(attrs)
     end
   end


### PR DESCRIPTION
**Note:** This is a speculative PR.

The `IdGenerator` object did very little. It can be summed up as the
following bit of code: `SecureRandom.uuid`. Keeping it around doesn't
add anything and it makes it hard to understand why the constant form
of the object is being called in the way it does.

Removing it means there's one less thing to understand in terms of
using the already existing `*Builder` classes.
