### PR TITLE
Add importer and auto-publisher: medical alerts

### DIFF
--- a/app/importers/medical_safety_alert_import.rb
+++ b/app/importers/medical_safety_alert_import.rb
@@ -1,0 +1,96 @@
+require "medical_safety_alert_import/mapper"
+require "medical_safety_alert_import/attachment_mapper"
+
+module MedicalSafetyAlertImport
+  def self.call(data_files_dir, attachments_dir)
+    DependencyContainer.new(
+      data_files_dir,
+      attachments_dir,
+    )
+    .get_instance
+    .call
+  end
+
+  class DependencyContainer
+    def initialize(data_files_dir, attachments_dir)
+      @data_files_dir = data_files_dir
+      @attachments_dir = attachments_dir
+    end
+
+    def get_instance
+      DocumentImport::BulkImporter.new(
+        import_job_builder: import_job_builder,
+        data_enum: data_enum,
+      )
+    end
+
+    private
+
+    def import_job_builder
+      ->(data) {
+        DocumentImport::SingleImport.new(
+          document_creator: document_creator,
+          logger: DocumentImport::Logger.new(STDOUT),
+          data: data,
+        )
+      }
+    end
+
+    def data_enum
+      data_files.lazy.map(&method(:parse_json_file))
+    end
+
+    def data_files
+      Dir.glob(File.join(@data_files_dir, "*.json"))
+    end
+
+    def parse_json_file(filename)
+      JSON.parse(File.read(filename)).merge ({
+        "import_source" => File.basename(filename),
+      })
+    end
+
+    def document_creator
+      AttachmentMapper.new(
+        import_mapper,
+        repo,
+        @attachments_dir,
+      )
+    end
+
+    def import_mapper
+      Mapper.new(
+        ->(attrs) {
+          CreateDocumentService.new(
+            report_builder,
+            repo,
+            MedicalSafetyAlertObserversRegistry.new.creation,
+            attrs,
+          ).call
+        },
+        repo,
+      )
+    end
+
+    def report_builder
+      SpecialistDocumentBuilder.new("medical_safety_alert",
+        ->(*args) {
+          null_validator(
+            SpecialistPublisherWiring
+            .get(:validatable_document_factories)
+            .medical_safety_alert_factory
+            .call(*args)
+          )
+        }
+      )
+    end
+
+    def repo
+      SpecialistPublisherWiring.get(:repository_registry).for_type("medical_safety_alert")
+    end
+
+    def null_validator(thing)
+      NullValidator.new(thing)
+    end
+  end
+end

--- a/app/importers/medical_safety_alert_import/attachment_mapper.rb
+++ b/app/importers/medical_safety_alert_import/attachment_mapper.rb
@@ -1,0 +1,55 @@
+require "validators/attachment_snippet_in_body_validator"
+require "document_import/attachment_helpers"
+
+module MedicalSafetyAlertImport
+  class AttachmentMapper
+    include ::DocumentImport::AttachmentHelpers
+
+    def initialize(import_mapper, repo, base_path = ".")
+      @import_mapper = import_mapper
+      @repo = repo
+      @base_path = base_path
+    end
+
+    def call(data)
+      document = import_mapper.call(data)
+
+      if document.valid?
+        data["_assets"].each do |asset_data|
+          attach_asset(document, asset_data, data)
+        end
+
+        repo.store(document)
+      end
+
+      document
+    end
+
+  private
+    attr_reader :import_mapper, :repo, :base_path
+
+    def attach_asset(document, asset_data, data)
+      attachment = add_attachment(
+        document,
+        attachable_file_attributes(base_path, asset_data),
+      )
+
+      replace_link_with_snippet(document, asset_data, attachment)
+    end
+
+    def imported_document(data)
+      AttachmentSnippetInBodyValidator.new(
+        import_mapper.call(data)
+      )
+    end
+
+    def add_attachment(document, asset_data)
+      document.add_attachment(asset_data)
+    end
+
+    def replace_link_with_snippet(document, asset, attachment)
+      search = "[ASSET_TAG](#ASSET#{asset.fetch("assetid")})"
+      replace_in_body(document, search, attachment.snippet)
+    end
+  end
+end

--- a/app/importers/medical_safety_alert_import/mapper.rb
+++ b/app/importers/medical_safety_alert_import/mapper.rb
@@ -1,0 +1,40 @@
+module MedicalSafetyAlertImport
+  class Mapper
+    def initialize(document_creator, repo)
+      @document_creator = document_creator
+      @repo = repo
+    end
+
+    def call(raw_data)
+      document = document_creator.call(desired_attributes(raw_data))
+      document
+    end
+
+  private
+    attr_reader :document_creator, :repo
+
+    def desired_attributes(data)
+      massage(data)
+        .slice(*desired_keys)
+        .symbolize_keys
+    end
+
+    def massage(data)
+      data.merge({
+        "title" => data["title"],
+        "assets" => [],
+        "body" => data["body"],
+      })
+    end
+
+    def desired_keys
+      %w(
+        body
+        title
+        alert_type
+        medical_specialism
+        issued_date
+      )
+    end
+  end
+end

--- a/bin/import_medical_safety_alerts
+++ b/bin/import_medical_safety_alerts
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "medical_safety_alert_import"
+
+data_files_dir = ARGV.fetch(0)
+attachments_dir = ARGV.fetch(1)
+
+# Override the timeout value for the Panopticon API during a data import.
+PANOPTICON_API_CREDENTIALS.merge!(timeout: 30)
+
+MedicalSafetyAlertImport.call(data_files_dir, attachments_dir)

--- a/bin/publish_medical_safety_alerts
+++ b/bin/publish_medical_safety_alerts
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "specialist_publisher"
+
+# Override global panopticon timeout as this is a long operation...
+PANOPTICON_API_CREDENTIALS.merge!(timeout: 30)
+
+# We need the repository separately to grab all the documents
+repository = SpecialistPublisherWiring.get(:repository_registry).for_type("medical_safety_alert")
+service = SpecialistPublisher.document_services("medical_safety_alert")
+
+$stdout.sync = true
+
+puts "Loading all draft medical safety alerts. This could take some time..."
+repository.all.lazy.select(&:draft?).each do |document|
+  print "Publishing draft document #{document.slug}..."
+  $stdout.flush
+  begin
+    service.republish(document.id).call
+    puts "SUCCESS"
+  rescue GdsApi::HTTPErrorResponse => e
+    puts "API_ERROR"
+    puts "  #{e.message}"
+  rescue StandardError => e
+    puts "FAILED"
+    puts "  #{e.message}"
+  end
+  $stdout.flush
+end


### PR DESCRIPTION
(cc @kalleth)

Again, to get things working on our VM, we also needed in `/app/importers/drug_safety_update_import.rb`:

``` ruby
require "document_import"
require_relative "../models/builders/specialist_document_builder"
```

and in `app/lib/specialist_publisher_wiring.rb`:

``` ruby
require_relative "../models/builders/specialist_document_builder"
```

Don't think these changes are needed on the live system, but tell me if I need to make them.
