### PR TITLE
Sort AAIB reports by Date of Occurrence before publishing

### DIFF
--- a/bin/publish_aaib_reports
+++ b/bin/publish_aaib_reports
@@ -13,7 +13,7 @@ service = SpecialistPublisher.document_services("aaib_report")
 $stdout.sync = true
 
 puts "Loading all draft AAIB reports. This could take some time..."
-repository.all.lazy.select(&:draft?).each do |document|
+repository.all.sort { |a, b| a.extra_fields[:date_of_occurrence] <=> b.extra_fields[:date_of_occurrence] }.lazy.select(&:draft?).each do |document|
   print "Publishing draft document #{document.slug}..."
   $stdout.flush
   begin


### PR DESCRIPTION
The initial import imported all of these documents in a pseudo-random
order, meaning that there was no meaningful logic to it when we sorted
them by `updated_at`.

This makes sure that we publish them in the correct order, which
resolves this problem.
