### PR TITLE
Check for First Published as change note

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,7 @@ module ApplicationHelper
         publish_locals = publish_form_text[:slug_not_unique]
       end
     elsif publishable
-      if !document.change_note.blank?
+      if !document.change_note.blank? && document.change_note != "First published."
         publish_locals = publish_form_text[:major_update]
       elsif document.minor_update
         publish_locals = publish_form_text[:minor_update]


### PR DESCRIPTION
Documents created in Specialist Publisher after change notes have been added have "First published." as a change note instead of a blank string. This commit changes the check to check for both states as older,
scraped content, still has the blank change note.

There's probably more work to refactor this out like a view adapter but I will do that in another commit as this fix should be out sooner rather than later.
