### PR TITLE
Add urgent flag and from_address to email alerts

### DIFF
--- a/app/exporters/email_alert_exporter.rb
+++ b/app/exporters/email_alert_exporter.rb
@@ -7,9 +7,7 @@ class EmailAlertExporter
 
   def call
     email_alert_api.send_alert(
-      "subject" => formatter.subject,
-      "body" => formatter.body,
-      "tags" => formatter.tags,
+      base_params.merge(formatter.extra_options)
     )
   end
 
@@ -19,4 +17,12 @@ private
     :email_alert_api,
     :formatter,
   )
+
+  def base_params
+    {
+      "subject" => formatter.subject,
+      "body" => formatter.body,
+      "tags" => formatter.tags,
+    }
+  end
 end

--- a/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
+++ b/app/exporters/formatters/abstract_document_publication_alert_formatter.rb
@@ -1,5 +1,6 @@
 require "plek"
 require "action_view"
+require "yaml"
 
 class AbstractDocumentPublicationAlertFormatter
   def initialize(dependencies = {})
@@ -36,6 +37,15 @@ class AbstractDocumentPublicationAlertFormatter
     )
   end
 
+  def extra_options
+    {
+      header: header,
+      footer: footer,
+      urgent: urgent,
+      from_address_id: from_address_id,
+    }.reject { |_k, v| v.nil? }
+  end
+
 private
   attr_reader(
     :document,
@@ -67,4 +77,29 @@ private
     extra_fields.each { |key, value| hash[key] = value.is_a?(Array) ? value : [value] }
     hash
   end
+
+  def header
+    nil
+  end
+
+  def footer
+    nil
+  end
+
+  def urgent
+    # DO NOT set default to false, this will send false to gov delivery
+    # and FORCE overriding of topic defaults set in gov delivery
+    # This should only be overridden where we explicitly want an
+    # email to be non urgent and not to fallback to gov delivery defaults
+    nil
+  end
+
+  def from_address_id
+    from_address_config[document.document_type]
+  end
+
+  def from_address_config
+    @config ||= YAML.load_file(File.join(Rails.root, "config", "gov_delivery_from_address_ids.yml"))[Rails.env]
+  end
+
 end

--- a/app/exporters/formatters/medical_safety_alert_publication_alert_formatter.rb
+++ b/app/exporters/formatters/medical_safety_alert_publication_alert_formatter.rb
@@ -10,4 +10,9 @@ private
   def document_noun
     "alert"
   end
+
+  def urgent
+    true
+  end
+
 end

--- a/config/gov_delivery_from_address_ids.yml
+++ b/config/gov_delivery_from_address_ids.yml
@@ -1,0 +1,11 @@
+production:
+  medical_safety_alert: 42026
+
+staging: &staging
+  medical_safety_alert: 16221
+
+development:
+  <<: *staging
+
+test:
+  medical_safety_alert: 12345

--- a/spec/exporters/email_alert_exporter_spec.rb
+++ b/spec/exporters/email_alert_exporter_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe EmailAlertExporter do
       name: "format name",
       subject: email_subject,
       body: email_body,
-      tags: email_tags
+      tags: email_tags,
+      extra_options: {},
     )
   }
   subject(:exporter) {
@@ -33,5 +34,17 @@ RSpec.describe EmailAlertExporter do
         "body" => email_body,
         "tags" => email_tags,
       )
+  end
+
+  it "includes extra options if they are specified" do
+    extra_options = {
+      urgent: true,
+      email_address_id: 12345,
+      header: "foo",
+      footer: "bar",
+    }
+    allow(formatter).to receive(:extra_options).and_return(extra_options)
+    exporter.call
+    expect(email_alert_api).to have_received(:send_alert).with(hash_including(extra_options))
   end
 end


### PR DESCRIPTION
DO NOT MERGE:
Depends on: https://github.com/alphagov/email-alert-api/pull/65

Changes to email_alert_api and gov delivery now allow us to send
headers, footers, from_address_id and urgent flags to in order to
customize specific email alert types and not fall back to gov delivery's
global defaults.

This commit sets up specialist-publisher to allow these options to be
passed using the publication_alert_formatters, however, we currently do
not have custom headers or footers required in order to implement them
for medical_safety_alerts. This will simply involve overwriting header and
footer methods on the formatter to render a template containing the
correct template.

Story: https://trello.com/c/M6XBkDUF/499-govdelivery-api-features-for-email-settings-3
