### PR TITLE
Make sure to touch public_updated_at on bulk publish

### DIFF
--- a/app/services/publish_document_service.rb
+++ b/app/services/publish_document_service.rb
@@ -20,7 +20,7 @@ class PublishDocumentService
   def publish
     unless document.minor_update
       document.update(bulk_published: bulk_publish)
-      document.update(public_updated_at: Time.current) unless bulk_publish
+      document.update(public_updated_at: Time.current)
     end
 
     document.publish!

--- a/spec/services/publish_document_service_spec.rb
+++ b/spec/services/publish_document_service_spec.rb
@@ -66,14 +66,20 @@ RSpec.describe PublishDocumentService do
     let(:bulk_publish) { true }
     it_behaves_like "a document publication"
 
+    let(:time) { double(:time) }
+
+    before do
+      allow(Time).to receive(:current).and_return(time)
+    end
+
     it "sets bulk published" do
       subject.call
       expect(document).to have_received(:update).with({bulk_published: true})
     end
 
-    it "does not set the public_updated_at" do
+    it "does sets the public_updated_at" do
       subject.call
-      expect(document).not_to have_received(:update).with(hash_including(:public_updated_at))
+      expect(document).to have_received(:update).with({public_updated_at: time})
     end
   end
 end


### PR DESCRIPTION
This seems wrong but means we can order things before publishing
in order for rummager to index the items in the correct order.

We should find a better solution for this after the imports as updating
public_updated_at when bulk publishing happens is wrong. This means the
user facing public_updated_at is changed each time a bulk publish is run even
though we do not expect bulk publishes to be a user facing change.
