### PR TITLE
Publication log rebuild includes first manual edition timestamp

### DIFF
--- a/bin/rebuild_major_publication_logs_for_manuals
+++ b/bin/rebuild_major_publication_logs_for_manuals
@@ -7,16 +7,15 @@ require "logger"
 logger = Logger.new(STDOUT)
 logger.formatter = Logger::Formatter.new
 
-manual_publication_log_filter = ManualPublicationLogFilter.new
-
 manual_records = ManualRecord.all
 count = manual_records.count
 
 logger.info "Deleting publication logs and rebuilding for major updates only for #{count} manuals"
 
 manual_records.to_a.each.with_index(1) do |manual, i|
+  manual_publication_log_filter = ManualPublicationLogFilter.new(manual)
   logger.info("[% 3d/% 3d] id=%s slug=%s" % [i, count, manual.id, manual.slug])
-  manual_publication_log_filter.delete_logs_and_rebuild_for_major_updates_only!(manual.slug)
+  manual_publication_log_filter.delete_logs_and_rebuild_for_major_updates_only!
 end
 
 logger.info "Rebuilding of publication logs complete."

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -7,8 +7,54 @@ class ManualPublicationLogFilter
   def delete_logs_and_rebuild_for_major_updates_only!
     PublicationLog.with_slug_prefix(@manual_slug).destroy_all
 
-    manual_record = ManualRecord.where(slug: @manual_slug).first
-    edition_ordering = EditionOrdering.new(document_editions_for_rebuild, manual_record.latest_edition.document_ids)
+    build_logs_for_all_first_document_editions_at_manual_edition_time
+    build_logs_for_all_other_suitable_document_editions
+  end
+
+  class EditionOrdering
+    def initialize(document_editions, document_ids)
+      @document_editions = document_editions
+      @document_ids = document_ids
+    end
+
+    def sort_by_document_ids_and_created_at
+      editions_not_matching_supplied_documents = @document_editions.where(:document_id.nin => @document_ids)
+      editions_matching_supplied_documents = @document_editions.where(:document_id.in => @document_ids)
+
+      order_by_document_ids(editions_matching_supplied_documents).concat(editions_not_matching_supplied_documents.order_by(:created_at, :asc).to_a)
+    end
+
+    private
+
+    def order_by_document_ids(document_editions)
+      document_editions.to_a.sort do |a, b|
+        a_index = @document_ids.index(a.document_id)
+        b_index = @document_ids.index(b.document_id)
+
+        a_index <=> b_index
+      end
+    end
+  end
+
+  private
+
+  def build_logs_for_all_first_document_editions_at_manual_edition_time
+    document_editions_for_first_manual_edition.map do |document_edition|
+      PublicationLog.create!(
+        title: document_edition.title,
+        slug: document_edition.slug,
+        version_number: document_edition.version_number,
+        change_note: document_edition.change_note,
+        created_at: first_manual_edition.updated_at,
+        updated_at: first_manual_edition.updated_at
+      )
+
+      document_edition.document_id
+    end
+  end
+
+  def build_logs_for_all_other_suitable_document_editions
+    edition_ordering = EditionOrdering.new(document_editions_for_rebuild, @manual_record.latest_edition.document_ids)
 
     edition_ordering.sort_by_document_ids_and_created_at.each do |edition|
       PublicationLog.create!(
@@ -22,34 +68,17 @@ class ManualPublicationLogFilter
     end
   end
 
-  class EditionOrdering
-    def initialize(editions, document_ids)
-      @editions = editions
-      @document_ids = document_ids
-    end
-
-    def sort_by_document_ids_and_created_at
-      editions_not_matching_supplied_documents = @editions.where(:document_id.nin => @document_ids)
-      editions_matching_supplied_documents = @editions.where(:document_id.in => @document_ids)
-
-      order_by_document_ids(editions_matching_supplied_documents).concat(editions_not_matching_supplied_documents.order_by(:created_at, :asc).to_a)
-    end
-
-    private
-
-    def order_by_document_ids(editions)
-      editions.to_a.sort do |a, b|
-        a_index = @document_ids.index(a.document_id)
-        b_index = @document_ids.index(b.document_id)
-
-        a_index <=> b_index
-      end
-    end
+  def document_editions_for_first_manual_edition
+    @document_editions_for_first_manual_edition ||= SpecialistDocumentEdition.where(:document_id.in => first_manual_edition.document_ids, :minor_update.nin => [true], version_number: 1).any_of({state: "published"}, { state: "archived"})
   end
 
-  private
+  def first_manual_edition
+    @first_manual_edition ||= @manual_record.editions.where(version_number: 1).first
+  end
 
   def document_editions_for_rebuild
-    SpecialistDocumentEdition.with_slug_prefix(@manual_slug).where(:minor_update.nin => [true]).any_of({state: "published"}, {state: "archived"})
+    ids_to_ignore = document_editions_for_first_manual_edition.map(&:_id)
+
+    SpecialistDocumentEdition.with_slug_prefix(@manual_slug).where(:minor_update.nin => [true], :_id.nin => ids_to_ignore).any_of({state: "published"}, {state: "archived"})
   end
 end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -71,7 +71,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       ]
     )
 
