### PR TITLE
Sort by relevant date before bulk publishing

### DIFF
--- a/bin/publish_dsu_reports
+++ b/bin/publish_dsu_reports
@@ -13,7 +13,7 @@ service = SpecialistPublisher.document_services("drug_safety_update")
 $stdout.sync = true
 
 puts "Loading all draft drug safety updates. This could take some time..."
-repository.all.lazy.select(&:draft?).each do |document|
+repository.all.sort { |a, b| a.extra_fields[:first_published_at] <=> b.extra_fields[:first_published_at] }.lazy.select(&:draft?).each do |document|
   print "Publishing draft document #{document.slug}..."
   $stdout.flush
   begin

--- a/bin/publish_maib_reports
+++ b/bin/publish_maib_reports
@@ -13,7 +13,7 @@ service = SpecialistPublisher.document_services("maib_report")
 $stdout.sync = true
 
 puts "Loading all draft MAIB reports. This could take some time..."
-repository.all.lazy.select(&:draft?).each do |document|
+repository.all.sort { |a, b| a.extra_fields[:date_of_occurrence] <=> b.extra_fields[:date_of_occurrence] }.lazy.select(&:draft?).each do |document|
   print "Publishing draft document #{document.slug}..."
   $stdout.flush
   begin

--- a/bin/publish_medical_safety_alerts
+++ b/bin/publish_medical_safety_alerts
@@ -13,7 +13,7 @@ service = SpecialistPublisher.document_services("medical_safety_alert")
 $stdout.sync = true
 
 puts "Loading all draft medical safety alerts. This could take some time..."
-repository.all.lazy.select(&:draft?).each do |document|
+repository.all.sort { |a, b| a.extra_fields[:issued_date] <=> b.extra_fields[:issued_date] }.lazy.select(&:draft?).each do |document|
   print "Publishing draft document #{document.slug}..."
   $stdout.flush
   begin

--- a/bin/publish_raib_reports
+++ b/bin/publish_raib_reports
@@ -13,7 +13,7 @@ service = SpecialistPublisher.document_services("raib_report")
 $stdout.sync = true
 
 puts "Loading all draft RAIB reports. This could take some time..."
-repository.all.lazy.select(&:draft?).each do |document|
+repository.all.sort { |a, b| a.extra_fields[:date_of_occurrence] <=> b.extra_fields[:date_of_occurrence] }.lazy.select(&:draft?).each do |document|
   print "Publishing draft document #{document.slug}..."
   $stdout.flush
   begin


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/2Aps6SeY/476-bulk-publish-in-date-of-occurrence-issued-or-published-at-order-2)

Bulk publishing should sort by:

RAIB - date of occurrence
MAIB - date of occurrence
Drug safety update - published
Drug and device alerts - issued
