### PR TITLE
Use the correct ENV keys for SSO

### DIFF
--- a/gds-sso.rb
+++ b/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
   config.user_model   = "User"
-  config.oauth_id     = ENV["SPECIALIST_PUBLISHER_OAUTH_ID"] || "not used"
-  config.oauth_secret = ENV["SPECIALIST_PUBLISHER_OAUTH_SECRET"] || "not used"
+  config.oauth_id     = ENV["OAUTH_ID"] || "not used"
+  config.oauth_secret = ENV["OAUTH_SECRET"] || "not used"
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
https://trello.com/c/m9ZWAIbQ/284-rename-the-specialist-publisher-v1-to-manuals-publisher-large
Use the correct ENV var keys for OAuth.