### PR TITLE
Fix republish script issues

### DIFF
--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -113,7 +113,7 @@ private
           entity: document,
         ).call
 
-        document.mark_as_exported_to_live_publishing_api!
+        document.mark_as_exported_to_live_publishing_api! if action != :republish
       end
     }
   end

--- a/bin/republish_manuals
+++ b/bin/republish_manuals
@@ -7,22 +7,17 @@ require "logger"
 logger = Logger.new(STDOUT)
 logger.formatter = Logger::Formatter.new
 
-repository = ManualsPublisherWiring.get(:repository_registry).manual_repository
-
-begin
-  count = repository.all.count
-rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError
-  count = "?"
-end
+manual_records = ManualRecord.all
+count = manual_records.count
 
 logger.info "Republishing #{count} manuals..."
 
-repository.all.each.with_index do |manual, i|
+manual_records.to_a.each.with_index do |manual_record, i|
   begin
-    logger.info("[ #{i} / #{count} ] id=#{manual.id} slug=#{manual.slug}]")
-    ManualServiceRegistry.new.republish(manual.id).call
+    logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
+    ManualServiceRegistry.new.republish(manual_record.manual_id).call
   rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError => e
-    logger.error("Did not publish manual with id=#{manual.id} slug=#{manual.slug}. It has at least one removed document which was not found: #{e.message}")
+    logger.error("Did not publish manual with id=#{manual_record.manual_id} slug=#{manual_record.slug}. It has at least one removed document which was not found: #{e.message}")
     next
   end
 end

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -2,7 +2,10 @@ class ManualPublicationLogFilter
   def delete_logs_and_rebuild_for_major_updates_only!(slug)
     PublicationLog.with_slug_prefix(slug).destroy_all
 
-    document_editions_for_rebuild(slug).each do |edition|
+    manual_record = ManualRecord.where(slug: slug).first
+    edition_ordering = EditionOrdering.new(document_editions_for_rebuild(slug), manual_record.latest_edition.document_ids)
+
+    edition_ordering.sort_by_document_ids_and_created_at.each do |edition|
       PublicationLog.create!(
         title: edition.title,
         slug: edition.slug,
@@ -11,6 +14,31 @@ class ManualPublicationLogFilter
         created_at: edition.exported_at || edition.updated_at,
         updated_at: edition.exported_at || edition.updated_at
       )
+    end
+  end
+
+  class EditionOrdering
+    def initialize(editions, document_ids)
+      @editions = editions
+      @document_ids = document_ids
+    end
+
+    def sort_by_document_ids_and_created_at
+      editions_not_matching_supplied_documents = @editions.where(:document_id.nin => @document_ids)
+      editions_matching_supplied_documents = @editions.where(:document_id.in => @document_ids)
+
+      order_by_document_ids(editions_matching_supplied_documents).concat(editions_not_matching_supplied_documents.order_by(:created_at, :asc).to_a)
+    end
+
+    private
+
+    def order_by_document_ids(editions)
+      editions.to_a.sort do |a, b|
+        a_index = @document_ids.index(a.document_id)
+        b_index = @document_ids.index(b.document_id)
+
+        a_index <=> b_index
+      end
     end
   end
 

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -8,8 +8,8 @@ class ManualPublicationLogFilter
         slug: edition.slug,
         version_number: edition.version_number,
         change_note: edition.change_note,
-        created_at: edition.exported_at,
-        updated_at: edition.exported_at
+        created_at: edition.exported_at || edition.updated_at,
+        updated_at: edition.exported_at || edition.updated_at
       )
     end
   end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -3,16 +3,9 @@ require "manual_publication_log_filter"
 
 describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_updates_only!" do
   let(:manual_slug) { "guidance/the-highway-code" }
+  let!(:manual_record) { ManualRecord.create(slug: manual_slug) }
   let(:other_slug) { "guidance/sellotape" }
   let(:exported_time) { Time.current }
