### PR TITLE
Add a controller for each document type

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,22 @@ $ bundle exec rake
 ## Adding a new specialist document format
 
 1. Add the document_type to the `document_types` array in `config/routes.rb`
-2. Add the schema to the `schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
-3. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.
-4. Define the factory with the builder in `app/lib/specialist_publisher_wiring.rb`.
-5. Define the entity factory in the ` app/models/entity_factory_registry.rb` and the validatable entity validator in `app/models/validatable_entity_factory_registry.rb`.
-6. Add a service registry for the format in `app/services` along with one for it's attachments. These are subclasses of `AbstractDocumentServiceRegistry` and `AbstractAttachmentServiceRegistry` respectively.
-7. Define a repository in `app/repositories/repository_registry.rb`
-8. Add observers, along with formatters required:
+2. Add a controller that inherits `AbstractDocumentController`
+3. Add the schema to the `schemas` folder and define the singleton for it in `app/lib/specialist_publisher_wiring.rb`
+4. Add a model (which is a subclass of `DocumentMetadataDecorator` and only defines the extra fields of the document type), validator and builder for the new format.
+5. Define the factory with the builder in `app/lib/specialist_publisher_wiring.rb`.
+6. Define the entity factory in the ` app/models/entity_factory_registry.rb` and the validatable entity validator in `app/models/validatable_entity_factory_registry.rb`.
+7. Add a service registry for the format in `app/services` along with one for it's attachments. These are subclasses of `AbstractDocumentServiceRegistry` and `AbstractAttachmentServiceRegistry` respectively.
+8. Define a repository in `app/repositories/repository_registry.rb`
+9. Add observers, along with formatters required:
   - `document_type_publication_alert_formatter.rb` in `app/exporters/formatters/`
   - `document_type_artefact_formatter.rb` in `app/lib/` for Panopticon
   - `document_type_indexable_formatter.rb` app/lib/` for Rummager
   - define a factory for `document_type_panopticon_registerer`, `document_type_rummager_indexer`, `document_type_rummager_deleter` and `document_type_content_api_exporter` in `app/lib/specialist_publisher_wiring.rb`
   - add an Observers registry for the docuemt type and add it to the has in the `observers_registry` method in `app/lib/specialist_publisher`
-7. Add `app/view_adapters/document_type_view_adapter.rb` along with it's entry in `app/view_adapters/view_adapter_registry.rb`. Also add the `_form.html.erb` which has the extra fields for that document_type. Be sure to pass the correct `form_namespace` matching the document_type.
-8. Add the entry to `app/lib/permission_checker.rb` for the owning organisation and a link in `app/views/layouts/application.html.erb` to the document index
-9. That's it!
+10. Add `app/view_adapters/document_type_view_adapter.rb` along with it's entry in `app/view_adapters/view_adapter_registry.rb`. Also add the `_form.html.erb` which has the extra fields for that document_type. Be sure to pass the correct `form_namespace` matching the document_type.
+11. Add the entry to `app/lib/permission_checker.rb` for the owning organisation and a link in `app/views/layouts/application.html.erb` to the document index
+12. That's it!
 
 ### Testing your new specialist document format
 

--- a/app/controllers/aaib_reports_controller.rb
+++ b/app/controllers/aaib_reports_controller.rb
@@ -1,0 +1,2 @@
+class AaibReportsController < AbstractDocumentsController
+end

--- a/app/controllers/cma_cases_controller.rb
+++ b/app/controllers/cma_cases_controller.rb
@@ -1,0 +1,2 @@
+class CmaCasesController < AbstractDocumentsController
+end

--- a/app/controllers/drug_safety_updates_controller.rb
+++ b/app/controllers/drug_safety_updates_controller.rb
@@ -1,0 +1,2 @@
+class DrugSafetyUpdatesController < AbstractDocumentsController
+end

--- a/app/controllers/international_development_funds_controller.rb
+++ b/app/controllers/international_development_funds_controller.rb
@@ -1,0 +1,2 @@
+class InternationalDevelopmentFundsController < AbstractDocumentsController
+end

--- a/app/controllers/maib_reports_controller.rb
+++ b/app/controllers/maib_reports_controller.rb
@@ -1,0 +1,2 @@
+class MaibReportsController < AbstractDocumentsController
+end

--- a/app/controllers/medical_safety_alerts_controller.rb
+++ b/app/controllers/medical_safety_alerts_controller.rb
@@ -1,0 +1,2 @@
+class MedicalSafetyAlertsController < AbstractDocumentsController
+end

--- a/app/controllers/raib_reports_controller.rb
+++ b/app/controllers/raib_reports_controller.rb
@@ -1,0 +1,2 @@
+class RaibReportsController < AbstractDocumentsController
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ SpecialistPublisher::Application.routes.draw do
   document_types.each do |type|
     type_slug = type.to_s.gsub("_", "-")
 
-    resources type.to_sym, controller: "abstract_documents", except: :destroy, path: type_slug do
+    resources type.to_sym, controller: type, except: :destroy, path: type_slug do
       resources :attachments, only: [:new, :create, :edit, :update]
       post :withdraw, on: :member
       post :publish, on: :member


### PR DESCRIPTION
Kaminari, internally, uses url_for(controller:, action:) to generate
routes. See
https://github.com/amatsuda/kaminari/blob/adca9b25b4d3fefcb12552e939d726
2eb86a3ec0/lib/kaminari/helpers/tags.rb#L30

In specialist-publisher, we had a route for each report
(aaib_reports_path) which all use the same controller and action. When
Kaminari calls url_for(controller: "abstract_documents", action:
"index"), the first matching
result in routes.rb is returned, which is AAIB reports. So the CMA
cases pagination links were linking to /aaib-reports?page=2.

To fix this, we have created a controller for each document type that
simply inherits from AbsctractDocumentController. While creating
additional code, this brings us closer to standard rails routing. We
have decided to prefer this to potentially confusing hacks around this
problem.
