### PR TITLE
Extract file upload logic from Attachable

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,15 +1,15 @@
-require "attachable"
-
 class Attachment
   include Mongoid::Document
   include Mongoid::Timestamps
-  include Attachable
 
   field :title
   field :filename
-  attaches :file, with_url_field: true, update_existing: true
+  field :file_id, type: String
+  field :file_url, type: String
 
   embedded_in :specialist_document_edition
+
+  before_save :upload_file, if: :file_has_changed?
 
   def to_param
     id
@@ -18,4 +18,40 @@ class Attachment
   def snippet
     "[InlineAttachment:#{filename}]"
   end
+
+  def file
+    raise ApiClientNotPresent unless AttachmentApi.client
+    unless file_id.nil?
+      @attachments ||= { }
+      @attachments[field] ||= AttachmentApi.client.asset(file_id)
+    end
+  end
+
+  def file=(file)
+    @file_has_changed = true
+    @uploaded_file = file
+  end
+
+  def file_has_changed?
+    @file_has_changed
+  end
+
+  def upload_file
+    raise ApiClientNotPresent unless AttachmentApi.client
+    begin
+      if file_id.nil?
+        response = AttachmentApi.client.create_asset(file: @uploaded_file)
+        self.file_id = response["id"].split("/").last
+      else
+        response = AttachmentApi.client.update_asset(file_id, file: @uploaded_file)
+      end
+      self.file_url = response["file_url"]
+    rescue StandardError
+      errors.add(:file_id, "could not be uploaded")
+    end
+  end
+
+  private :upload_file
+
+  class ::ApiClientNotPresent < StandardError; end
 end

--- a/config/initializers/attachment_api.rb
+++ b/config/initializers/attachment_api.rb
@@ -1,7 +1,11 @@
 require "gds_api/asset_manager"
 require "plek"
 
-Attachable.asset_api_client = GdsApi::AssetManager.new(
-  Plek.current.find("asset-manager"),
-  bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"],
-)
+module AttachmentApi
+  def self.client
+    @client ||= GdsApi::AssetManager.new(
+      Plek.current.find("asset-manager"),
+      bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"],
+    )
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,4 +1,4 @@
-require "fast_spec_helper"
+require "spec_helper"
 require "attachment"
 
 describe Attachment do
@@ -11,5 +11,54 @@ describe Attachment do
 
   it "generates a snippet" do
     expect(attachment.snippet).to eq("[InlineAttachment:document.pdf]")
+  end
+
+  context "#save" do
+    let(:edition) do
+      FactoryGirl.create(:specialist_document_edition)
+    end
+
+    let(:upload_file) do
+      Tempfile.new("foobar.csv")
+    end
+
+    before do
+      edition.attachments << attachment
+      attachment.specialist_document_edition = edition
+    end
+
+    it "uploads a file before saving" do
+      expect(AttachmentApi.client).to receive(:create_asset)
+        .with(file: upload_file)
+        .and_return({ "file_url" => "some/file/url", "id" => "some_file_id" })
+
+      attachment.file = upload_file
+      expect(attachment.file_has_changed?).to be true
+
+      attachment.save
+
+      expect(attachment.file_id).to eq("some_file_id")
+      expect(attachment.file_url).to eq("some/file/url")
+    end
+
+    context "when a file has already been uploaded" do
+      before do
+        attachment.file_id = "some_file_id"
+      end
+
+      it "updates the uploaded file on the Attachment" do
+        expect(AttachmentApi.client).to receive(:update_asset)
+          .with("some_file_id", file: upload_file)
+          .and_return({ "file_url" => "some/file/url", "id" => "some_file_id" })
+
+        attachment.file = upload_file
+        expect(attachment.file_has_changed?).to be true
+
+        attachment.save
+
+        expect(attachment.file_id).to eq("some_file_id")
+        expect(attachment.file_url).to eq("some/file/url")
+      end
+    end
   end
 end


### PR DESCRIPTION
The govuk_content_models trait `Attachable` [is not compatible with hash responses](https://github.com/alphagov/govuk_content_models/blob/master/app/traits/attachable.rb#L65) from gds-api-adapters `GdsApi::Response`.
We've recently updated the gds-api-adapters gem so it now returns hash responses but this breaks interaction with the Asset Manager API due to the dependency on the `Attachable` trait.
So extract this file upload logic into the `Attachment` class so we can handle hash responses from gds-api-adapters.
This is probably a better solution than https://github.com/alphagov/manuals-publisher/pull/760

/cc @tijmenb @kevindew 