### PR TITLE
Migrate guidance/capital-funding-guide-hca

### DIFF
--- a/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
+++ b/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
@@ -1,9 +1,14 @@
 require "manual_relocator"
+require "cli_manual_deleter"
+require "stringio"
 
 class RemoveRedirectCapitalFundingGuide < Mongoid::Migration
   def self.up
+    bad_manual_id = "7228d773-a416-4ec1-9549-5fb91b1caaf5"
     manual_slug = "guidance/capital-funding-guide"
     new_manual_slug = "#{manual_slug}-hca"
+
+    CliManualDeleter.new(manual_slug, manual_id: bad_manual_id, stdin: StringIO.new("y")).call
 
     ManualRelocator.move(new_manual_slug, manual_slug)
   end

--- a/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
+++ b/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
@@ -1,3 +1,20 @@
+# The history
+# ===========
+#
+# The Homes and Communities Agency have a manual "The Capital Funding Guide"
+# that they wanted to make extensive revisions to.  Removing sections
+# wasn't possible when they made their changes so they created a new version of
+# the manual at a new slug and worked on that.  They asked if we could remove
+# the existing one and move the new one onto that old slug.  That wasn't easy
+# so we issued some redirects to send visits to the old slug over to the
+# new one.  Now that we're ready to tidy this up, we are planning to remove
+# the existing manual (with unpublishings and gones via the publishing-api)
+# and then reslug the new manual back onto the old slug and republish it.
+#
+# We also need to remove another draft manual that was created with the same
+# slug as the old one.  It's not been published or edited much, so we can
+# just delete it.  This document has slug "guidance/capital-funding-guide"
+# and id: 7228d773-a416-4ec1-9549-5fb91b1caaf5
 require "manual_relocator"
 require "cli_manual_deleter"
 require "stringio"
@@ -8,11 +25,16 @@ class RemoveRedirectCapitalFundingGuide < Mongoid::Migration
     manual_slug = "guidance/capital-funding-guide"
     new_manual_slug = "#{manual_slug}-hca"
 
+    puts "Removing bad manual #{bad_manual_id} at #{manual_slug}."
     CliManualDeleter.new(manual_slug, manual_id: bad_manual_id, stdin: StringIO.new("y")).call
 
+    puts "Removing existing manual #{manual_slug} and reslugging #{new_manual_slug} back onto it."
     ManualRelocator.move(new_manual_slug, manual_slug)
   end
 
   def self.down
+    # Whilst it would be possible to reverse this, it would be a lot of work
+    # for something that is unlikely to ever get run.
+    raise IrreversibleMigration
   end
 end

--- a/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
+++ b/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
@@ -1,0 +1,13 @@
+require "manual_relocator"
+
+class RemoveRedirectCapitalFundingGuide < Mongoid::Migration
+  def self.up
+    manual_slug = "guidance/capital-funding-guide"
+    new_manual_slug = "#{manual_slug}-hca"
+
+    ManualRelocator.move(new_manual_slug, manual_slug)
+  end
+
+  def self.down
+  end
+end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -91,9 +91,10 @@ private
     # Clean up manual sections belonging to the temporary manual path
     document_ids.each do |document_id|
       puts "Redirecting #{document_id} to '/#{to_slug}'"
+      most_recent_edition = SpecialistDocumentEdition.where(document_id: document_id).order_by([:version_number, :desc]).first
       publishing_api.unpublish(document_id,
                                type: "redirect",
-                               alternative_path: "/#{to_slug}",
+                               alternative_path: "/#{most_recent_edition.slug}",
                                discard_drafts: true)
     end
 

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -1,99 +1,111 @@
 class ManualRelocator
+  attr_reader :from_slug, :to_slug
+
+  def initialize(from_slug, to_slug)
+    @from_slug = from_slug
+    @to_slug = to_slug
+  end
+
   def self.move(from_slug, to_slug)
-    redirect_and_remove(to_slug)
-    reslug(from_slug, to_slug)
+    new(from_slug, to_slug).move!
+  end
+
+  def move!
+    redirect_and_remove
+    reslug
+  end
+
+  def old_manual
+    @old_manual ||= fetch_manual(to_slug)
+  end
+
+  def new_manual
+    @new_manual ||= fetch_manual(from_slug)
   end
 
 private
 
-  def self.redirect_and_remove(manual_slug)
-    manual_records = ManualRecord.where(slug: manual_slug)
-    raise "No manual found for slug '#{manual_slug}'" unless manual_records.any?
-
-    puts "Found #{manual_records.count} manuals for slug '#{manual_slug}'"
-
-    manual_records.each do |manual_record|
-      if manual_record.editions.any?
-        # Redirect all sections of the manual we're going to remove
-        # to prevent dead bookmarked URLs.
-        document_ids = manual_record.editions.flat_map(&:document_ids).uniq
-
-        document_ids.each do |document_id|
-          editions = SpecialistDocumentEdition.where(document_id: document_id)
-          edition = editions.last
-
-          begin
-            puts "Redirecting content item '/#{edition.slug}' to '/#{manual_slug}'"
-            publishing_api.unpublish(edition.document_id,
-                                     type: "redirect",
-                                     alternative_path: "/#{manual_slug}",
-                                     discard_drafts: true)
-          rescue GdsApi::HTTPNotFound
-            puts "Content item with content_id #{document_id} not present in the publishing API"
-          end
-
-          # Destroy all the editons of this manual as it's going away
-          editions.map(&:destroy)
-        end
-      end
-
-      puts "Destroying old PublicationLogs for #{manual_record.slug}"
-      PublicationLog.change_notes_for(manual_record.slug).each { |log| log.destroy }
-
-      # Destroy the manual record
-      puts "Destroying manual #{manual_record._id}"
-      manual_record.destroy
-    end
+  def fetch_manual(slug)
+    manuals = ManualRecord.where(slug: slug)
+    raise "No manual found for slug '#{slug}'" if manuals.count == 0
+    raise "More than one manual found for slug '#{slug}'" if manuals.count > 1
+    manuals.first
   end
 
