### PR TITLE
Let publishing api deal with timestamps

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -41,7 +41,6 @@ private
       document_type: "manual",
       title: rendered_manual_attributes.fetch(:title),
       description: rendered_manual_attributes.fetch(:summary),
-      public_updated_at: rendered_manual_attributes.fetch(:updated_at).iso8601,
       update_type: update_type,
       publishing_app: "manuals-publisher",
       rendering_app: "manuals-frontend",

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -61,7 +61,7 @@ private
   end
 
   def update_type
-    manual.documents.all?(&:minor_update?) ? "minor" : "major"
+    manual.documents.select(&:needs_exporting?).all?(&:minor_update?) ? "minor" : "major"
   end
 
   def rendered_manual_attributes

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -31,7 +31,6 @@ private
       document_type: "manual_section",
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),
-      public_updated_at: rendered_document_attributes.fetch(:updated_at).iso8601,
       update_type: update_type,
       publishing_app: "manuals-publisher",
       rendering_app: "manuals-frontend",

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -18,6 +18,7 @@ Feature: Publishing a manual
     Then the updated manual document is available to preview
     When I publish the manual
     Then the manual and the edited document are published
+    And the manual documents that I didn't edit were not republished
 
   Scenario: Add a section to a published manual
     Given a published manual exists

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -28,7 +28,8 @@ Feature: Publishing a manual
   Scenario: Add a change note
     Given a published manual exists
     When I create a new draft of a section with a change note
-    And I re-publish the section
+    And I publish the manual
+    Then the manual is published as a major update
 
   Scenario: Omit the change note
     Given a published manual exists
@@ -37,6 +38,8 @@ Feature: Publishing a manual
     Then I see an error requesting that I provide a change note
     When I indicate that the change is minor
     Then the document is updated without a change note
+    When I publish the manual
+    Then the manual is published as a minor update
 
   Scenario: A manual fails to publish from the queue due to an unrecoverable error
     Given a draft manual exists without any documents

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -260,6 +260,7 @@ Then(/^I see errors for the document fields$/) do
 end
 
 When(/^I publish the manual$/) do
+  go_to_manual_page(@manual.title) if current_path != manual_path(@manual)
   publish_manual
 end
 
@@ -468,10 +469,6 @@ When(/^I create a new draft of a section with a change note$/) do
   edit_manual_document(@manual_title, document.title, fields)
 end
 
-When(/^I re\-publish the section$/) do
-  publish_manual
-end
-
 Then(/^I see an error requesting that I provide a change note$/) do
   expect(page).to have_content("You must provide a change note or indicate minor update")
 end
@@ -487,6 +484,18 @@ Then(/^the document is updated without a change note$/) do
     section_title: @updated_document.title,
     section_summary: @updated_fields[:section_summary],
   )
+end
+
+Then(/^the manual is published as a major update$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "major" })
+end
+
+Then(/^the manual is published as a minor update$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "minor" })
 end
 
 When(/^I add another section to the manual$/) do

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -316,6 +316,12 @@ Then(/^the updated manual document is available to preview$/) do
   )
 end
 