-    subject.delete_logs_and_rebuild_for_major_updates_only!(manual_slug)
+    described_class.new(manual_record).delete_logs_and_rebuild_for_major_updates_only!
   end
 
   it "deletes all existing publication logs for the supplied manual slug only" do

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -5,72 +5,111 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   let(:manual_slug) { "guidance/the-highway-code" }
   let!(:manual_record) { ManualRecord.create(slug: manual_slug) }
   let(:other_slug) { "guidance/sellotape" }
-  let(:exported_time) { Time.current }
+  let(:document_edition_exported_time) { Time.current }
 
-  let!(:archived_major_update_document_edition) do
-    create(:specialist_document_edition,
-           state: "archived",
-           slug: "#{manual_slug}/additional-data",
-           exported_at: exported_time - 2.days
-          )
-  end
-
-  let!(:draft_major_update_document_edition) do
-    create(:specialist_document_edition,
-           state: "draft",
-           slug: "#{manual_slug}/draft-info",
-           exported_at: exported_time - 3.days
-          )
-  end
-
-  let!(:published_minor_update_document_edition) do
+  let(:document_a_edition_published_version_1_major_update) do
     create(:specialist_document_edition,
            state: "published",
            slug: "#{manual_slug}/first-further-info",
-           minor_update: true
+           exported_at: document_edition_exported_time,
+           version_number: 1,
           )
   end
 
-  let!(:published_major_update_document_edition_1) do
+  let(:document_a_edition_published_version_2_major_update) do
     create(:specialist_document_edition,
            state: "published",
-           slug: "#{manual_slug}/first-further-info",
-           exported_at: exported_time - 1.day
+           slug: document_a_edition_published_version_1_major_update.slug,
+           document_id: document_a_edition_published_version_1_major_update.document_id,
+           exported_at: document_edition_exported_time,
+           version_number: 2
           )
   end
 
-  let!(:published_major_update_document_edition_2) do
+  let(:document_b_edition_published_version_1_major_update) do
     create(:specialist_document_edition,
            state: "published",
            slug: "#{manual_slug}/second-further-info",
-           exported_at: exported_time - 1.day
+           exported_at: document_edition_exported_time,
+           version_number: 1,
+          )
+  end
+
+  let(:document_b_edition_published_version_2_minor_update) do
+    create(:specialist_document_edition,
+           state: "published",
+           slug: document_b_edition_published_version_1_major_update.slug,
+           document_id: document_b_edition_published_version_1_major_update.document_id,
+           exported_at: document_edition_exported_time,
+           minor_update: true,
+           version_number: 2
+          )
+  end
+
+  let(:document_c_edition_archived_version_1_major_update) do
+    create(:specialist_document_edition,
+           state: "archived",
+           slug: "#{manual_slug}/additional-data",
+           exported_at: document_edition_exported_time,
+           version_number: 1
+          )
+  end
+
+  let(:document_d_edition_draft_version_1_major_update) do
+    create(:specialist_document_edition,
+           state: "draft",
+           slug: "#{manual_slug}/draft-info",
+           exported_at: document_edition_exported_time,
+           version_number: 1
+          )
+  end
+
+  let(:document_e_edition_published_version_1_major_update) do
+    create(:specialist_document_edition,
+           state: "published",
+           slug: "#{manual_slug}/third-further-info",
+           exported_at: document_edition_exported_time,
+           version_number: 1,
           )
   end
 
   let!(:previous_publication_logs) { create_list(:publication_log, 2, slug: manual_slug) }
   let!(:previous_other_publication_log) { create :publication_log, slug: other_slug }
 
