### PR TITLE
Move manual editions to own collection

### DIFF
--- a/db/migrate/20161111135556_move_manual_record_editions_to_own_collection.rb
+++ b/db/migrate/20161111135556_move_manual_record_editions_to_own_collection.rb
@@ -1,0 +1,35 @@
+# The history
+# ===========
+#
+# ManualRecord embeds the editions, however a handful of the manuals have
+# so many editions that they are starting to butt up against the 16Mb document
+# size limit in our versio of mongo.  This means users can't make changes and
+# get strange behaviour from the system.
+#
+# To get around this and keep the API as simple as possible we turn the
+# `embeds_many` association on ManualRecord into a `has_many` association
+# and move all the existing editions out of ManualRecord's collection and
+# into their own collection.
+class MoveManualRecordEditionsToOwnCollection < Mongoid::Migration
+  def self.up
+    manual_records_collection = Mongoid.database.collection("manual_records")
+    manual_record_editions_collection = Mongoid.database.collection("manual_record_editions")
+    manual_records_collection.find.each do |manual_record|
+      editions = manual_record["editions"]
+      puts "Migrating #{editions.count} editions for #{manual_record["manual_id"]}:#{manual_record["slug"]}"
+      editions.each do |edition|
+        edition["manual_record_id"] = manual_record["_id"]
+        edition["manual_id"] = manual_record["manual_id"]
+        manual_record_editions_collection.insert edition
+      end
+    end
+
+    manual_records_collection.update({}, {:'$unset' => {editions: 1}}, multi: true)
+  end
+
+  def self.down
+    # Whilst it would be possible to reverse this, it would be a lot of work
+    # for something that is unlikely to ever get run.
+    raise IrreversibleMigration
+  end
+end

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -16,6 +16,23 @@ describe ManualRecord, hits_db: true do
       it "returns the edition with the highest version number" do
         expect(record.latest_edition.version_number).to eq(3)
       end
+
+      it "returns the most recent new draft even if it hasn't been saved yet" do
+        # make everything published
+        record.editions.each { |e| e.state = "published"; e.save! }
+        # build a new draft
+        new_draft = record.new_or_existing_draft_edition
+        expect(new_draft).not_to be_persisted
+        expect(record.latest_edition).to eq(new_draft)
+      end
+    end
+  end
+
+  context "saving" do
+    it "saves the latest edition if it needs saving" do
+      new_draft = record.new_or_existing_draft_edition
+      record.save!
+      expect(new_draft).to be_persisted
     end
   end
 

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ManualRecord, hits_db: true do
-  subject(:record) { ManualRecord.new }
+  subject(:record) { ManualRecord.create }
 
   describe "#latest_edition" do
     context "when there are several previous editions" do


### PR DESCRIPTION
For: https://trello.com/c/gSCJJpNu/59-amend-text-in-manuals-not-working

We move ManualRecord::Editions from being embedded in the ManualRecord documents to living in their own collection.  This avoids manuals with many editions from hitting the 16Mb document limit in Mongo and not accepting any more changes.

There are some more notes in each commit.  The intention is to run this migration during a deploy; it doesn't take very long (5s for the migration, 10s for the whole `rake db:migrate` process on the dev VM), but the old code and new code/schema are incompatible so we need to turn off the publisher for the duration to avoid losing any edits that occur during the migration.