### PR TITLE
Remove finder name from email subject

### DIFF
--- a/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
+++ b/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
@@ -18,7 +18,7 @@ class AbstractDocumentPublicationAlertFormatter
   end
 
   def subject
-    "#{name}: #{document.title}"
+    document.title
   end
 
   def body

--- a/spec/exporters/formatters/abstract_document_publication_alert_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_document_publication_alert_formatter_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe AbstractDocumentPublicationAlertFormatter do
   end
 
   it "has a subject containing the document title" do
-    expect(formatter.subject).to include("Specialist Documents")
-    expect(formatter.subject).to include("Some title")
+    expect(formatter.subject).to eq("Some title")
   end
 
   it "has a body containing the document title, url, and summary" do


### PR DESCRIPTION
As requested by Holly.
