### PR TITLE
Manuals Publisher should use port 3205

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rails s -p 3064
+web: bundle exec rails s -p 3205
 worker: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
https://github.gds/gds/development/pull/342
https://github.com/alphagov/govuk-puppet/pull/4897/commits/b9f018e4f00840d9f9246d26cf098c1d60d61eb8

We can't use the existing port config from specialist-publisher so use 3205