### PR TITLE
Fix broken migration

### DIFF
--- a/db/migrate/20141201143333_move_specialist_document_edition_change_history_to_publication_log.rb
+++ b/db/migrate/20141201143333_move_specialist_document_edition_change_history_to_publication_log.rb
@@ -7,7 +7,7 @@ class MoveSpecialistDocumentEditionChangeHistoryToPublicationLog < Mongoid::Migr
         PublicationLog.create!(
           slug: edition.slug,
           title: edition.title,
-          change_note: latest_change.note,
+          change_note: latest_change.respond_to?(:note) ? latest_change.note : "First published.",
           version_number: edition.version_number,
         )
       end
@@ -20,6 +20,6 @@ class MoveSpecialistDocumentEditionChangeHistoryToPublicationLog < Mongoid::Migr
 
 private
   def self.editions_with_change_history
-    SpecialistDocumentEdition.where(:change_history.nin => [nil, []])
+    SpecialistDocumentEdition.where(:change_history.nin => [nil, []]).uniq { |e| e.document_id }
   end
 end


### PR DESCRIPTION
DO NOT MERGE!

When a changehistory entry has no note. Fix the migration to use "First published"
