### PR TITLE
Initialise Documents with a change note

### DIFF
--- a/app/models/builders/specialist_document_builder.rb
+++ b/app/models/builders/specialist_document_builder.rb
@@ -8,14 +8,24 @@ class SpecialistDocumentBuilder
 
   def call(attrs)
     document_factory.call(SecureRandom.uuid, editions).
-      tap { |d| d.update(attrs.merge(document_type: @document_type)) }
+      tap { |d| d.update(attrs.merge(defaults)) }
   end
 
-  private
+private
 
-  attr_reader :document_factory
+  attr_reader(
+    :document_type,
+    :document_factory,
+  )
 
   def editions
     []
+  end
+
+  def defaults
+    {
+      document_type: document_type,
+      change_note: "First published.",
+    }
   end
 end

--- a/spec/models/builders/specialist_document_builder_spec.rb
+++ b/spec/models/builders/specialist_document_builder_spec.rb
@@ -12,7 +12,10 @@ describe SpecialistDocumentBuilder do
   describe "#call" do
     it "creates a new document" do
       expect(builder.call({})).to eq(document)
-      expect(document).to have_received(:update).with({document_type: document_type})
+      expect(document).to have_received(:update).with({
+        document_type: document_type,
+        change_note: "First published.",
+      })
     end
   end
 end


### PR DESCRIPTION
When we first build a document we should initialise it with a chnage
note of "First published"
