### PR TITLE
Pass updated_at through to new edition

### DIFF
--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -186,7 +186,7 @@ protected
 
   def previous_edition_attributes
     latest_edition.attributes
-      .except("_id", "updated_at")
+      .except("_id")
       .symbolize_keys
   end
 


### PR DESCRIPTION
Bug: If you edit a specialist document with a validation error, the
form re-renders, but displays a new_document_form rather than an edit
one. This means if you fix your validation error and submit, you end up
creating a new document by mistake.

I discovered that this was due to form_for’s reliance on the
`persisted?` method on a model, which is defined for specialist
documents in the DocumentViewAdapter class (I haven’t completely got my
head around why). This uses the `updated_at` method to decide if the
model is persisted.

The update is done (after a few hoops) on the SpecialistDocument
model, by copying across all of the attributes, but currently strips
out `updated_at`. This results in it being nil, which results in
`persisted?` being false, which results in form_for thinking the model
has not been saved.

This fixes that.

Problems I have with this commit:
- There are no additional tests for it. The cucumber tests didn’t pick
  this up (they should have) because each step starts by specifying the
  URL to visit, meaning it reloads the correct URL, rather than
  maintaining the state, like a user would. I believe this is done due to
  the attempts to abstract out the ‘cucumberness’ of them. Ideally this
  would be refactored so this doesn’t happen, but I have other bugs to
  get onto right now.
- I don’t know what the reasoning was for stripping out `updated_at`
  between updates. I believe it should be overwritten by the persistence
  step (by Mongoid?), so it _shouldn’t_ be a problem. All of the tests
  still pass, so it must be fine, right? :-/

Comments and discussion (over a 1 line commit) welcome.
