### PR TITLE
Tighten up PublicationLog#change_notes_for

### DIFF
--- a/app/models/publication_log.rb
+++ b/app/models/publication_log.rb
@@ -12,7 +12,7 @@ class PublicationLog
 
   alias_attribute :published_at, :created_at
 
-  scope :with_slug_prefix, ->(slug) { where(slug: /^#{slug}.*/) }
+  scope :with_slug_prefix, ->(slug) { where(slug: /^#{slug}(\/|$)/) }
 
   def self.change_notes_for(slug)
     with_slug_prefix(slug)

--- a/spec/models/publication_log_spec.rb
+++ b/spec/models/publication_log_spec.rb
@@ -76,6 +76,40 @@ describe PublicationLog, hits_db: true do
         expect(PublicationLog.change_notes_for(slug)).to eq(change_notes_for_first_doc)
       end
 
+      context "and some are for documents with similar slugs" do
+        let!(:similar_slug) { "cma-cases/my-slug-belongs-to-me" }
+
+        let!(:change_note_for_similar_slug) {
+          PublicationLog.create(
+            slug: similar_slug,
+            title: "",
+            change_note: "A similar note",
+            version_number: 1,
+          )
+        }
+
+        it "does not include the notes for the similar slug" do
+          expect(PublicationLog.change_notes_for(slug)).not_to include change_note_for_similar_slug
+        end
+      end
+
+      context "and some are for child documents of the slug" do
+        let!(:child_slug) { "cma-cases/my-slug/my-lovely-document-slug" }
+
+        let!(:change_note_for_child_slug) {
+          PublicationLog.create(
+            slug: child_slug,
+            title: "",
+            change_note: "A child note",
+            version_number: 1,
+          )
+        }
+
+        it "includes the notes for the child" do
+          expect(PublicationLog.change_notes_for(slug)).to include change_note_for_child_slug
+        end
+      end
+
       context "multiple publication logs exist for a particular edition version" do
         before do
           PublicationLog.create(


### PR DESCRIPTION
This method would return all publication logs that had the supplied slug
as a prefix to allow us to get the publication logs for a manual section
at the same time as the publication logs for the manual.  However this
didn't account for manuals whose slugs might be a prefix of another
manual.  For example the manual slug 'guidance/test' is a prefix of the
manual slug 'guidance/test-manual'.  This means when asking for the logs
for 'guidance/test' you would get the logs for both manuals (and all their
sections) which is almost certainly not what you wanted.

We tighten up the regexp used to extract the logs so that the slug is
followed by a / (so we get logs for child sections) or the end of the
string (so we get logs for the manual).

This has happened as there are a handful of manuals whose slugs are a
prefix of another manual, but in practice they're all either withdrawn
or unpublished, so there are no logs.  But it's likely to become a bigger
problem if we don't fix it.