### PR TITLE
Use the asset manager bearer token from ENV

### DIFF
--- a/config/initializers/attachment_api.rb
+++ b/config/initializers/attachment_api.rb
@@ -1,9 +1,7 @@
-# This file is overwritten on deployment. In order to authenticate in dev
-# environment with asset-manager any random string is required as bearer_token
 require "gds_api/asset_manager"
 require "plek"
 
 Attachable.asset_api_client = GdsApi::AssetManager.new(
   Plek.current.find("asset-manager"),
-  bearer_token: "1234567890",
+  bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"],
 )


### PR DESCRIPTION
Bearer tokens and other secrets are no longer managed by alphagov-deployment so use the asset manager bearer token from the application's environment