### PR TITLE
Wrap Finder formats in a Dropdown if GDS Editor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,45 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  def current_finder
+    finders.fetch(request.path.split("/")[1], nil)
+  end
+  helper_method :current_finder
+
+  def finders
+    {
+      "aaib-reports" => {
+        document_type: "aaib_report",
+        title: "AAIB Reports",
+      },
+      "cma-cases" => {
+        document_type: "cma_case",
+        title: "CMA Cases",
+      },
+      "international-development-funds" => {
+        document_type: "international_development_fund",
+        title: "International Development Funds",
+      },
+      "drug-safety-update" => {
+        document_type: "drug_safety_update",
+        title: "Drug Safety Update",
+      },
+      "medical-safety-alert" => {
+        document_type: "medical_safety_alert" ,
+        title: "Medical Safety Alerts",
+      },
+      "maib-reports" => {
+        document_type: "maib_report",
+        title: "MAIB Reports",
+      },
+      "raib-reports" => {
+        document_type: "raib_report",
+        title: "RAIB Reports",
+      },
+    }
+  end
+  helper_method :finders
+
   def url_maker
     UrlMaker.new
   end
@@ -31,6 +70,11 @@ class ApplicationController < ActionController::Base
     permission_checker.can_withdraw?(format)
   end
   helper_method :current_user_can_withdraw?
+
+  def current_user_is_gds_editor?
+    permission_checker.is_gds_editor?
+  end
+  helper_method :current_user_is_gds_editor?
 
   def current_organisation_slug
     current_user.organisation_slug

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -18,12 +18,12 @@ class PermissionChecker
     can_publish?(format)
   end
 
-private
-  attr_reader :user
-
   def is_gds_editor?
     user.has_permission?(GDS_EDITOR_PERMISSION)
   end
+
+private
+  attr_reader :user
 
   def is_editor?
     user.has_permission?(EDITOR_PERMISSION)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,27 +8,30 @@
 
 <% content_for :navbar_items do %>
   <li><%= nav_link_to 'Manuals', '/manuals' %></li>
-  <% if current_user_can_edit?("aaib_report") %>
-    <li><%= nav_link_to 'AAIB Reports', '/aaib-reports' %></li>
-  <% end -%>
-  <% if current_user_can_edit?("cma_case") %>
-    <li><%= nav_link_to 'CMA Cases', '/cma-cases' %></li>
-  <% end -%>
-  <% if current_user_can_edit?("international_development_fund") %>
-    <li><%= nav_link_to 'International Development Funds', '/international-development-funds' %></li>
-  <% end -%>
-  <% if current_user_can_edit?("drug_safety_update") %>
-    <li><%= nav_link_to 'Drug Safety Update', '/drug-safety-updates' %></li>
-  <% end -%>
-  <% if current_user_can_edit?("medical_safety_alert") %>
-    <li><%= nav_link_to 'Medical Safety Alerts', '/medical-safety-alerts' %></li>
-  <% end -%>
-  <% if current_user_can_edit?("maib_report") %>
-    <li><%= nav_link_to 'MAIB Reports', '/maib-reports' %></li>
-  <% end -%>
-  <% if current_user_can_edit?("raib_report") %>
-    <li><%= nav_link_to 'RAIB Reports', '/raib-reports' %></li>
-  <% end -%>
+
+  <% if current_user_is_gds_editor? %>
+    <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+        <% if current_finder %>
+          <%= current_finder[:title] %>
+        <% else %>
+          Finders
+        <% end %>
+        <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu" role="menu">
+  <% end %>
+
+  <% finders.each do |key, value| %>
+    <% if current_user_can_edit?(value[:document_type]) %>
+      <li><%= nav_link_to value[:title], "/#{key}" %></li>
+    <% end %>
+  <% end %>
+
+  <% if current_user_is_gds_editor? %>
+      </ul>
+    </li>
+  <% end %>
 <% end %>
 
 <% content_for :navbar_right do %>


### PR DESCRIPTION
As GDS Editors, the amount of Finders was breaking the header navigation. Now, we wrap the Finders in dropdown tags if the user is from GDS. We also display the name of the current finder in the dropdown
if one is selected.

Also, adding a new route and permission check in the view requires adding a new item in the hash in the application controller.

![screen shot 2014-10-29 at 17 43 12 1](https://cloud.githubusercontent.com/assets/449004/4831245/190cd040-5f93-11e4-9146-cebcdae17104.png)
