### PR TITLE
Update call to render to new syntax

### DIFF
--- a/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
+++ b/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
@@ -23,7 +23,8 @@ class AbstractDocumentPublicationAlertFormatter
 
   def body
     view_renderer.render(
-      template: "email_alerts/publication.html",
+      template: "email_alerts/publication",
+      formats: ["html"],
       locals: {
         human_document_type: name,
         document_noun: document_noun,


### PR DESCRIPTION
This deprecation warning was turning up about 100 times during the
cucumber tests.

`DEPRECATION WARNING: Passing the format in the template name is
deprecated. Please pass render with :formats => [:html] instead.
(called from body at
/var/govuk/specialist-publisher/app/exporters/formatters/abstract_docume
nt_publication_alert_formatter.rb:25)`

So I did what it said.
