### PR TITLE
Import documents based on sorted filename

### DIFF
--- a/app/importers/drug_safety_update_import.rb
+++ b/app/importers/drug_safety_update_import.rb
@@ -41,7 +41,7 @@ module DrugSafetyUpdateImport
     end
 
     def data_files
-      Dir.glob(File.join(@data_files_dir, "*.json"))
+      Dir.glob(File.join(@data_files_dir, "*.json")).sort
     end
 
     def parse_json_file(filename)

--- a/app/importers/medical_safety_alert_import.rb
+++ b/app/importers/medical_safety_alert_import.rb
@@ -41,7 +41,7 @@ module MedicalSafetyAlertImport
     end
 
     def data_files
-      Dir.glob(File.join(@data_files_dir, "*.json"))
+      Dir.glob(File.join(@data_files_dir, "*.json")).sort
     end
 
     def parse_json_file(filename)

--- a/app/importers/raib_import.rb
+++ b/app/importers/raib_import.rb
@@ -41,7 +41,7 @@ module RaibImport
     end
 
     def data_files
-      Dir.glob(File.join(@data_files_dir, "*.json"))
+      Dir.glob(File.join(@data_files_dir, "*.json")).sort
     end
 
     def parse_json_file(filename)


### PR DESCRIPTION
Currently, documents are imported in filesystem order: which isn't
likely to have a particularly useful order. There are parallel
changes to the scrapers to prefix all JSON filenames with ISO8601
dates [YYYY-MM-DD] which is sort-safe.