-  def self.reslug(old_slug, new_slug)
-    hca_manual_record = ManualRecord.find_by(slug: old_slug)
+  def redirect_and_remove
+    if old_manual.editions.any?
+      # Redirect all sections of the manual we're going to remove
+      # to prevent dead bookmarked URLs.
+      document_ids = old_manual.editions.flat_map(&:document_ids).uniq
 
+      document_ids.each do |document_id|
+        editions = SpecialistDocumentEdition.where(document_id: document_id)
+        edition = editions.last
+
+        begin
+          puts "Redirecting content item '/#{edition.slug}' to '/#{old_manual.slug}'"
+          publishing_api.unpublish(edition.document_id,
+                                   type: "redirect",
+                                   alternative_path: "/#{old_manual.slug}",
+                                   discard_drafts: true)
+        rescue GdsApi::HTTPNotFound
+          puts "Content item with content_id #{document_id} not present in the publishing API"
+        end
+
+        # Destroy all the editons of this manual as it's going away
+        editions.map(&:destroy)
+      end
+    end
+
+    puts "Destroying old PublicationLogs for #{old_manual.slug}"
+    PublicationLog.change_notes_for(old_manual.slug).each { |log| log.destroy }
+
+    # Destroy the manual record
+    puts "Destroying manual #{old_manual._id}"
+    old_manual.destroy
+  end
+
+  def reslug
     # Reslug the manual sections
-    hca_document_ids = hca_manual_record.editions.flat_map(&:document_ids).uniq
-    hca_document_ids.each do |document_id|
+    document_ids = new_manual.editions.flat_map(&:document_ids).uniq
+    document_ids.each do |document_id|
       sections = SpecialistDocumentEdition.where(document_id: document_id)
       sections.each do |section|
         reslug_msg = "Reslugging section '#{section.slug}'"
-        section.slug.gsub!(old_slug, new_slug)
+        new_section_slug = section.slug.gsub(from_slug, to_slug)
         puts "#{reslug_msg} as '#{section.slug}'"
-        section.save!
+        section.set(:slug, new_section_slug)
       end
     end
 
     # Reslug the manual
-    reslug_msg = "Reslugging manual '#{hca_manual_record.slug}'"
-    new_slug = hca_manual_record.slug.gsub(old_slug, new_slug)
-    puts "#{reslug_msg} as '#{new_slug}'"
-
-    hca_manual_record.set(:slug, new_slug)
+    puts "Reslugging manual '#{new_manual.slug}' as '#{to_slug}'"
+    new_manual.set(:slug, to_slug)
 
     # Reslug the existing publication logs
-    puts "Reslugging publication logs for #{old_slug} to #{new_slug}"
-    PublicationLog.change_notes_for(old_slug).each do |publication_log|
-      publication_log.set(:slug, publication_log.slug.gsub(old_slug, new_slug))
+    puts "Reslugging publication logs for #{from_slug} to #{to_slug}"
+    PublicationLog.change_notes_for(from_slug).each do |publication_log|
+      publication_log.set(:slug, publication_log.slug.gsub(from_slug, to_slug))
     end
-    puts PublicationLog.change_notes_for(new_slug).inspect
 
     # Clean up manual sections belonging to the temporary manual path
-    hca_document_ids = hca_manual_record.editions.flat_map(&:document_ids).uniq
-    hca_document_ids.each do |document_id|
-      puts "Redirecting #{document_id} to '/#{new_slug}'"
+    document_ids.each do |document_id|
+      puts "Redirecting #{document_id} to '/#{to_slug}'"
       publishing_api.unpublish(document_id,
                                type: "redirect",
-                               alternative_path: "/#{new_slug}",
+                               alternative_path: "/#{to_slug}",
                                discard_drafts: true)
     end
 
     # Clean up the drafted manual in the Publishing API
