### PR TITLE
Fix content schema tests

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -39,13 +39,7 @@ git checkout $SCHEMA_GIT_COMMIT
 cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-# TODO as schemas are added for them, change this to include more formats
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec \
-  spec/lib/publishing_api_finder_publisher_spec.rb \
-  spec/manual_publishing_api_exporter_spec.rb \
-  spec/manual_section_publishing_api_exporter_spec.rb \
-  spec/exporters/formatters/specialist_document_publishing_api_formatter_spec.rb
-
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec
 EXIT_STATUS=$?
 echo "EXIT STATUS: $EXIT_STATUS"
 

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -1,0 +1,61 @@
+require "fast_spec_helper"
+require "support/govuk_content_schema_helpers"
+
+require "manual_publishing_api_links_exporter"
+
+describe ManualPublishingAPILinksExporter do
+  subject {
+    ManualPublishingAPILinksExporter.new(
+      export_recipent,
+      organisation,
+      manual
+    )
+  }
+
+  let(:export_recipent) { double(:export_recipent, call: nil) }
+
+  let(:organisation) {
+    {
+      "web_url" => "https://www.gov.uk/government/organisations/cabinet-office",
+      "title" => "Cabinet Office",
+      "details" => { "abbreviation" => "CO", "content_id" => "d94d63a5-ce8e-40a1-ab4c-4956eab27259" },
+    }
+  }
+
+  let(:manual) {
+    double(
+      :manual,
+      id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+      attributes: {
+        slug: "guidance/my-first-manual",
+        organisation_slug: "cabinet-office",
+      },
+      documents: documents,
+    )
+  }
+
+  let(:documents) {
+    [
+      double(:document, id: "c19ffb7d-448c-4cc8-bece-022662ef9611"),
+      double(:document, id: "f9c91a07-6a41-4b97-94a8-ecdc81997d49"),
+    ]
+  }
+
+  it "exports links for the manual" do
+    subject.call
+
+    expect(export_recipent).to have_received(:call).with(
+      manual.id,
+      hash_including(
+        links: {
+          organisations: [organisation["details"]["content_id"]],
+          sections: %w[c19ffb7d-448c-4cc8-bece-022662ef9611 f9c91a07-6a41-4b97-94a8-ecdc81997d49],
+        }
+      )
+    )
+  end
+
+  it "exports links valid against the schema" do
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_links_schema("manual")
+  end
+end


### PR DESCRIPTION
These were broken by the change in path to two of the exporter files. 

I've also added a schema test for a manuals links, and included both links tests in the schema tests.