### PR TITLE
Change Manual Section format to use underscore

### DIFF
--- a/app/lib/manual_document_artefact_formatter.rb
+++ b/app/lib/manual_document_artefact_formatter.rb
@@ -11,7 +11,7 @@ class ManualDocumentArtefactFormatter < AbstractArtefactFormatter
   end
 
   def kind
-    "manual-section"
+    "manual_section"
   end
 
   def rendering_app

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -124,7 +124,7 @@ module ManualHelpers
   def check_manual_document_is_published_to_publishing_api(slug, attrs)
     assert_publishing_api_put_item("/#{slug}",
       "base_path" => "/#{slug}",
-      "format" => "manual-section",
+      "format" => "manual_section",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "specialist-publisher",
     )

--- a/lib/manual_section_publishing_api_exporter.rb
+++ b/lib/manual_section_publishing_api_exporter.rb
@@ -23,7 +23,7 @@ private
   def exportable_attributes
     {
       base_path: base_path,
-      format: "manual-section",
+      format: "manual_section",
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),
       public_updated_at: rendered_document_attributes.fetch(:updated_at),

--- a/spec/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/manual_section_publishing_api_exporter_spec.rb
@@ -66,7 +66,7 @@ describe ManualSectionPublishingAPIExporter do
       "/guidance/my-first-manual/first-section",
       hash_including(
         base_path: "/guidance/my-first-manual/first-section",
-        format: "manual-section",
+        format: "manual_section",
         title: "Document title",
         description: "This is the first section",
         public_updated_at: Date.new(2013, 12, 31),


### PR DESCRIPTION
To keep this consistent with other formats the format should be underscored.