-
-  let!(:published_major_update_document_edition) do
-    create(:specialist_document_edition,
-           state: "published",
-           slug: "#{manual_slug}/further-info",
-           exported_at: exported_time - 1.day
-          )
-  end
 
   let!(:archived_major_update_document_edition) do
     create(:specialist_document_edition,
@@ -33,8 +26,24 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   let!(:published_minor_update_document_edition) do
     create(:specialist_document_edition,
            state: "published",
-           slug: "#{manual_slug}/further-info",
+           slug: "#{manual_slug}/first-further-info",
            minor_update: true
+          )
+  end
+
+  let!(:published_major_update_document_edition_1) do
+    create(:specialist_document_edition,
+           state: "published",
+           slug: "#{manual_slug}/first-further-info",
+           exported_at: exported_time - 1.day
+          )
+  end
+
+  let!(:published_major_update_document_edition_2) do
+    create(:specialist_document_edition,
+           state: "published",
+           slug: "#{manual_slug}/second-further-info",
+           exported_at: exported_time - 1.day
           )
   end
 
@@ -42,6 +51,26 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   let!(:previous_other_publication_log) { create :publication_log, slug: other_slug }
 
   before do
+    manual_record.editions.create!(
+      state: "published",
+      version_number: 1,
+      document_ids: [
+        published_major_update_document_edition_1.document_id,
+        archived_major_update_document_edition.document_id,
+        published_major_update_document_edition_2.document_id
+      ]
+    )
+
+    manual_record.editions.create!(
+      state: "published",
+      version_number: 2,
+      document_ids: [
+        published_major_update_document_edition_1.document_id,
+        published_major_update_document_edition_2.document_id,
+        archived_major_update_document_edition.document_id,
+      ]
+    )
+
     subject.delete_logs_and_rebuild_for_major_updates_only!(manual_slug)
   end
 
@@ -52,13 +81,14 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     expect(PublicationLog.where(_id: previous_other_publication_log.id).exists?).to eq true
   end
 
-  it "builds logs for major updates in the 'archived' and 'published' status only" do
-    publication_logs_for_supplied_slug = PublicationLog.with_slug_prefix(manual_slug)
+  it "builds logs for major updates in the 'archived' and 'published' status only in the same order as the documents on the most recent manual" do
+    publication_logs_for_supplied_slug = PublicationLog.with_slug_prefix(manual_slug).order_by(:id, :asc)
 
-    expect(publication_logs_for_supplied_slug.count).to eq 2
+    expect(publication_logs_for_supplied_slug.count).to eq 3
 
-    expect_log_attributes_to_match_edition(PublicationLog.where(slug: published_major_update_document_edition.slug).first, published_major_update_document_edition)
-    expect_log_attributes_to_match_edition(PublicationLog.where(slug: archived_major_update_document_edition.slug).first, archived_major_update_document_edition)
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[0], published_major_update_document_edition_1)
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[1], published_major_update_document_edition_2)
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[2], archived_major_update_document_edition)
   end
 
   def expect_log_attributes_to_match_edition(log, edition)
@@ -70,5 +100,36 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       created_at: edition.exported_at,
       updated_at: edition.exported_at
     )
+  end
+end
+
+describe ManualPublicationLogFilter::EditionOrdering do
+  describe ".sort_by_document_ids_and_created_at" do
+    let!(:edition_in_third_position) { create :specialist_document_edition }
+    let!(:edition_in_first_position) { create :specialist_document_edition }
+    let!(:edition_in_second_position) { create :specialist_document_edition }
+
+    let!(:other_edition_newer) { create :specialist_document_edition, created_at: Time.now - 1.day }
+    let!(:other_edition_older) { create :specialist_document_edition, created_at: Time.now - 1.week }
+
+    let!(:document_ids) {
+      [
+        edition_in_first_position.document_id,
+        edition_in_second_position.document_id,
+        edition_in_third_position.document_id,
+      ]
+    }
+
+    let(:expected_document_order) {
+      document_ids.concat([other_edition_older.document_id, other_edition_newer.document_id])
+    }
+
+    let(:subject) { described_class.new(SpecialistDocumentEdition.all, document_ids) }
+
+    it "returns editions in the supplied document id and created_at order" do
+      ordered_editions = subject.sort_by_document_ids_and_created_at
+
+      expect(ordered_editions.map(&:document_id)).to eq expected_document_order
+    end
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -36,7 +36,7 @@ FactoryGirl.define do
     summary "My summary"
     body "My body"
     document_type "cma_case"
-    document_id "document-id-1"
+    sequence(:document_id) { |n| "document-id-#{n}" }
     extra_fields do
       {
         opened_date: "2013-04-20",


### PR DESCRIPTION
This PR includes a few fixes for the task of rebuilding publication logs and republishing, following  https://github.com/alphagov/manuals-publisher/pull/767