-  before do
+  let(:first_manual_edition_creation_time) { Time.current - 1.week }
+  let(:second_manual_edition_creation_time) { first_manual_edition_creation_time - 1.day }
+
+  let!(:first_manual_edition) {
     manual_record.editions.create!(
       state: "published",
       version_number: 1,
       document_ids: [
-        published_major_update_document_edition_1.document_id,
-        archived_major_update_document_edition.document_id,
-        published_major_update_document_edition_2.document_id
-      ]
+        document_a_edition_published_version_1_major_update.document_id,
+        document_b_edition_published_version_1_major_update.document_id,
+        document_c_edition_archived_version_1_major_update.document_id,
+      ],
+      created_at: first_manual_edition_creation_time,
+      updated_at: first_manual_edition_creation_time
     )
+  }
 
+  let!(:second_manual_edition) {
     manual_record.editions.create!(
       state: "published",
       version_number: 2,
       document_ids: [
-        published_major_update_document_edition_1.document_id,
-        published_major_update_document_edition_2.document_id,
-        archived_major_update_document_edition.document_id,
-      ]
+        document_a_edition_published_version_2_major_update.document_id,
+        document_b_edition_published_version_2_minor_update.document_id,
+        document_c_edition_archived_version_1_major_update.document_id,
+        document_d_edition_draft_version_1_major_update.document_id,
+        document_e_edition_published_version_1_major_update.document_id
+      ],
+      created_at: second_manual_edition_creation_time,
+      updated_at: first_manual_edition_creation_time
     )
+  }
 
+  before do
     described_class.new(manual_record).delete_logs_and_rebuild_for_major_updates_only!
   end
 
@@ -81,24 +120,33 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     expect(PublicationLog.where(_id: previous_other_publication_log.id).exists?).to eq true
   end
 
-  it "builds logs for major updates in the 'archived' and 'published' status only in the same order as the documents on the most recent manual" do
+  it "builds logs for major updates in the 'archived' and 'published' status" do
     publication_logs_for_supplied_slug = PublicationLog.with_slug_prefix(manual_slug).order_by(:id, :asc)
 
-    expect(publication_logs_for_supplied_slug.count).to eq 3
+    expect(publication_logs_for_supplied_slug.count).to eq 5
 
-    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[0], published_major_update_document_edition_1)
-    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[1], published_major_update_document_edition_2)
-    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[2], archived_major_update_document_edition)
+    # First versions of document editions should have their associated logs "re-set"
+    # to the associated manual edition updated time. There are some cases where such editions have
+    # timestamps that post-date the manual edition update time. This is thought
+    # to be "wrong" because the first manual and first editions of its documents
+    # are expected to all be exported at the same time.
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[0], document_a_edition_published_version_1_major_update, first_manual_edition.updated_at)
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[1], document_b_edition_published_version_1_major_update, first_manual_edition.updated_at)
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[2], document_c_edition_archived_version_1_major_update, first_manual_edition.updated_at)
+
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[3], document_a_edition_published_version_2_major_update, document_a_edition_published_version_2_major_update.updated_at)
+    expect_log_attributes_to_match_edition(publication_logs_for_supplied_slug[4], document_e_edition_published_version_1_major_update, document_e_edition_published_version_1_major_update.updated_at)
+
   end
 
-  def expect_log_attributes_to_match_edition(log, edition)
+  def expect_log_attributes_to_match_edition(log, document_edition, expected_time)
     expect(log).to have_attributes(
-      slug: edition.slug,
-      title: edition.title,
-      version_number: edition.version_number,
-      change_note: edition.change_note,
-      created_at: edition.exported_at,
-      updated_at: edition.exported_at
+      slug: document_edition.slug,
+      title: document_edition.title,
+      version_number: document_edition.version_number,
+      change_note: document_edition.change_note,
+      created_at: expected_time,
+      updated_at: expected_time
     )
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -31,12 +31,12 @@ FactoryGirl.define do
   end
 
   factory :specialist_document_edition do
+    document_id { BSON::ObjectId.new }
     sequence(:slug) {|n| "test-specialist-document-#{n}" }
     sequence(:title) {|n| "Test Specialist Document #{n}" }
     summary "My summary"
     body "My body"
     document_type "cma_case"
-    sequence(:document_id) { |n| "document-id-#{n}" }
     extra_fields do
       {
         opened_date: "2013-04-20",


### PR DESCRIPTION
Trello card: https://trello.com/c/x6vSw5LM/55-update-history

Best reviewed commit-by-commit.

We don't seem to be able to always rely on document editions to faithfully reproduce the timestamps of publication logs that are currently seen in production.

The main commit in this PR involves a special case for those document editions that are associated with a first manual edition. The publication logs for these cases have a timestamp that is set to the manual `updated_at` time rather than the document edition timestamp. This appears to improve the accuracy of the rebuilt publication log timestamps in relation to what's currently seen on production.


