### PR TITLE
Copy updated_at to public_updated_at for editions

### DIFF
--- a/db/migrate/20141208165132_add_public_updated_at_to_all_specialist_document_editions.rb
+++ b/db/migrate/20141208165132_add_public_updated_at_to_all_specialist_document_editions.rb
@@ -1,0 +1,22 @@
+class AddPublicUpdatedAtToAllSpecialistDocumentEditions < Mongoid::Migration
+  def self.up
+    editions = SpecialistDocumentEdition.where(:document_type.in => %w(
+      cma_case
+      aaib_report
+      maib_report
+      raib_report
+      drug_safety_update
+      medical_safety_alert
+      international_development_fund
+    ))
+
+    editions.each do |edition|
+      # use set in order to not touch updated_at timestamps
+      edition.set(:public_updated_at, edition.updated_at)
+    end
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
copy the existing updated_at to public_updated_at without touching the updated_at.

This will mean all documents after this migration will use the new default functionality for
setting public_updated_at on major/minor updates.
