### PR TITLE
dasherize format in tags hash

### DIFF
--- a/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
+++ b/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
@@ -13,7 +13,7 @@ class AbstractDocumentPublicationAlertFormatter
 
   def tags
     arrayified_extra_fields.merge(
-      format: [document.document_type]
+      format: [document.document_type.dasherize]
     )
   end
 


### PR DESCRIPTION
Subscriber lists are stored in email-alert-api (set by the finder-api
rake task) dasherized, whereas specialist publisher submit the
notifications with the format underscored.

This fixes that.
