### PR TITLE
Fix url generation to remove extra query string params

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -23,6 +23,10 @@ class Manual
     id
   end
 
+  def eql?(other)
+    id.eql? other.id
+  end
+
   def attributes
     {
       id: id,

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -155,6 +155,10 @@ class SpecialistDocument
     editions.any?(&:persisted?)
   end
 
+  def eql?(other)
+    id.eql?(other.id)
+  end
+
 protected
 
   attr_reader :slug_generator, :edition_factory

--- a/spec/features/manual_urls_spec.rb
+++ b/spec/features/manual_urls_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe "manual urls", type: :feature do
+  before do
+    login_as(:gds_editor)
+  end
+
+  let!(:manual) { create_manual_without_ui(title: "A manual", summary: "A manual summary", body: "A manual body") }
+  let!(:section) { create_manual_document_without_ui(manual, { title: "Section 1", summary: "A section summary", body: "A section body" }) }
+
+  it "should respond with 'OK'" do
+    visit "/manuals"
+
+    expect(page).to have_link("A manual", href: %r{/manuals/#{manual.id}$})
+
+    click_on "A manual"
+
+    expect(page).to have_link("Edit manual", href: %r{/manuals/#{manual.id}/edit$})
+    expect(page).to have_link("Section 1", href: %r{/manuals/#{manual.id}/sections/#{section.id}$})
+
+    click_on "Section 1"
+
+    expect(page).to have_link("Edit section", href: %r{/manuals/#{manual.id}/sections/#{section.id}/edit$})
+  end
+end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -13,10 +13,11 @@ describe Manual do
       organisation_slug: organisation_slug,
       state: state,
       updated_at: updated_at,
+      version_number: 10,
     )
   }
 
-  let(:id) { double(:id) }
+  let(:id) { "0123-4567-89ab-cdef" }
   let(:updated_at) { double(:updated_at) }
   let(:title) { double(:title) }
   let(:summary) { double(:summary) }
@@ -29,6 +30,18 @@ describe Manual do
     expect {
       Manual.new({})
     }.to raise_error
+  end
+
+  describe "#eql?" do
+    it "is considered the same as another manual instance if they have the same id" do
+      expect(manual).to eql(manual)
+      expect(manual).to eql(Manual.new(id: manual.id))
+      expect(manual).not_to eql(Manual.new(id: manual.id.reverse))
+    end
+
+    it "is considered the same as another manual instance with the same id even if the version number is different" do
+      expect(manual).to eql(Manual.new(id: manual.id, version_number: manual.version_number + 1))
+    end
   end
 
   describe "#publish" do
@@ -51,6 +64,16 @@ describe Manual do
     end
   end
 
+  describe "#version_number" do
+    it "comes from the initializer attributes" do
+      expect(manual.version_number).to eq 10
+    end
+
+    it "defaults to 0 if not supplied in the initalizer attributes" do
+      expect(Manual.new(id: "1234-5678").version_number).to eq 0
+    end
+  end
+
   describe "#attributes" do
     it "returns a hash of attributes" do
       expect(manual.attributes).to eq(
@@ -62,7 +85,7 @@ describe Manual do
         organisation_slug: organisation_slug,
         state: state,
         updated_at: updated_at,
-        version_number: 0,
+        version_number: 10,
       )
     end
   end

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -20,12 +20,6 @@ describe ManualWithDocuments do
   let(:organisation_slug) { double(:organisation_slug) }
   let(:state) { double(:state) }
 
-  it "rasies an error without an ID" do
-    expect {
-      Manual.new({})
-    }.to raise_error
-  end
-
   describe "#publish" do
     it "notifies the underlying manual" do
       manual_with_documents.publish

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -72,7 +72,7 @@ describe SpecialistDocument do
   }
 
   let(:draft_edition_v3) {
-    double(:draft_edition_v2,
+    double(:draft_edition_v3,
       edition_messages.merge(
         title: "Draft edition v3",
         state: "draft",
@@ -115,6 +115,20 @@ describe SpecialistDocument do
       )
     )
   }
+
+  describe "#eql?" do
+    let(:editions) { [draft_edition_v1] }
+
+    it "is considered the same as another specialist document instance if they have the same id" do
+      expect(doc).to eql(doc)
+      expect(doc).to eql(SpecialistDocument.new(slug_generator, doc.id, [draft_edition_v1]))
+      expect(doc).not_to eql(SpecialistDocument.new(slug_generator, doc.id.reverse, [draft_edition_v1]))
+    end
+
+    it "is considered the same as another specialist document instance with the same id even if they have different version numbers" do
+      expect(doc).to eql(SpecialistDocument.new(slug_generator, doc.id, [draft_edition_v2]))
+    end
+  end
 
   context "with one draft edition" do
     let(:editions) { [draft_edition_v1] }


### PR DESCRIPTION
Urls in the system were being generated with path params duplicated
as query params as follows:

    /manuals/<manual_id>?id=<manual_id>
    /manuals/<manual_id>/sections/<section_id>?id=<section_id>&manual_id=<manual_id>

After some digging we discovered that this was because the objects we were
using for url generation were not the ManualRecord or
SpecialistDocumentEdition mongoid documents, or even the Manual and
SpecialistDocument model objects.  Instead they were deeply wrapped up in
SimpleDelegator classes like NullValidator or ManualWithDocuments.

The rails routing algorithm uses the provided arguments to fill in the
path segments in the url, but does equality to decide if the argument
has been consumed and should be removed for consideration later when
building query string params.  The SimpleDelegator objects mean that
the manual and section instances were not considered equal and so were
not removed from the list of arguments used already in building the
url and so ended up in the query string as well as the path.  We can
see the SimpleDelegator and eql? behaviour below:

    class A; end
    a1 = A.new
    a2 = A.new
    a1.eql? a2 #=> false
    a1.eql? a1 #=> true

    class B < SimpleDelegator; end
    ba1 = B.new(a1)
    ba2 = B.new(a2)
    ba1.eql? ba2 #=> false
    ba1.eql? ba1 #=> false
    ba1.eql? a1 #=> true

The delegate thinks it is equal to the delegated object, but does not
think it is equal to another delegate - even when that other delegate is
itself.  This is because the delegate delegates eql? to the wrapped object
and this does object equality, so really `ba1.eql? ba1` is doing
`a1.eql? ba1`.  If instead we define our own eql? method on the wrapped
object we get the following behaviour:

    class C
      attr_reader :id
      def initialize(id)
        @id = id
      end
      def eql?(other)
        @id.eql? other.id
      end
    end

    c1 = C.new(1)
    c1_2 = C.new(1)
    c2 = C.new(2)
    c1.eql? c1 #=> true
    c1.eql? c1_2 #=> true
    c2.eql? c1 #=> false

    bc1 = B.new(c1)
    bc1_2 = B.new(c1_2)

    bc1.eql? bc1 #=> true
    bc1.eql? c1 #=> true
    bc1_2.eql? c1 #=> true
    bc1.eql? c1_2 #=> true
    bc1.eql? bc1_2 #=> true

So this is what we do, we add eql? implementations to Manual and
SpecialistDocumentEdition to make sure they are considered equal,
not matter how deeply wrapepd in simple delegators they are.

There's a closed (but not fixed) issue report on journey (the rails
routing algorithms) that explains this situation here:

https://github.com/rails/journey/issues/29