### PR TITLE
Limit sidekiq workers to 2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rails s -p 3064
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,1 @@
+:concurrency:  2


### PR DESCRIPTION
If not overridden, sidekiq starts with 25 workers by default. This can
cause problems if too many workers try to connect to the database at the same time,
etc.

This change reduces this number to a more reasonable number (2).