-    puts "Redirecting #{hca_manual_record.manual_id} to '/#{new_slug}'"
-    publishing_api.unpublish(hca_manual_record.manual_id,
+    puts "Redirecting #{new_manual.manual_id} to '/#{to_slug}'"
+    publishing_api.unpublish(new_manual.manual_id,
                              type: "redirect",
-                             alternative_path: "/#{new_slug}",
+                             alternative_path: "/#{to_slug}",
                              discard_drafts: true)
   end
 
-  def self.publishing_api
+  def publishing_api
     ManualsPublisherWiring.get(:publishing_api_v2)
   end
 end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -32,22 +32,35 @@ private
     manuals.first
   end
 
+  def old_manual_document_ids
+    @old_manual_document_ids ||= old_manual.editions.flat_map(&:document_ids).uniq
+  end
+
+  def new_manual_document_ids
+    @new_manual_document_ids ||= new_manual.editions.flat_map(&:document_ids).uniq
+  end
+
   def redirect_and_remove
     if old_manual.editions.any?
       # Redirect all sections of the manual we're going to remove
       # to prevent dead bookmarked URLs.
-      document_ids = old_manual.editions.flat_map(&:document_ids).uniq
-
-      document_ids.each do |document_id|
-        editions = SpecialistDocumentEdition.where(document_id: document_id)
-        edition = editions.last
+      old_manual_document_ids.each do |document_id|
+        editions = all_editions_of_section(document_id)
+        section_slug = editions.first.slug
 
         begin
-          puts "Redirecting content item '/#{edition.slug}' to '/#{old_manual.slug}'"
-          publishing_api.unpublish(edition.document_id,
-                                   type: "redirect",
-                                   alternative_path: "/#{old_manual.slug}",
-                                   discard_drafts: true)
+          if old_sections_reused_in_new_manual.include? document_id
+            puts "Issuing gone for content item '/#{section_slug}' as it will be reused by a section in '#{new_manual.slug}'"
+            publishing_api.unpublish(document_id,
+                                     type: "gone",
+                                     discard_drafts: true)
+          else
+            puts "Redirecting content item '/#{section_slug}' to '/#{old_manual.slug}'"
+            publishing_api.unpublish(document_id,
+                                     type: "redirect",
+                                     alternative_path: "/#{old_manual.slug}",
+                                     discard_drafts: true)
+          end
         rescue GdsApi::HTTPNotFound
           puts "Content item with content_id #{document_id} not present in the publishing API"
         end
@@ -61,15 +74,45 @@ private
     PublicationLog.change_notes_for(old_manual.slug).each { |log| log.destroy }
 
     # Destroy the manual record
-    puts "Destroying manual #{old_manual._id}"
+    puts "Destroying manual #{old_manual.manual_id}"
     old_manual.destroy
+
+    puts "Issuing gone for #{old_manual.manual_id}"
+    publishing_api.unpublish(old_manual.manual_id,
+                             type: "gone",
+                             discard_drafts: true)
+  end
+
+  def old_sections_reused_in_new_manual
+    @old_sections_reused_in_new_manual ||= _calculate_old_sections_reused_in_new_manual
+  end
+
+  def _calculate_old_sections_reused_in_new_manual
+    old_document_ids_and_section_slugs = old_manual_document_ids.map do |document_id|
+      [document_id, most_recent_edition_of_section(document_id).slug.gsub(to_slug, "")]
+    end
+
+    new_section_slugs = new_manual_document_ids.map do |document_id|
+      most_recent_edition_of_section(document_id).slug.gsub(from_slug, "")
+    end
+
+    old_document_ids_and_section_slugs.
+      select { |_document_id, slug| new_section_slugs.include? slug }.
+      map { |document_id, _slug| document_id }
+  end
+
+  def most_recent_edition_of_section(document_id)
+    all_editions_of_section(document_id).first
+  end
+
+  def all_editions_of_section(document_id)
+    SpecialistDocumentEdition.where(document_id: document_id).order_by([:version_number, :desc])
   end
 
   def reslug
     # Reslug the manual sections
-    document_ids = new_manual.editions.flat_map(&:document_ids).uniq
-    document_ids.each do |document_id|
-      sections = SpecialistDocumentEdition.where(document_id: document_id)
+    new_manual_document_ids.each do |document_id|
+      sections = all_editions_of_section(document_id)
       sections.each do |section|
         reslug_msg = "Reslugging section '#{section.slug}'"
         new_section_slug = section.slug.gsub(from_slug, to_slug)
@@ -89,9 +132,9 @@ private
     end
 
     # Clean up manual sections belonging to the temporary manual path
-    document_ids.each do |document_id|
+    new_manual_document_ids.each do |document_id|
       puts "Redirecting #{document_id} to '/#{to_slug}'"
-      most_recent_edition = SpecialistDocumentEdition.where(document_id: document_id).order_by([:version_number, :desc]).first
+      most_recent_edition = most_recent_edition_of_section(document_id)
       publishing_api.unpublish(document_id,
                                type: "redirect",
                                alternative_path: "/#{most_recent_edition.slug}",

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -175,8 +175,10 @@ private
         published_edition.document_ids.map { |document_id| most_recent_published_edition_of_section(document_id) }
       )
 
+      puts "Publishing previously published edition of manual: #{new_manual.manual_id}"
       publishing_api.publish(new_manual.manual_id, "republish")
       published_edition.document_ids.each do |document_id|
+        puts "Publishing previously published edition of manual section: #{document_id}"
         publishing_api.publish(document_id, "republish")
       end
     end
@@ -188,8 +190,10 @@ private
     )
 
     if new_manual.latest_edition.state == "published"
+      puts "Publishing latest edition of manual: #{new_manual.manual_id}"
       publishing_api.publish(new_manual.manual_id, "republish")
       new_manual.latest_edition.document_ids.each do |document_id|
