### PR TITLE
Fix Publication Log Change History migration

### DIFF
--- a/db/migrate/20141201143333_move_specialist_document_edition_change_history_to_publication_log.rb
+++ b/db/migrate/20141201143333_move_specialist_document_edition_change_history_to_publication_log.rb
@@ -3,12 +3,14 @@ class MoveSpecialistDocumentEditionChangeHistoryToPublicationLog < Mongoid::Migr
     editions_with_change_history.each do |edition|
       latest_change = edition.change_history.last
 
-      PublicationLog.create!(
-        slug: edition.slug,
-        title: edition.title,
-        change_note: latest_change.note,
-        version_number: edition.version_number,
-      )
+      if latest_change
+        PublicationLog.create!(
+          slug: edition.slug,
+          title: edition.title,
+          change_note: latest_change.note,
+          version_number: edition.version_number,
+        )
+      end
     end
   end
 
@@ -18,6 +20,6 @@ class MoveSpecialistDocumentEditionChangeHistoryToPublicationLog < Mongoid::Migr
 
 private
   def self.editions_with_change_history
-    SpecialistDocumentEdition.where(:change_history.ne => nil)
+    SpecialistDocumentEdition.where(:change_history.nin => [nil, []])
   end
 end


### PR DESCRIPTION
Previous version of this migration returned SpecialistDocumentEditions with empty array change notes history. This commit fixes the query to only return editions with a change note history with something in it and also adds a condition to make sure that the object pulled from the array isn't nil.
