### PR TITLE
Don't touch bulk published on a minor update

### DIFF
--- a/app/services/publish_document_service.rb
+++ b/app/services/publish_document_service.rb
@@ -18,7 +18,7 @@ class PublishDocumentService
   attr_reader :document_repository, :listeners, :document_id, :bulk_publish
 
   def publish
-    document.update(bulk_published: bulk_publish)
+    document.update(bulk_published: bulk_publish) unless document.minor_update
     document.publish!
 
     listeners.each { |o| o.call(document) }

--- a/spec/services/publish_document_service_spec.rb
+++ b/spec/services/publish_document_service_spec.rb
@@ -3,7 +3,8 @@ require "publish_document_service"
 RSpec.describe PublishDocumentService do
   let(:document_id) { double(:document_id) }
   let(:repository) { double(:repository) }
-  let(:document) { double(:document, extra_fields: {bulk_published: false}) }
+  let(:document) { double(:document, minor_update: minor_update, extra_fields: {bulk_published: false}) }
+  let(:minor_update) { nil }
   let(:listeners) { [] }
 
   subject {
@@ -36,6 +37,15 @@ RSpec.describe PublishDocumentService do
     it "clears bulk published" do
       subject.call
       expect(document).to have_received(:update).with({bulk_published: false})
+    end
+
+    context "on a minor update" do
+      let(:minor_update) { true }
+
+      it "does not clear bulk published" do
+        subject.call
+        expect(document).not_to have_received(:update)
+      end
     end
   end
 


### PR DESCRIPTION
We should leave the "bulk published" attribute alone on a minor update (i.e. set to whatever it was previously).
