### PR TITLE
DRY up exporters and formatters in Observers

### DIFF
--- a/app/observers/aaib_report_observers_registry.rb
+++ b/app/observers/aaib_report_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: AaibReportPublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    AaibReportPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end

--- a/app/observers/abstract_specialist_document_observers_registry.rb
+++ b/app/observers/abstract_specialist_document_observers_registry.rb
@@ -60,6 +60,15 @@ private
   end
 
   def publication_alert_exporter
+    ->(document) {
+      EmailAlertExporter.new(
+        delivery_api: delivery_api,
+        formatter: publication_alert_formatter(document),
+      ).call
+    }
+  end
+
+  def publication_alert_formatter
     raise NotImplementedError
   end
 

--- a/app/observers/cma_case_observers_registry.rb
+++ b/app/observers/cma_case_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: CmaCasePublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    CmaCasePublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end

--- a/app/observers/drug_safety_update_observers_registry.rb
+++ b/app/observers/drug_safety_update_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: DrugSafetyUpdatePublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    DrugSafetyUpdatePublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end

--- a/app/observers/international_development_fund_observers_registry.rb
+++ b/app/observers/international_development_fund_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: InternationalDevelopmentFundPublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    InternationalDevelopmentFundPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end

--- a/app/observers/medical_safety_alert_observers_registry.rb
+++ b/app/observers/medical_safety_alert_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: MedicalSafetyAlertPublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    MedicalSafetyAlertPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end


### PR DESCRIPTION
Refactor to remove duplication of EmailAlertExporter setup for each observer registry. This means the observer registries now only require to set up a specific formatter and use a common EmailAlertExporter.