+        puts "Publishing latest edition of manual section: #{document_id}"
         publishing_api.publish(document_id, "republish")
       end
     end
@@ -209,11 +213,13 @@ private
       end
     )
 
+    puts "Sending a draft of manual #{simple_manual.id} (version: #{simple_manual.version_number})"
     ManualPublishingAPIExporter.new(
       put_content, organisation, manual_renderer, PublicationLog, simple_manual
     ).call
 
     simple_manual.documents.each do |simple_document|
+      puts "Sending a draft of manual section #{simple_document.id} (version: #{simple_document.version_number})"
       ManualSectionPublishingAPIExporter.new(
         put_content, organisation, manual_document_renderer, simple_manual, simple_document
       ).call

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -1,0 +1,89 @@
+class ManualRelocator
+  def self.move(from_slug, to_slug)
+    redirect_and_remove(to_slug)
+    reslug(from_slug, to_slug)
+  end
+
+private
+
+  def self.redirect_and_remove(manual_slug)
+    manual_records = ManualRecord.where(slug: manual_slug)
+    raise "No manual found for slug '#{manual_slug}'" unless manual_records.any?
+
+    puts "Found #{manual_records.count} manuals for slug '#{manual_slug}'"
+
+    manual_records.each do |manual_record|
+      if manual_record.editions.any?
+        # Redirect all sections of the manual we're going to remove
+        # to prevent dead bookmarked URLs.
+        document_ids = manual_record.editions.flat_map(&:document_ids).uniq
+
+        document_ids.each do |document_id|
+          editions = SpecialistDocumentEdition.where(document_id: document_id)
+          edition = editions.last
+
+          begin
+            puts "Redirecting content item '/#{edition.slug}' to '/#{manual_slug}'"
+            publishing_api.unpublish(edition.document_id,
+                                     type: "redirect",
+                                     alternative_path: "/#{manual_slug}",
+                                     discard_drafts: true)
+          rescue GdsApi::HTTPNotFound
+            puts "Content item with content_id #{document_id} not present in the publishing API"
+          end
+
+          # Destroy all the editons of this manual as it's going away
+          editions.map(&:destroy)
+        end
+      end
+
+      # Destroy the manual record
+      puts "Destroying manual #{manual_record._id}"
+      manual_record.destroy
+    end
+  end
+
+  def self.reslug(old_slug, new_slug)
+    hca_manual_record = ManualRecord.find_by(slug: old_slug)
+
+    # Reslug the manual sections
+    hca_document_ids = hca_manual_record.editions.flat_map(&:document_ids).uniq
+    hca_document_ids.each do |document_id|
+      sections = SpecialistDocumentEdition.where(document_id: document_id)
+      sections.each do |section|
+        reslug_msg = "Reslugging section '#{section.slug}'"
+        section.slug.gsub!(old_slug, new_slug)
+        puts "#{reslug_msg} as '#{section.slug}'"
+        section.save!
+      end
+    end
+
+    # Reslug the manual
+    reslug_msg = "Reslugging manual '#{hca_manual_record.slug}'"
+    new_slug = hca_manual_record.slug.gsub(old_slug, new_slug)
+    puts "#{reslug_msg} as '#{new_slug}'"
+
+    hca_manual_record.set(:slug, new_slug)
+
+    # Clean up manual sections belonging to the temporary manual path
+    hca_document_ids = hca_manual_record.editions.flat_map(&:document_ids).uniq
+    hca_document_ids.each do |document_id|
+      puts "Redirecting #{document_id} to '/#{new_slug}'"
+      publishing_api.unpublish(document_id,
+                               type: "redirect",
+                               alternative_path: "/#{new_slug}",
+                               discard_drafts: true)
+    end
+
+    # Clean up the drafted manual in the Publishing API
+    puts "Redirecting #{hca_manual_record.manual_id} to '/#{new_slug}'"
+    publishing_api.unpublish(hca_manual_record.manual_id,
+                             type: "redirect",
+                             alternative_path: "/#{new_slug}",
+                             discard_drafts: true)
+  end
+
+  def self.publishing_api
+    ManualsPublisherWiring.get(:publishing_api_v2)
+  end
+end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -37,6 +37,9 @@ private
         end
       end
 
+      puts "Destroying old PublicationLogs for #{manual_record.slug}"
+      PublicationLog.change_notes_for(manual_record.slug).each { |log| log.destroy }
+
       # Destroy the manual record
       puts "Destroying manual #{manual_record._id}"
       manual_record.destroy
@@ -64,6 +67,13 @@ private
     puts "#{reslug_msg} as '#{new_slug}'"
 
     hca_manual_record.set(:slug, new_slug)
