### PR TITLE
Correct naming: remove the word "reports"

### DIFF
--- a/bin/publish_dsu_reports
+++ b/bin/publish_dsu_reports
@@ -12,7 +12,7 @@ service = SpecialistPublisher.document_services("drug_safety_update")
 
 $stdout.sync = true
 
-puts "Loading all draft DSU reports. This could take some time..."
+puts "Loading all draft drug safety updates. This could take some time..."
 repository.all.lazy.select(&:draft?).each do |document|
   print "Publishing draft document #{document.slug}..."
   $stdout.flush


### PR DESCRIPTION
We're not referring to drug safety updates as reports elsewhere.

Also, "Loading all draft DSU reports" reads as:
"Loading all draft drug safety update reports"

A little clunky.
