### PR TITLE
Revert "Add a deprecation warning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Warning: This repository is deprecated. It has been replaced with [manuals-publisher](https://github.com/alphagov/manuals-publisher). Please update your git remote.
-
 [![Code Climate](https://codeclimate.com/github/alphagov/specialist-publisher.png)](https://codeclimate.com/github/alphagov/specialist-publisher)
 
 # Specialist publisher


### PR DESCRIPTION
This reverts commit c26371275e9cdd56aad80ff1125a6bc3be4e5bc0.

Originally, we pushed a copy of this repository to a new
remote. However, this will lose issue and pull request
history so we're going to do a rename, instead. GitHub will
automatically set up redirects for us.