### PR TITLE
Update phantomjs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test do
   gem "factory_girl", "4.3.0"
   gem "database_cleaner", "1.2.0"
   gem "poltergeist", "1.5.0"
+  gem "phantomjs", ">= 1.9.7.1"
   gem "webmock", "~> 1.17.4"
   gem "rspec", "3.0.0"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     parser (2.1.9)
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
-    phantomjs (1.9.7.0)
+    phantomjs (1.9.7.1)
     plek (1.7.0)
     poltergeist (1.5.0)
       capybara (~> 2.1)
@@ -373,6 +373,7 @@ DEPENDENCIES
   mongoid (= 2.5.2)
   mongoid_rails_migrations (= 1.0.0)
   multi_json (= 1.10.0)
+  phantomjs (>= 1.9.7.1)
   plek (= 1.7.0)
   poltergeist (= 1.5.0)
   pry


### PR DESCRIPTION
On mavericks the phantomjs gem cannot find new
versions of homebrew installed phantomjs binaries.
Later versions of the phantomjs gem install their own into
/Users/:user/.phantomjs.

This will fix this error
"Phantomjs does not appear to be installed in
/Users/:user/.phantomjs/1.9.7/darwin/bin/phantomjs, installing!"
