### PR TITLE
Minor updates dont update published at mk2

### DIFF
--- a/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_specialist_document_indexable_formatter.rb
@@ -4,6 +4,6 @@ class AbstractSpecialistDocumentIndexableFormatter < AbstractIndexableFormatter
 
 private
   def last_update
-    entity.minor_update? ? entity.last_published_at : entity.updated_at
+    entity.previous_major_updated_at
   end
 end

--- a/app/exporters/specialist_document_database_exporter.rb
+++ b/app/exporters/specialist_document_database_exporter.rb
@@ -63,7 +63,7 @@ private
 
   def document_metadata
     {
-      published_at: document.minor_update? ? document.last_published_at : document.updated_at,
+      published_at: document.previous_major_updated_at,
     }
   end
 

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -132,8 +132,8 @@ class SpecialistDocument
     end
   end
 
-  def last_published_at
-    published_edition.updated_at
+  def previous_major_updated_at
+    last_major_edition.updated_at
   end
 
 protected
@@ -179,6 +179,14 @@ protected
     if most_recent_non_draft && most_recent_non_draft.published?
       most_recent_non_draft
     end
+  end
+
+  def last_major_edition
+    major_editions.last
+  end
+
+  def major_editions
+    editions.reject { |e| e.minor_update? }
   end
 
   def most_recent_non_draft

--- a/spec/exporters/formatters/abstract_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_indexable_formatter_spec.rb
@@ -1,6 +1,10 @@
 require "formatters/abstract_indexable_formatter"
 
 RSpec.shared_examples_for "an indexable formatter" do
+  before do
+    allow(document).to receive(:previous_major_updated_at).and_return(double)
+  end
+
   it "should respond to #id" do
     expect(formatter).to respond_to(:id)
   end

--- a/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/abstract_specialist_document_indexable_formatter_spec.rb
@@ -2,19 +2,11 @@ require "formatters/abstract_specialist_document_indexable_formatter"
 
 RSpec.shared_examples_for "a specialist document indexable formatter" do
   describe "last update" do
-    it "returns the document's last_published_at if it is a minor update" do
-      last_published_at = double(:last_published_at)
-      expect(document).to receive(:last_published_at).and_return(last_published_at)
-      allow(document).to receive(:minor_update?).and_return(true)
+    it "returns the document's major_updated_at" do
+      major_updated_at = double(:previous_major_updated_at)
+      expect(document).to receive(:previous_major_updated_at).and_return(major_updated_at)
 
-      expect(formatter.indexable_attributes[:last_update]).to eq(last_published_at)
-    end
-
-    it "returns the document's updated_at if it is a major update" do
-      updated_at = double(:updated_at)
-      expect(document).to receive(:updated_at).and_return(updated_at)
-
-      expect(formatter.indexable_attributes[:last_update]).to eq(updated_at)
+      expect(formatter.indexable_attributes[:last_update]).to eq(major_updated_at)
     end
   end
 end

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -625,4 +625,24 @@ describe SpecialistDocument do
       end
     end
   end
+
+  describe "previous_major_updated_at" do
+    let(:major_edition_updated_at)  { double(:major_edition_updated_at) }
+    let(:minor_edition_updated_at)  { double(:minor_edition_updated_at) }
+    let(:new_edition_updated_at)    { double(:new_edition_updated_at) }
+    let(:major_edition) { double(:major_edition, minor_update?: false, updated_at: major_edition_updated_at) }
+    let(:minor_edition) { double(:minor_edition, minor_update?: true, updated_at: minor_edition_updated_at) }
+    let(:new_edition)   { double(:new_edition, minor_update?: true, updated_at: new_edition_updated_at) }
+
+    let(:editions) { [major_edition, minor_edition, new_edition] }
+
+    it "returns the previous edition's updated_at if the latest edition is a minor update" do
+      expect(doc.previous_major_updated_at).to eq(major_edition_updated_at)
+    end
+
+    it "returns the new edition's updated_at if the latest edition is a major update" do
+      allow(new_edition).to receive(:minor_update?).and_return(false)
+      expect(doc.previous_major_updated_at).to eq(new_edition_updated_at)
+    end
+  end
 end

--- a/spec/specialist_document_database_exporter_spec.rb
+++ b/spec/specialist_document_database_exporter_spec.rb
@@ -23,13 +23,13 @@ describe SpecialistDocumentDatabaseExporter do
     end
   }
 
-  let(:last_published_time) { double(:last_published_time) }
+  let(:previous_major_updated_at) { double(:previous_major_updated_at) }
   let(:newly_published_time) { double(:newly_published_time) }
   let(:document) {
     double(:document,
       slug: document_slug,
       minor_update?: false,
-      last_published_at: last_published_time,
+      previous_major_updated_at: previous_major_updated_at,
       updated_at: newly_published_time,
     )
   }
@@ -131,25 +131,5 @@ describe SpecialistDocumentDatabaseExporter do
         )
       )
     )
-  end
-
-  context "published dates" do
-    it "updates the published date if it is a major update" do
-      exporter.call
-
-      expect(export_recipent).to have_received(:create_or_update_by_slug!).with(
-        hash_including(published_at: newly_published_time)
-      )
-    end
-
-    it "does not update the published date if it is a minor update" do
-      allow(document).to receive(:minor_update?).and_return(true)
-
-      exporter.call
-
-      expect(export_recipent).to have_received(:create_or_update_by_slug!).with(
-        hash_including(published_at: last_published_time)
-      )
-    end
   end
 end


### PR DESCRIPTION
When publishing, we first update the document to say that it is
'published', then we export it to the content api. Because by the
time the exporter calls the published_edition after the document has
been updated to published, this returns the latest_edition instead.

Instead we must find the last major edition and use its updated_at
to retain the published at date across minor updates.
