### PR TITLE
Add default /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,6 @@ ManualsPublisher::Application.routes.draw do
   post "manuals/:manual_id/sections/preview" => "ManualDocuments#preview", as: "preview_new_manual_document"
 
   root to: redirect("/manuals")
+
+  get "/healthcheck", to: proc { [200, {}, ["OK"]] }
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "healthcheck path", type: :request do
+  it "should respond with 'OK'" do
+    get "/healthcheck"
+
+    expect(response.status).to eq(200)
+    expect(response.body).to eq("OK")
+  end
+end


### PR DESCRIPTION
Integration is alerting because this route is not responding. It's pretty standard across our applications so I've added `/healthcheck`.