+
+    # Reslug the existing publication logs
+    puts "Reslugging publication logs for #{old_slug} to #{new_slug}"
+    PublicationLog.change_notes_for(old_slug).each do |publication_log|
+      publication_log.set(:slug, publication_log.slug.gsub(old_slug, new_slug))
+    end
+    puts PublicationLog.change_notes_for(new_slug).inspect
 
     # Clean up manual sections belonging to the temporary manual path
     hca_document_ids = hca_manual_record.editions.flat_map(&:document_ids).uniq

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -45,13 +45,13 @@ describe ManualRelocator do
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }
-    let!(:existing_section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/existing_section_1", document_id: "12345") }
-    let!(:existing_section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/existing_section_2", document_id: "23456") }
-    let!(:temporary_section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_1", document_id: "abcdef") }
-    let!(:temporary_section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg") }
+    let!(:existing_section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/existing_section_1", document_id: "12345", version_number: 1, state: "published") }
+    let!(:existing_section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/existing_section_2", document_id: "23456", version_number: 1, state: "published") }
+    let!(:temporary_section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_1", document_id: "abcdef", version_number: 1, state: "published") }
+    let!(:temporary_section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg", version_number: 1, state: "published") }
 
-    let!(:existing_section_3) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/section_3", document_id: "34567") }
-    let!(:temporary_section_3) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/section_3", document_id: "cdefgh") }
+    let!(:existing_section_3) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/section_3", document_id: "34567", version_number: 1, state: "published") }
+    let!(:temporary_section_3) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/section_3", document_id: "cdefgh", version_number: 1, state: "published") }
 
     let!(:existing_publication_log) { FactoryGirl.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
     let!(:temporary_publication_log) { FactoryGirl.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }
@@ -100,108 +100,228 @@ describe ManualRelocator do
 
     context "for valid manuals" do
       before do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
 
         organisations_api_has_organisation(temp_manual.organisation_slug)
+        stub_any_publishing_api_publish
         stub_any_publishing_api_unpublish
         stub_any_publishing_api_put_content
-        subject.move!
       end
 
-      it "destroys the existing manual" do
-        expect {
-          existing_manual.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+      shared_examples_for "removing the existing manual" do
+        it "destroys the existing manual" do
+          expect {
+            existing_manual.reload
+          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        end
+
+        it "unpublishes the existing manual with a gone" do
+          assert_publishing_api_unpublish(existing_manual_id,
+                                          type: "gone",
+                                          discard_drafts: true)
+        end
+
+        it "unpublishes the existing manual's sections with redirects to the existing slug" do
+          assert_publishing_api_unpublish(existing_section_1.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}",
+                                          discard_drafts: true)
+
+          assert_publishing_api_unpublish(existing_section_2.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}",
+                                          discard_drafts: true)
+        end
+
+        it "issues a gone for existing manual's sections that would be reused one of the new manual's sections" do
+          assert_publishing_api_unpublish(existing_section_3.document_id,
+                                          type: "gone",
+                                          discard_drafts: true)
+        end
+
+        it "destroys the existing manual's sections" do
+          expect {
+            existing_section_1.reload
+          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+
+          expect {
+            existing_section_2.reload
+          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+
+          expect {
+            existing_section_3.reload
+          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        end
+
+        it "removes the publication logs for the existing manual" do
+          expect { existing_publication_log.reload }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        end
+
       end
 
-      it "moves the temporary manual to the existing slug" do
-        expect(temp_manual.reload.slug).to eq(existing_slug)
-        expect(ManualRecord.where(slug: temp_slug).count).to be(0)
+      context "when the temp manual has no draft" do
+        before do
+          temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+          subject.move!
+        end
+
+        it_behaves_like "removing the existing manual"
+
+        it "moves the temporary manual to the existing slug" do
+          expect(temp_manual.reload.slug).to eq(existing_slug)
+          expect(ManualRecord.where(slug: temp_slug).count).to be(0)
+        end
+
+        it "unpublishes the temporary manual with a redirect to the existing slug" do
+          assert_publishing_api_unpublish(temp_manual_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}",
+                                          discard_drafts: true)
+        end
+
+        it "moves the temporary manual's sections to the existing slug" do
+          expect(temporary_section_1.reload.slug).to eq("#{existing_slug}/temp_section_1")
+          expect(temporary_section_2.reload.slug).to eq("#{existing_slug}/temp_section_2")
+          expect(temporary_section_3.reload.slug).to eq("#{existing_slug}/section_3")
+          expect(SpecialistDocumentEdition.where(slug: /#{temp_slug}/).count).to be(0)
+        end
+
+        it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
+          assert_publishing_api_unpublish(temporary_section_1.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}/temp_section_1",
+                                          discard_drafts: true)
+
+          assert_publishing_api_unpublish(temporary_section_2.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}/temp_section_2",
+                                          discard_drafts: true)
+
+          assert_publishing_api_unpublish(temporary_section_3.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}/section_3",
+                                          discard_drafts: true)
+        end
+
+        it "sends a new draft of the temporary manual with the existing slug as a route" do
+          assert_publishing_api_put_content(temp_manual_id, with_route_matcher("/#{existing_slug}"))
+        end
+
+        it "sends a publish request for the temporary manual" do
+          assert_publishing_api_publish(temp_manual_id)
+        end
+
+        it "sends a new draft of each of the temporary manual's sections with the existing slug version of their path as a route" do
+          assert_publishing_api_put_content(temporary_section_1.document_id, with_route_matcher("/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.document_id, with_route_matcher("/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_3.document_id, with_route_matcher("/#{existing_slug}/section_3"))
+        end
+
+        it "sends a publish request for each of the temporary manual's sections" do
+          assert_publishing_api_publish(temporary_section_1.document_id)
+          assert_publishing_api_publish(temporary_section_2.document_id)
+          assert_publishing_api_publish(temporary_section_3.document_id)
+        end
       end
 
-      it "unpublishes the temporary manual with a redirect to the existing slug" do
-        assert_publishing_api_unpublish(temp_manual_id,
-                                        type: "redirect",
-                                        alternative_path: "/#{existing_slug}",
-                                        discard_drafts: true)
+      context "when the temp manual has a draft" do
+        let!(:temporary_section_1_v2) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_1", document_id: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
+        let!(:temporary_section_2_v2) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
+
+        before do
+          temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
+          temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), state: "draft", version_number: 2, body: "This is in draft")
+          subject.move!
+        end
+
+        it_behaves_like "removing the existing manual"
+
+        it "moves the temporary manual to the existing slug" do
+          expect(temp_manual.reload.slug).to eq(existing_slug)
+          expect(ManualRecord.where(slug: temp_slug).count).to be(0)
+        end
+
+        it "unpublishes the temporary manual with a redirect to the existing slug" do
+          assert_publishing_api_unpublish(temp_manual_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}",
+                                          discard_drafts: true)
+        end
+
+        it "moves the temporary manual's sections to the existing slug" do
+          expect(temporary_section_1.reload.slug).to eq("#{existing_slug}/temp_section_1")
+          expect(temporary_section_2.reload.slug).to eq("#{existing_slug}/temp_section_2")
+          expect(temporary_section_3.reload.slug).to eq("#{existing_slug}/section_3")
+          expect(SpecialistDocumentEdition.where(slug: /#{temp_slug}/).count).to be(0)
+        end
+
+        it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
+          assert_publishing_api_unpublish(temporary_section_1.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}/temp_section_1",
+                                          discard_drafts: true)
+
+          assert_publishing_api_unpublish(temporary_section_2.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}/temp_section_2",
+                                          discard_drafts: true)
+
+          assert_publishing_api_unpublish(temporary_section_3.document_id,
+                                          type: "redirect",
+                                          alternative_path: "/#{existing_slug}/section_3",
+                                          discard_drafts: true)
+        end
+
+        it "sends a draft of the published version of the temporary manual with the existing slug as a route" do
+          assert_publishing_api_put_content(temp_manual_id, with_body_and_route_matcher("This has been published", "/#{existing_slug}"))
+        end
+
+        it "sends a publish request for the published version of the temporary manual" do
+          assert_publishing_api_publish(temp_manual_id)
+        end
+
+        it "sends a draft of the draft version of the temporary manual with the existing slug as a route" do
+          assert_publishing_api_put_content(temp_manual_id, with_body_and_route_matcher("This is in draft", "/#{existing_slug}"))
+        end
+
+        it "sends a draft of each of the temporary manual's published sections with the existing slug version of their path as a route" do
+          assert_publishing_api_put_content(temporary_section_1.document_id, with_body_and_route_matcher(temporary_section_1.body, "/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.document_id, with_body_and_route_matcher(temporary_section_2.body, "/#{existing_slug}/temp_section_2"))
+        end
+
+        it "sends a publish request for each of the temporary manual's published sections" do
+          assert_publishing_api_publish(temporary_section_1.document_id)
+          assert_publishing_api_publish(temporary_section_2.document_id)
+        end
+
+        it "does not send a publish request for any section only present in the new draft" do
+          assert_publishing_api_publish(temporary_section_3.document_id, nil, 0)
+        end
+
+        it "sends a draft of each of the temporary manual's draft sections with the existing slug version of their path as a route" do
+          assert_publishing_api_put_content(temporary_section_1.document_id, with_body_and_route_matcher(temporary_section_1_v2.body, "/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.document_id, with_body_and_route_matcher(temporary_section_2_v2.body, "/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_3.document_id, with_body_and_route_matcher(temporary_section_3.body, "/#{existing_slug}/section_3"))
+        end
       end
+    end
+  end
 
-      it "unpublishes the existing manual with a gone" do
-        assert_publishing_api_unpublish(existing_manual_id,
-                                        type: "gone",
-                                        discard_drafts: true)
-      end
+  def with_body_matcher(body)
+    ->(request) do
+      data = JSON.parse(request.body)
+      unrendered_body = data["details"]["body"].detect { |body| body["content_type"] == "text/govspeak" }
+      (unrendered_body && unrendered_body["content"] == body)
+    end
+  end
 
-      it "unpublishes the existing manual's sections with redirects to the existing slug" do
-        assert_publishing_api_unpublish(existing_section_1.document_id,
-                                        type: "redirect",
-                                        alternative_path: "/#{existing_slug}",
-                                        discard_drafts: true)
-
-        assert_publishing_api_unpublish(existing_section_2.document_id,
-                                        type: "redirect",
-                                        alternative_path: "/#{existing_slug}",
-                                        discard_drafts: true)
-      end
-
-      it "issues a gone for existing manual's sections that would be reused one of the new manual's sections" do
-        assert_publishing_api_unpublish(existing_section_3.document_id,
-                                        type: "gone",
-                                        discard_drafts: true)
-      end
-
-      it "destroys the existing manual's sections" do
-        expect {
-          existing_section_1.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
-
-        expect {
-          existing_section_2.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
-
-        expect {
-          existing_section_3.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
-      end
-
-      it "moves the temporary manual's sections to the existing slug" do
-        expect(temporary_section_1.reload.slug).to eq("#{existing_slug}/temp_section_1")
-        expect(temporary_section_2.reload.slug).to eq("#{existing_slug}/temp_section_2")
-        expect(temporary_section_3.reload.slug).to eq("#{existing_slug}/section_3")
-        expect(SpecialistDocumentEdition.where(slug: /#{temp_slug}/).count).to be(0)
-      end
-
-      it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
-        assert_publishing_api_unpublish(temporary_section_1.document_id,
-                                        type: "redirect",
-                                        alternative_path: "/#{existing_slug}/temp_section_1",
-                                        discard_drafts: true)
-
-        assert_publishing_api_unpublish(temporary_section_2.document_id,
-                                        type: "redirect",
-                                        alternative_path: "/#{existing_slug}/temp_section_2",
-                                        discard_drafts: true)
-
-        assert_publishing_api_unpublish(temporary_section_3.document_id,
-                                        type: "redirect",
-                                        alternative_path: "/#{existing_slug}/section_3",
-                                        discard_drafts: true)
-      end
-
-      it "removes the publication logs for the existing manual" do
-        expect { existing_publication_log.reload }.to raise_error(Mongoid::Errors::DocumentNotFound)
-      end
-
-      it "sends a new draft of the temporary manual with the existing slug as a route" do
-        assert_publishing_api_put_content(temp_manual_id, with_route_matcher("/#{existing_slug}"))
-      end
-
-      it "sends a new draft of each of the temporary manual's sections with the existing slug version of their path as a route" do
-        assert_publishing_api_put_content(temporary_section_1.document_id, with_route_matcher("/#{existing_slug}/temp_section_1"))
-        assert_publishing_api_put_content(temporary_section_2.document_id, with_route_matcher("/#{existing_slug}/temp_section_2"))
-        assert_publishing_api_put_content(temporary_section_3.document_id, with_route_matcher("/#{existing_slug}/section_3"))
-      end
+  def with_body_and_route_matcher(body, path)
+    ->(request) do
+      data = JSON.parse(request.body)
+      routes = data["routes"]
+      unrendered_body = data["details"]["body"].detect { |body| body["content_type"] == "text/govspeak" }
+      (unrendered_body && unrendered_body["content"] == body) &&
+      ((data["base_path"] == path) && (routes.any? { |route| route["path"] == path }))
     end
   end
 

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -49,13 +49,16 @@ describe ManualRelocator do
     let!(:temporary_section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_1", document_id: "abcdef") }
     let!(:temporary_section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg") }
 
+    let!(:existing_section_3) { FactoryGirl.create(:specialist_document_edition, slug: "#{existing_slug}/section_3", document_id: "34567") }
+    let!(:temporary_section_3) { FactoryGirl.create(:specialist_document_edition, slug: "#{temp_slug}/section_3", document_id: "cdefgh") }
+
     let!(:existing_publication_log) { FactoryGirl.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
     let!(:temporary_publication_log) { FactoryGirl.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }
 
     before do
       allow(STDOUT).to receive(:puts)
-      existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456))
-      temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg))
+      existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567))
+      temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh))
       stub_any_publishing_api_unpublish
       subject.move!
     end
@@ -78,6 +81,12 @@ describe ManualRelocator do
                                       discard_drafts: true)
     end
 
+    it "unpublishes the existing manual with a gone" do
+      assert_publishing_api_unpublish(existing_manual_id,
+                                      type: "gone",
+                                      discard_drafts: true)
+    end
+
     it "unpublishes the existing manual's sections with redirects to the existing slug" do
       assert_publishing_api_unpublish(existing_section_1.document_id,
                                       type: "redirect",
@@ -90,6 +99,12 @@ describe ManualRelocator do
                                       discard_drafts: true)
     end
 
+    it "issues a gone for existing manual's sections that would be reused one of the new manual's sections" do
+      assert_publishing_api_unpublish(existing_section_3.document_id,
+                                      type: "gone",
+                                      discard_drafts: true)
+    end
+
     it "destroys the existing manual's sections" do
       expect {
         existing_section_1.reload
@@ -98,11 +113,16 @@ describe ManualRelocator do
       expect {
         existing_section_2.reload
       }.to raise_error(Mongoid::Errors::DocumentNotFound)
+
+      expect {
+        existing_section_3.reload
+      }.to raise_error(Mongoid::Errors::DocumentNotFound)
     end
 
     it "moves the temporary manual's sections to the existing slug" do
       expect(temporary_section_1.reload.slug).to eq("#{existing_slug}/temp_section_1")
       expect(temporary_section_2.reload.slug).to eq("#{existing_slug}/temp_section_2")
+      expect(temporary_section_3.reload.slug).to eq("#{existing_slug}/section_3")
       expect(SpecialistDocumentEdition.where(slug: /#{temp_slug}/).count).to be(0)
     end
 
@@ -115,6 +135,11 @@ describe ManualRelocator do
       assert_publishing_api_unpublish(temporary_section_2.document_id,
                                       type: "redirect",
                                       alternative_path: "/#{existing_slug}/temp_section_2",
+                                      discard_drafts: true)
+
+      assert_publishing_api_unpublish(temporary_section_3.document_id,
+                                      type: "redirect",
+                                      alternative_path: "/#{existing_slug}/section_3",
                                       discard_drafts: true)
     end
 

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require "manual_relocator"
+
+describe ManualRelocator do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  describe ".move" do
+    let(:existing_manual_id) { SecureRandom.uuid }
+    let(:temp_manual_id) { SecureRandom.uuid }
+    let(:existing_slug) { "guidance/real-slug" }
+    let(:temp_slug) { "guidance/temporary-slug" }
+    let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug) }
+    let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug) }
+    let!(:existing_section_1) { FactoryGirl.create(:specialist_document_edition, document_id: "12345") }
+    let!(:existing_section_2) { FactoryGirl.create(:specialist_document_edition, document_id: "23456") }
+    let!(:temporary_section_1) { FactoryGirl.create(:specialist_document_edition, document_id: "abcdef") }
+    let!(:temporary_section_2) { FactoryGirl.create(:specialist_document_edition, document_id: "bcdefg") }
+
+    before do
+      allow(STDOUT).to receive(:puts)
+      existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456))
+      temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg))
+      stub_any_publishing_api_unpublish
+      ManualRelocator.move(temp_slug, existing_slug)
+    end
+
+    it "moves a manual from one slug to another" do
+      expect(temp_manual.reload.slug).to eq(existing_slug)
+      expect(ManualRecord.where(slug: temp_slug).count).to be(0)
+    end
+
+    it "unpublishes the temporary manual" do
+      assert_publishing_api_unpublish(temp_manual_id,
+                                      type: "redirect",
+                                      alternative_path: "/#{existing_slug}",
+                                      discard_drafts: true)
+    end
+
+    it "redirects existing manual section paths" do
+      assert_publishing_api_unpublish(existing_section_1.document_id,
+                                      type: "redirect",
+                                      alternative_path: "/#{existing_slug}",
+                                      discard_drafts: true)
+
+      assert_publishing_api_unpublish(existing_section_2.document_id,
+                                      type: "redirect",
+                                      alternative_path: "/#{existing_slug}",
+                                      discard_drafts: true)
+    end
+
+    it "redirects temporary manual section paths" do
+      assert_publishing_api_unpublish(temporary_section_1.document_id,
+                                      type: "redirect",
+                                      alternative_path: "/#{existing_slug}",
+                                      discard_drafts: true)
+
+      assert_publishing_api_unpublish(temporary_section_2.document_id,
+                                      type: "redirect",
+                                      alternative_path: "/#{existing_slug}",
+                                      discard_drafts: true)
+
+    end
+  end
+end

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -115,10 +115,23 @@ describe ManualRelocator do
           }.to raise_error(Mongoid::Errors::DocumentNotFound)
         end
 
-        it "unpublishes the existing manual with a gone" do
-          assert_publishing_api_unpublish(existing_manual_id,
-                                          type: "gone",
-                                          discard_drafts: true)
+        it "replaces the existing manual with a gone item" do
+          gone_object = {
+            base_path: "/#{existing_slug}",
+            content_id: existing_manual_id,
+            document_type: "gone",
+            publishing_app: "manuals-publisher",
+            schema_name: "gone",
+            routes: [
+              {
+                path: "/#{existing_slug}",
+                type: "exact"
+              }
+            ]
+          }
+
+          assert_publishing_api_put_content(existing_manual_id, request_json_matches(gone_object))
+          assert_publishing_api_publish(existing_manual_id)
         end
 
         it "unpublishes the existing manual's sections with redirects to the existing slug" do
@@ -134,9 +147,22 @@ describe ManualRelocator do
         end
 
         it "issues a gone for existing manual's sections that would be reused one of the new manual's sections" do
-          assert_publishing_api_unpublish(existing_section_3.document_id,
-                                          type: "gone",
-                                          discard_drafts: true)
+          gone_object = {
+            base_path: "/#{existing_section_3.slug}",
+            content_id: existing_section_3.document_id,
+            document_type: "gone",
+            publishing_app: "manuals-publisher",
+            schema_name: "gone",
+            routes: [
+              {
+                path: "/#{existing_section_3.slug}",
+                type: "exact"
+              }
+            ]
+          }
+
+          assert_publishing_api_put_content(existing_section_3.document_id, request_json_matches(gone_object))
+          assert_publishing_api_publish(existing_section_3.document_id)
         end
 
         it "destroys the existing manual's sections" do

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -109,12 +109,12 @@ describe ManualRelocator do
     it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
       assert_publishing_api_unpublish(temporary_section_1.document_id,
                                       type: "redirect",
-                                      alternative_path: "/#{existing_slug}",
+                                      alternative_path: "/#{existing_slug}/temp_section_1",
                                       discard_drafts: true)
 
       assert_publishing_api_unpublish(temporary_section_2.document_id,
                                       type: "redirect",
-                                      alternative_path: "/#{existing_slug}",
+                                      alternative_path: "/#{existing_slug}/temp_section_2",
                                       discard_drafts: true)
     end
 


### PR DESCRIPTION
https://trello.com/c/EQScfnzQ/712-delete-rename-hca-manual

to `guidance/capital-funding-guide`
This moving the existing manual out of the way then changing the slug of the manual we wish to move.