### PR TITLE
Hack around kaminari's inability to handle generic controllers.

### DIFF
--- a/app/views/specialist_documents/index.html.erb
+++ b/app/views/specialist_documents/index.html.erb
@@ -24,6 +24,6 @@
         </li>
       <% end %>
     </ul>
-    <%= paginate documents %>
+    <%= paginate documents, params: { document_type: document_type } %>
   </div>
 </div>

--- a/config/initializers/kaminari_overrides.rb
+++ b/config/initializers/kaminari_overrides.rb
@@ -1,0 +1,14 @@
+module Kaminari
+  module Helpers
+    class Tag
+      def page_url_for(page)
+        doc_type = @params[:document_type]
+        other_params = @params.except(:document_type).merge(@param_name => (page <= 1 ? nil : page), :only_path => true)
+
+        route_helper = "#{doc_type.pluralize}_path"
+
+        @template.send(route_helper, other_params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a TEMPORARY fix to allow pagination to work until we fix pagination properly.

Kaminari, internally, uses url_for(controller:, action:) to generate routes. See
https://github.com/amatsuda/kaminari/blob/adca9b25b4d3fefcb12552e939d7262eb86a3ec0/lib/kaminari/helpers/tags.rb#L30

In specialist-publisher, we have a route for each report (aaib_reports_path) which all use the same controller and action. When Kaminari calls `url_for(controller: "abstract_documents", action: "index")`, the first matching
result in routes.rb is returned, which is AAIB reports. So the CMA cases pagination links are linking to /aaib-reports?page=2.

Override how page_url_for(page) works in specialist-publisher to instead take an extra parameter of document_type and call the correct routing helper using send. Ugh.

Better fixes for this are probably:
1. Switch pagination libraries to something which allows explicit path overriding.
2. Use wrapper controllers -- one for each format -- which inherit from `AbstractDocumentsController`
3. Make a pull request to kaminari to fix this.
4. Disable pagination.