+Then(/^the manual documents that I didn't edit were not republished$/) do
+  @documents.reject { |d| d.id == @updated_document.id }.each do |document|
+    check_manual_document_was_not_published(document)
+  end
+end
+
 Then(/^the manual and its new document are published$/) do
   check_manual_and_documents_were_published(
     @manual,
@@ -390,6 +396,7 @@ Given(/^a published manual with some sections was created without the UI$/) do
 end
 
 When(/^I edit one of the manual's documents$/) do
+  WebMock::RequestRegistry.instance.reset!
   @updated_document = @documents.first
 
   @updated_fields = {
@@ -403,6 +410,7 @@ When(/^I edit one of the manual's documents$/) do
 end
 
 When(/^I edit one of the manual's documents without a change note$/) do
+  WebMock::RequestRegistry.instance.reset!
   @updated_document = @documents.first
 
   @updated_fields = {

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -165,7 +165,7 @@ module ManualHelpers
   end
 
   def check_manual_was_published(manual)
-    check_manual_document_is_published_to_publishing_api(manual.id)
+    check_manual_is_published_to_publishing_api(manual.id)
   end
 
   def check_manual_document_was_not_published(document)

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -313,15 +313,16 @@ private
       public_updated_at: section_edition.public_updated_at,
       minor_update: section_edition.minor_update,
       attachments: section_edition.attachments.to_a,
+      needs_exporting: section_edition.exported_at.nil?,
     )
   end
 
   class SimpleSection
     attr_reader :id, :title, :slug, :summary, :body, :document_type, :updated_at,
       :version_number, :extra_fields, :public_updated_at, :minor_update,
-      :attachments
+      :attachments, :needs_exporting
 
-    def initialize(id:, title:, slug:, summary:, body:, document_type:, updated_at:, version_number:, extra_fields:, public_updated_at:, minor_update:, attachments:)
+    def initialize(id:, title:, slug:, summary:, body:, document_type:, updated_at:, version_number:, extra_fields:, public_updated_at:, minor_update:, attachments:, needs_exporting:)
       @id = id
       @title = title
       @slug = slug
@@ -334,6 +335,7 @@ private
       @public_updated_at = public_updated_at
       @minor_update = minor_update
       @attachments = attachments
+      @needs_exporting = needs_exporting
     end
 
     def attributes
@@ -347,6 +349,10 @@ private
 
     def minor_update?
       !!minor_update
+    end
+
+    def needs_exporting?
+      !!needs_exporting
     end
   end
 end

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -110,28 +110,31 @@ describe ManualPublishingAPIExporter do
 
     expect(export_recipent).to have_received(:call).with(
       "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-      hash_including(
-        base_path: "/guidance/my-first-manual",
-        schema_name: "manual",
-        document_type: "manual",
-        title: "My first manual",
-        description: "This is my first manual",
-        public_updated_at: Time.new(2013, 12, 31, 12, 0, 0).iso8601,
-        update_type: "major",
-        publishing_app: "manuals-publisher",
-        rendering_app: "manuals-frontend",
-        routes: [
-          {
-            path: "/guidance/my-first-manual",
-            type: "exact",
-          },
-          {
-            path: "/guidance/my-first-manual/updates",
-            type: "exact",
-          }
-        ],
-        locale: "en",
-      ))
+      all_of(
+        hash_including(
+          base_path: "/guidance/my-first-manual",
+          schema_name: "manual",
+          document_type: "manual",
+          title: "My first manual",
+          description: "This is my first manual",
+          update_type: "major",
+          publishing_app: "manuals-publisher",
+          rendering_app: "manuals-frontend",
+          routes: [
+            {
+              path: "/guidance/my-first-manual",
+              type: "exact",
+            },
+            {
+              path: "/guidance/my-first-manual/updates",
+              type: "exact",
+            }
+          ],
+          locale: "en",
+        ),
+        hash_excluding(:public_updated_at)
+      )
+    ).once
   end
 
   it "exports section metadata for the manual" do

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -35,6 +35,7 @@ describe ManualPublishingAPIExporter do
         id: "60023f27-0657-4812-9339-264f1c0fd90d",
         attributes: document_attributes,
         minor_update?: false,
+        needs_exporting?: true,
       )
     ]
   }
@@ -184,5 +185,185 @@ describe ManualPublishingAPIExporter do
         }
       )
     )
