### PR TITLE
Rename update timestamp to public

### DIFF
--- a/app/exporters/specialist_document_database_exporter.rb
+++ b/app/exporters/specialist_document_database_exporter.rb
@@ -94,7 +94,7 @@ private
       .map { |publication|
         {
           note: publication.change_note,
-          published_timestamp: publication.published_at.utc,
+          public_timestamp: publication.published_at.utc,
         }
       }
   end

--- a/spec/specialist_document_database_exporter_spec.rb
+++ b/spec/specialist_document_database_exporter_spec.rb
@@ -125,7 +125,7 @@ describe SpecialistDocumentDatabaseExporter do
           change_history: [
             {
               note: "Change is good!",
-              published_timestamp: published_at.utc,
+              public_timestamp: published_at.utc,
             }
           ]
         )


### PR DESCRIPTION
With the work to create updates from publication logs we mistakingly renamed this. This commit corrects it to public_timestamp like other document formats.
