### PR TITLE
No minor manual publication logs

### DIFF
--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -38,6 +38,8 @@ class SpecialistDocumentEdition
   scope :published,           where(state: "published")
   scope :archived,            where(state: "archived")
 
+  scope :with_slug_prefix, ->(slug) { where(slug: /^#{slug}.*/) }
+
   index "document_id"
   index "state"
   index "updated_at"

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -48,6 +48,7 @@ private
     ->(manual, _: nil) {
       manual.documents.each do |doc|
         next unless doc.needs_exporting?
+        next if doc.minor_update?
 
         PublicationLog.create!(
           title: doc.title,

--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -12,7 +12,11 @@ class DocumentAssociationMarshaller
     }
 
     removed_docs = Array(record.removed_document_ids).map { |doc_id|
-      document_repository.fetch(doc_id)
+      begin
+        document_repository.fetch(doc_id)
+      rescue KeyError
+        raise RemovedDocumentIdNotFoundError, "No document found for ID #{doc_id}"
+      end
     }
 
     decorator.call(manual, documents: docs, removed_documents: removed_docs)
@@ -37,4 +41,6 @@ class DocumentAssociationMarshaller
 
 private
   attr_reader :manual_specific_document_repository_factory, :decorator
+
+  class RemovedDocumentIdNotFoundError < StandardError; end
 end

--- a/bin/rebuild_major_publication_logs_for_manuals
+++ b/bin/rebuild_major_publication_logs_for_manuals
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../config/environment", __FILE__)
+require "logger"
+
+logger = Logger.new(STDOUT)
+logger.formatter = Logger::Formatter.new
+
+manual_publication_log_filter = ManualPublicationLogFilter.new
+
+manual_records = ManualRecord.all
+count = manual_record.count
+
+logger.info "Deleting publication logs and rebuilding for major updates only for #{count} manuals"
+
+manual_records.each.with_index(1) do |manual, i|
+  logger.info("[% 3d/% 3d] id=%s slug=%s" % [i, count, manual.id, manual.slug])
+  manual_publication_log_filter.delete_logs_and_rebuild_for_major_updates_only!(manual.slug)
+end
+
+logger.info "Rebuilding of publication logs complete."

--- a/bin/republish_manuals
+++ b/bin/republish_manuals
@@ -9,13 +9,22 @@ logger.formatter = Logger::Formatter.new
 
 repository = ManualsPublisherWiring.get(:repository_registry).manual_repository
 
-count = repository.all.count
+begin
+  count = repository.all.count
+rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError
+  count = "?"
+end
 
 logger.info "Republishing #{count} manuals..."
 
 repository.all.each.with_index do |manual, i|
-  logger.info("[% 3d/% 3d] id=%s slug=%s" % [i + 1, count, manual.id, manual.slug])
-  ManualServiceRegistry.new.republish(manual.id).call
+  begin
+    logger.info("[ #{i} / #{count} ] id=#{manual.id} slug=#{manual.slug}]")
+    ManualServiceRegistry.new.republish(manual.id).call
+  rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError => e
+    logger.error("Did not publish manual with id=#{manual.id} slug=#{manual.slug}. It has at least one removed document which was not found: #{e.message}")
+    next
+  end
 end
 
 logger.info "Republishing of #{count} manuals complete."

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -1,0 +1,22 @@
+class ManualPublicationLogFilter
+  def delete_logs_and_rebuild_for_major_updates_only!(slug)
+    PublicationLog.with_slug_prefix(slug).destroy_all
+
+    document_editions_for_rebuild(slug).each do |edition|
+      PublicationLog.create!(
+        title: edition.title,
+        slug: edition.slug,
+        version_number: edition.version_number,
+        change_note: edition.change_note,
+        created_at: edition.exported_at,
+        updated_at: edition.exported_at
+      )
+    end
+  end
+
+  private
+
+  def document_editions_for_rebuild(slug)
+    SpecialistDocumentEdition.with_slug_prefix(slug).where(:minor_update.nin => [true]).any_of({state: "published"}, {state: "archived"})
+  end
+end

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+require "sidekiq/testing"
+
+RSpec.describe "Republishing manuals", type: :feature do
+  before do
+    Sidekiq::Testing.inline!
+    login_as(:generic_editor)
+    stub_organisation_details(GDS::SSO.test_user.organisation_slug)
+  end
+
+  let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
+
+  def manual_repository
+    ManualsPublisherWiring.get(:repository_registry).manual_repository
+  end
+
+  describe "publishing a manual with major and minor updates" do
+    before do
+      manual = create_manual_without_ui(manual_fields)
+
+      @documents = [].tap do |documents|
+        documents << create_manual_document_without_ui(manual, { title: "Section 1 major", summary: "Section 1 summary", body: "Section body" })
+        documents << create_manual_document_without_ui(manual, { title: "Section 1", summary: "Section 1 minor summary", body: "Section body minor update", minor_update: true })
+      end
+
+      # Re-fetch manual to include documents
+      @manual = manual_repository.fetch(manual.id)
+
+      publish_manual_without_ui(@manual)
+    end
+
+    it "sends the manual and the sections to the Publishing API" do
+      @documents.each do |document|
+        check_manual_and_documents_were_published(@manual, document, manual_fields, document_fields(document))
+      end
+    end
+
+    it "creates publication logs for major updates to documents only" do
+      expect(PublicationLog.count).to eq 1
+      expect(PublicationLog.first.title).to eq "Section 1 major"
+    end
+  end
+end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+require "manual_publication_log_filter"
+
+describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_updates_only!" do
+  let(:manual_slug) { "guidance/the-highway-code" }
+  let(:other_slug) { "guidance/sellotape" }
+  let(:exported_time) { Time.current }
+
+  let!(:published_major_update_document_edition) do
+    create(:specialist_document_edition,
+           state: "published",
+           slug: "#{manual_slug}/further-info",
+           exported_at: exported_time - 1.day
+          )
+  end
+
+  let!(:archived_major_update_document_edition) do
+    create(:specialist_document_edition,
+           state: "archived",
+           slug: "#{manual_slug}/additional-data",
+           exported_at: exported_time - 2.days
+          )
+  end
+
+  let!(:draft_major_update_document_edition) do
+    create(:specialist_document_edition,
+           state: "draft",
+           slug: "#{manual_slug}/draft-info",
+           exported_at: exported_time - 3.days
+          )
+  end
+
+  let!(:published_minor_update_document_edition) do
+    create(:specialist_document_edition,
+           state: "published",
+           slug: "#{manual_slug}/further-info",
+           minor_update: true
+          )
+  end
+
+  let!(:previous_publication_logs) { create_list(:publication_log, 2, slug: manual_slug) }
+  let!(:previous_other_publication_log) { create :publication_log, slug: other_slug }
+
+  before do
+    subject.delete_logs_and_rebuild_for_major_updates_only!(manual_slug)
+  end
+
+  it "deletes all existing publication logs for the supplied manual slug only" do
+    expect(PublicationLog.where(_id: previous_publication_logs.first.id).exists?).to eq false
+    expect(PublicationLog.where(_id: previous_publication_logs.second.id).exists?).to eq false
+
+    expect(PublicationLog.where(_id: previous_other_publication_log.id).exists?).to eq true
+  end
+
+  it "builds logs for major updates in the 'archived' and 'published' status only" do
+    publication_logs_for_supplied_slug = PublicationLog.with_slug_prefix(manual_slug)
+
+    expect(publication_logs_for_supplied_slug.count).to eq 2
+
+    expect_log_attributes_to_match_edition(PublicationLog.where(slug: published_major_update_document_edition.slug).first, published_major_update_document_edition)
+    expect_log_attributes_to_match_edition(PublicationLog.where(slug: archived_major_update_document_edition.slug).first, archived_major_update_document_edition)
+  end
+
+  def expect_log_attributes_to_match_edition(log, edition)
+    expect(log).to have_attributes(
+      slug: edition.slug,
+      title: edition.title,
+      version_number: edition.version_number,
+      change_note: edition.change_note,
+      created_at: edition.exported_at,
+      updated_at: edition.exported_at
+    )
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -53,4 +53,11 @@ FactoryGirl.define do
     editions {"s"}
     initialize_with { new(slug_generator, id, editions) }
   end
+
+  factory :publication_log do
+    sequence(:slug) { |n| "test-publication-log-#{n}" }
+    sequence(:title) { |n| "Test Publication Log #{n}" }
+    version_number { [1, 2, 3].sample }
+    sequence(:change_note) { |n| "Change note #{n}" }
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/x6vSw5LM/55-update-history)

Minor manual changes intermingled with major ones are confusing to users.

This PR prevents minor updates from creating publication logs for manuals, and also implements a script for rebuilding all historical logs to exclude minor updates.

Previously reviewed as https://github.com/alphagov/manuals-publisher/pull/764