### PR TITLE
Make ManualRelocator be more robust with what it considers published

### DIFF
--- a/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
+++ b/db/migrate/20161031154415_remove_redirect_capital_funding_guide.rb
@@ -26,7 +26,7 @@ class RemoveRedirectCapitalFundingGuide < Mongoid::Migration
     new_manual_slug = "#{manual_slug}-hca"
 
     puts "Removing bad manual #{bad_manual_id} at #{manual_slug}."
-    CliManualDeleter.new(manual_slug, manual_id: bad_manual_id, stdin: StringIO.new("y")).call
+    CliManualDeleter.new(manual_slug, manual_id: bad_manual_id, stdin: StringIO.new("y")).call if ManualRecord.where(manual_id: bad_manual_id).first.present?
 
     puts "Removing existing manual #{manual_slug} and reslugging #{new_manual_slug} back onto it."
     ManualRelocator.move(new_manual_slug, manual_slug)

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -49,8 +49,8 @@ private
 
   def manual_is_currently_published?(manual)
     # to be currently published either...
-    # 1. it's got one edition that is published
-    (manual.editions.count == 1 && manual.latest_edition.state == "published") ||
+    # 1. the latest edition is published
+    (manual.latest_edition.state == "published") ||
     # or
     # 2. the last two editions are published and draft
     (manual.editions.order_by([:version_number, :desc]).limit(2).map(&:state) == %w(draft published))


### PR DESCRIPTION
If the latest edition is published, that's acceptable not just when it's
the only edition.

We deployed #765 to integration and the migration failed because the HCA version of the manual was currently published, but had more than one edition and it failed.