### PR TITLE
Hide attachments list on update action of document

### DIFF
--- a/app/views/specialist_documents/_attachments_form.html.erb
+++ b/app/views/specialist_documents/_attachments_form.html.erb
@@ -1,21 +1,23 @@
 <div class="col-md-4">
   <%= render partial: 'shared/govspeak-help' %>
 
-  <h2>Attachments</h2>
+  <% if action_name != 'update' %>
+    <h2>Attachments</h2>
 
-  <% if document.persisted? %>
-    <%= link_to "Add attachment", new_specialist_document_attachment_path(document) %>
-  <% else %>
-    <p>To add an attachment, please save the draft first.</p>
-  <% end %>
-
-  <ul class="attachments">
-    <% document.attachments.each do |attachment| %>
-      <li class="attachment">
-        <span class="title"><%= attachment.title %></span>
-        <span class="snippet"><%= attachment.snippet %></span>
-        <%= link_to "edit", edit_specialist_document_attachment_path(document, attachment) %>
-      </li>
+    <% if document.persisted? %>
+      <%= link_to "Add attachment", new_specialist_document_attachment_path(document) %>
+    <% else %>
+      <p>To add an attachment, please save the draft first.</p>
     <% end %>
-  </ul>
+
+    <ul class="attachments">
+      <% document.attachments.each do |attachment| %>
+        <li class="attachment">
+          <span class="title"><%= attachment.title %></span>
+          <span class="snippet"><%= attachment.snippet %></span>
+          <%= link_to "edit", edit_specialist_document_attachment_path(document, attachment) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
 </div>


### PR DESCRIPTION
Bug: go to edit a specialist document which has attachments, submit an
invalid edit, receive 500 error.

This is caused by a similar problem to 4ce549e, but I have resolved it
differently.

Because we aren’t really editing an existing document edition, but
duplicating it and saving that one, the embedded attachments respond to
`#new_record?` with true. This means that url_for(attachment) links to
the plural not the singular route of attachment.

However, for this problem, it is much less important that we display
this correctly on the update action, so instead we simply remove the
ability to edit attachments on an invalid document.

Same concerns as the other commit.
