### PR TITLE
DRY up Observer registries for remaining formats

### DIFF
--- a/app/observers/maib_report_observers_registry.rb
+++ b/app/observers/maib_report_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: MaibReportPublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    MaibReportPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end

--- a/app/observers/raib_report_observers_registry.rb
+++ b/app/observers/raib_report_observers_registry.rb
@@ -24,15 +24,10 @@ private
     SpecialistPublisherWiring.get(:specialist_document_content_api_withdrawer)
   end
 
-  def publication_alert_exporter
-    ->(document) {
-      EmailAlertExporter.new(
-        delivery_api: delivery_api,
-        formatter: RaibReportPublicationAlertFormatter.new(
-          url_maker: url_maker,
-          document: document,
-        ),
-      ).call
-    }
+  def publication_alert_formatter(document)
+    RaibReportPublicationAlertFormatter.new(
+      url_maker: url_maker,
+      document: document,
+    )
   end
 end


### PR DESCRIPTION
These were missing from the previous pull request to DRY up the observer registries found here:
https://github.com/alphagov/specialist-publisher/pull/314
