### PR TITLE
Update name for Democratic Republic of the Congo

### DIFF
--- a/finders/schemas/international-development-funds.json
+++ b/finders/schemas/international-development-funds.json
@@ -34,7 +34,7 @@
           "value": "burma"
         },
         {
-          "label": "Democratic Republic of Congo",
+          "label": "Democratic Republic of the Congo",
           "value": "democratic-republic-of-congo"
         },
         {


### PR DESCRIPTION
**trello**: https://trello.com/c/rxjklHjL/191-country-name-change-democratic-republic-of-the-congo
>The country formerly known as 'Democratic Republic of Congo' is now officially called 'Democratic Republic of **the** Congo'.