### PR TITLE
Inject document type not a pre-scoped model to repositories.

### DIFF
--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -21,49 +21,49 @@ class RepositoryRegistry
 
   def aaib_report_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("aaib_report"),
+      document_type: "aaib_report",
       document_factory: entity_factories.aaib_report_factory,
     )
   end
 
   def cma_case_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("cma_case"),
+      document_type: "cma_case",
       document_factory: entity_factories.cma_case_factory,
     )
   end
 
   def drug_safety_update_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("drug_safety_update"),
+      document_type: "drug_safety_update",
       document_factory: entity_factories.drug_safety_update_factory,
     )
   end
 
   def maib_report_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("maib_report"),
+      document_type: "maib_report",
       document_factory: entity_factories.maib_report_factory,
     )
   end
 
   def medical_safety_alert_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("medical_safety_alert"),
+      document_type: "medical_safety_alert",
       document_factory: entity_factories.medical_safety_alert_factory,
     )
   end
 
   def international_development_fund_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("international_development_fund"),
+      document_type: "international_development_fund",
       document_factory: entity_factories.international_development_fund_factory,
     )
   end
 
   def raib_report_repository
     SpecialistDocumentRepository.new(
-      specialist_document_editions: scoped_editions("raib_report"),
+      document_type: "raib_report",
       document_factory: entity_factories.raib_report_factory,
     )
   end
@@ -107,17 +107,12 @@ class RepositoryRegistry
       document_factory = entity_factories.manual_document_factory_factory.call(manual)
 
       SpecialistDocumentRepository.new(
-        specialist_document_editions: scoped_editions("manual"),
+        document_type: "manual",
         document_factory: document_factory,
       )
     }
   end
 
 private
-
   attr_reader :entity_factories
-
-  def scoped_editions(document_type)
-    SpecialistDocumentEdition.where(document_type: document_type)
-  end
 end

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -12,7 +12,7 @@ class SpecialistDocumentRepository
   end
 
   def initialize(dependencies)
-    @specialist_document_editions = dependencies.fetch(:specialist_document_editions)
+    @document_type = dependencies.fetch(:document_type)
     @document_factory = dependencies.fetch(:document_factory)
   end
 
@@ -81,7 +81,7 @@ class SpecialistDocumentRepository
 
 private
   attr_reader(
-    :specialist_document_editions,
+    :document_type,
     :document_factory,
   )
 
@@ -106,5 +106,9 @@ private
       specialist_document_editions
         .all
     )
+  end
+
+  def specialist_document_editions
+    SpecialistDocumentEdition.where(document_type: document_type)
   end
 end

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -4,7 +4,7 @@ describe SpecialistDocumentRepository do
 
   let(:specialist_document_repository) do
     SpecialistDocumentRepository.new(
-      specialist_document_editions: SpecialistDocumentEdition,
+      document_type: document_type,
       document_factory: document_factory,
     )
   end
@@ -12,6 +12,7 @@ describe SpecialistDocumentRepository do
   let(:document_factory) { double(:document_factory, call: document) }
 
   let(:document_id) { "document-id" }
+  let(:document_type) { "generic_document"}
 
   let(:document) {
     SpecialistDocument.new(slug_generator, edition_factory, document_id, editions)
@@ -71,6 +72,7 @@ describe SpecialistDocumentRepository do
 
         edition = FactoryGirl.create(:specialist_document_edition,
                             document_id: document_id,
+                            document_type: document_type,
                             updated_at: n.days.ago)
 
         allow(document_factory).to receive(:call)
@@ -95,7 +97,6 @@ describe SpecialistDocumentRepository do
     before do
       allow(SpecialistDocument).to receive(:new).and_return(document)
       allow(SpecialistDocumentEdition).to receive(:where)
-        .with(document_id: document_id)
         .and_return(editions_proxy)
     end
 


### PR DESCRIPTION
In each case in the `RepositoryRegistry`, `specialist_document_editions` was just a pre-scoped `SpecialistDocumentEdition` by document type.

I have refactored this scoping to happen within the Repository, as every place that a repository was being used was being scoped by document type, and there is no scenario we have encountered where this is not the case.

Further, part of the point of using the repository pattern is to concrete all datastore access/operations inside the repository, so having this occur outside the repository smelled a little to me.

This will provide further benefits when we introduce a Single Source of Truth to list the available document types, making it much easier for us to use that Single Source of Truth in future to simplify repository (and builder, and etc) access.