+  end
+
+  context "when no documents need exporting" do
+    let(:documents) {
+      [
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: false,
+        ),
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: true,
+          needs_exporting?: false,
+        )
+      ]
+    }
+
+    it "exports with the update_type set to minor" do
+      subject.call
+
+      expect(export_recipent).to have_received(:call).with(
+        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+        hash_including(update_type: "minor")
+      )
+    end
+  end
+
+  context "when one document needs exporting and it is a minor update" do
+    let(:documents) {
+      [
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: false,
+        ),
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: true,
+          needs_exporting?: true,
+        )
+      ]
+    }
+
+    it "exports with the update_type set to minor" do
+      subject.call
+
+      expect(export_recipent).to have_received(:call).with(
+        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+        hash_including(update_type: "minor")
+      )
+    end
+  end
+
+  context "when one document needs exporting and it is a major update" do
+    let(:documents) {
+      [
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: false,
+        ),
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: true,
+        )
+      ]
+    }
+
+    it "exports with the update_type set to major" do
+      subject.call
+
+      expect(export_recipent).to have_received(:call).with(
+        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+        hash_including(update_type: "major")
+      )
+    end
+  end
+
+  context "when multiple documents need exporting, but none are major updates" do
+    let(:documents) {
+      [
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: true,
+          needs_exporting?: true,
+        ),
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: true,
+          needs_exporting?: true,
+        )
+      ]
+    }
+
+    it "exports with the update_type set to minor" do
+      subject.call
+
+      expect(export_recipent).to have_received(:call).with(
+        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+        hash_including(update_type: "minor")
+      )
+    end
+  end
+
+  context "when multiple documents need exporting, and at least one is a major updates" do
+    let(:documents) {
+      [
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: true,
+        ),
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: true,
+          needs_exporting?: true,
+        )
+      ]
+    }
+
+    it "exports with the update_type set to major" do
+      subject.call
+
+      expect(export_recipent).to have_received(:call).with(
+        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+        hash_including(update_type: "major")
+      )
+    end
+  end
+
+  context "when multiple documents need exporting, and all are major updates" do
+    let(:documents) {
+      [
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: true,
+        ),
+        double(
+          :document,
+          id: "60023f27-0657-4812-9339-264f1c0fd90d",
+          attributes: document_attributes,
+          minor_update?: false,
+          needs_exporting?: true,
+        )
+      ]
+    }
+
+    it "exports with the update_type set to major" do
+      subject.call
+
+      expect(export_recipent).to have_received(:call).with(
+        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
+        hash_including(update_type: "major")
+      )
+    end
   end
 end

--- a/spec/exporters/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_section_publishing_api_exporter_spec.rb
@@ -86,23 +86,26 @@ describe ManualSectionPublishingAPIExporter do
 
     expect(export_recipent).to have_received(:call).with(
       document.id,
-      hash_including(
-        base_path: document_base_path,
-        schema_name: "manual_section",
-        document_type: "manual_section",
-        title: "Document title",
-        description: "This is the first section",
-        public_updated_at: Time.new(2013, 12, 31, 12, 0, 0).iso8601,
-        update_type: "minor",
-        publishing_app: "manuals-publisher",
-        rendering_app: "manuals-frontend",
-        routes: [
-          {
-            path: document_base_path,
-            type: "exact",
-          }
-        ],
-      ))
+      all_of(
+        hash_including(
+          base_path: document_base_path,
+          schema_name: "manual_section",
+          document_type: "manual_section",
+          title: "Document title",
+          description: "This is the first section",
+          update_type: "minor",
+          publishing_app: "manuals-publisher",
+          rendering_app: "manuals-frontend",
+          routes: [
+            {
+              path: document_base_path,
+              type: "exact",
+            }
+          ],
+        ),
+        hash_excluding(:public_updated_at)
+      )
+    )
   end
 
   it "exports section metadata for the document" do

--- a/spec/support/all_of_matcher.rb
+++ b/spec/support/all_of_matcher.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :all_of do |*expected_matchers|
+  match do |actual|
+    expected_matchers.all? { |matcher| matcher === actual }
+  end
+end


### PR DESCRIPTION
Publishing API can set timestamps correctly based on the api events we send it for the content and the update_type params used.  This PR attempts to fix: https://trello.com/c/OC3RskhE/63-timestamps-on-manuals by making sure our update_types are set correctly and not sending public_updated_at to the API anymore.  More notes in the commits.