### PR TITLE
Always send first editions to publishing api as major updates

### DIFF
--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -90,6 +90,10 @@ private
   end
 
   def update_type
+    # The first edition to be sent to the publishing-api must always be sent as
+    # a major update
+    return "major" unless document.has_ever_been_published?
+
     document.minor_update? ? "minor" : "major"
   end
 

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -15,6 +15,7 @@ class Manual
     @id = attributes.fetch(:id)
     @updated_at = attributes.fetch(:updated_at, nil)
     @version_number = attributes.fetch(:version_number, 0)
+    @ever_been_published = !!attributes.fetch(:ever_been_published, false)
 
     update(attributes)
   end
@@ -85,5 +86,9 @@ class Manual
 
   def withdrawn?
     state == "withdrawn"
+  end
+
+  def has_ever_been_published?
+    @ever_been_published
   end
 end

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -39,6 +39,10 @@ class ManualRecord
     @latest_edition ||= editions.order_by([:version_number, :desc]).first
   end
 
+  def has_ever_been_published?
+    editions.any? { |x| x.state == "published" }
+  end
+
   after_save :save_and_clear_latest_edition
 
 private

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -86,6 +86,7 @@ class SpecialistDocument
   def published?
     editions.any?(&:published?)
   end
+  alias_method :has_ever_been_published?, :published?
 
   def draft?
     latest_edition.draft?

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -77,6 +77,7 @@ private
       state: edition.state,
       version_number: edition.version_number,
       updated_at: edition.updated_at,
+      ever_been_published: manual_record.has_ever_been_published?
     )
 
     association_marshallers.reduce(base_manual) { |manual, marshaller|

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -42,6 +42,17 @@ Feature: Publishing a manual
     When I publish the manual
     Then the manual is published as a minor update
 
+  Scenario: Minor changes are published as major for first editions
+    Given a published manual exists
+    When I create a document for the manual as a minor change
+    And I publish the manual
+    Then the manual is published as a major update
+    And the section is published as a major update
+    When I edit one of the manual's documents as a minor change
+    And I publish the manual
+    Then the manual is published as a minor update
+    And the section is published as a minor update
+
   Scenario: A manual fails to publish from the queue due to an unrecoverable error
     Given a draft manual exists without any documents
     And a draft document exists for the manual

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -132,6 +132,23 @@ When(/^I create a document for the manual$/) do
   @document = most_recently_created_manual.documents.to_a.last
 end
 
+When(/^I create a document for the manual as a minor change$/) do
+  @document_title = "Created Section 1"
+  @document_slug = [@manual_slug, "created-section-1"].join("/")
+
+  @document_fields = {
+    section_title: @document_title,
+    section_summary: "Section 1 summary",
+    section_body: "Section 1 body",
+  }
+
+  create_manual_document(@manual_fields.fetch(:title), @document_fields) do
+    check("Minor update")
+  end
+
+  @document = most_recently_created_manual.documents.to_a.last
+end
+
 Then(/^I see the manual has the new section$/) do
   visit manuals_path
   click_on @manual_fields.fetch(:title)
@@ -423,6 +440,21 @@ When(/^I edit one of the manual's documents without a change note$/) do
   edit_manual_document(@manual_title, @updated_document.title, @updated_fields)
 end
 
+When(/^I edit one of the manual's documents as a minor change$/) do
+  WebMock::RequestRegistry.instance.reset!
+  @updated_document = @documents.first
+
+  @updated_fields = {
+    section_title: @updated_document.title,
+    section_summary: "Updated section",
+    section_body: "Updated section",
+  }
+
+  edit_manual_document(@manual_title, @updated_document.title, @updated_fields) do
+    check("Minor update")
+  end
+end
+
 When(/^I start creating a new manual document$/) do
   @document_fields = {
     section_title: "Section 1",
@@ -504,6 +536,18 @@ Then(/^the manual is published as a minor update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
   check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "minor" })
+end
+
+Then(/^the section is published as a major update$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "major" })
+end
+
+Then(/^the section is published as a minor update$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "minor" })
 end
 
 When(/^I add another section to the manual$/) do

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -28,6 +28,8 @@ module ManualHelpers
 
     fill_in_fields(fields)
 
+    yield if block_given?
+
     save_as_draft
   end
 
@@ -62,6 +64,8 @@ module ManualHelpers
     click_on section_title
     click_on "Edit"
     fill_in_fields(new_fields)
+
+    yield if block_given?
 
     save_as_draft
   end
@@ -221,13 +225,13 @@ module ManualHelpers
     assert_publishing_api_discard_draft(content_id)
   end
 
-  def check_manual_document_is_drafted_to_publishing_api(content_id)
+  def check_manual_document_is_drafted_to_publishing_api(content_id, extra_attributes: {})
     attributes = {
       "schema_name" => "manual_section",
       "document_type" => "manual_section",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "manuals-publisher",
-    }
+    }.merge(extra_attributes)
     assert_publishing_api_put_content(content_id, request_json_including(attributes))
   end
 

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -297,6 +297,12 @@ private
         version_number: version_number, updated_at: updated_at,
       }
     end
+
+    def has_ever_been_published?
+      # The ManualRelocator only works on published manuals so this will always
+      # be true for any manual we are asked to relocate.
+      true
+    end
   end
 
   def build_simple_section(section_edition)
@@ -314,15 +320,19 @@ private
       minor_update: section_edition.minor_update,
       attachments: section_edition.attachments.to_a,
       needs_exporting: section_edition.exported_at.nil?,
+      # This isn't the same as the calculation in SpecialistDocument, but we
+      # don't have access to all the other editions here, and this should be
+      # close enough
+      ever_been_published: (section_edition.version_number > 1) || section_edition.exported_at.nil?,
     )
   end
 
   class SimpleSection
     attr_reader :id, :title, :slug, :summary, :body, :document_type, :updated_at,
       :version_number, :extra_fields, :public_updated_at, :minor_update,
-      :attachments, :needs_exporting
+      :attachments, :needs_exporting, :ever_been_published
 
-    def initialize(id:, title:, slug:, summary:, body:, document_type:, updated_at:, version_number:, extra_fields:, public_updated_at:, minor_update:, attachments:, needs_exporting:)
+    def initialize(id:, title:, slug:, summary:, body:, document_type:, updated_at:, version_number:, extra_fields:, public_updated_at:, minor_update:, attachments:, needs_exporting:, ever_been_published:)
       @id = id
       @title = title
       @slug = slug
@@ -336,6 +346,7 @@ private
       @minor_update = minor_update
       @attachments = attachments
       @needs_exporting = needs_exporting
+      @ever_been_published = ever_been_published
     end
 
     def attributes
@@ -353,6 +364,10 @@ private
 
     def needs_exporting?
       !!needs_exporting
+    end
+
+    def has_ever_been_published?
+      !!ever_been_published
     end
   end
 end

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -110,4 +110,34 @@ describe ManualRecord, hits_db: true do
       expect(ManualRecord.all_by_updated_at.to_a).to eq([later_edition, middle_edition, early_edition])
     end
   end
+
+  describe "#has_ever_been_published?" do
+    it "is false for an unsaved instance" do
+      expect(ManualRecord.new).not_to have_ever_been_published
+    end
+
+    it "is false for a saved instance with no editions" do
+      expect(record).not_to have_ever_been_published
+    end
+
+    it "is false for a saved instance with no published editions" do
+      record.editions.create!(state: "draft", version_number: 1)
+      record.editions.create!(state: "withdrawn", version_number: 2)
+      record.editions.create!(state: "draft", version_number: 3)
+      expect(subject).not_to have_ever_been_published
+    end
+
+    it "is true for a saved instance with a published edition" do
+      record.editions.create!(state: "published", version_number: 1)
+      expect(subject).to have_ever_been_published
+    end
+
+    it "is true for a saved instance with any published editions even if it's not the latest" do
+      record.editions.create!(state: "draft", version_number: 1)
+      record.editions.create!(state: "published", version_number: 2)
+      record.editions.create!(state: "withdrawn", version_number: 3)
+      record.editions.create!(state: "draft", version_number: 4)
+      expect(subject).to have_ever_been_published
+    end
+  end
 end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -44,6 +44,20 @@ describe Manual do
     end
   end
 
+  describe "#has_ever_been_published?" do
+    it "is false if not told at initialize time" do
+      expect(Manual.new(id: "1234-5678-9012-3456")).not_to have_ever_been_published
+    end
+
+    it "is false if told so at initialize time" do
+      expect(Manual.new(id: "1234-5678-9012-3456", ever_been_published: false)).not_to have_ever_been_published
+    end
+
+    it "is true if told so at initialize time" do
+      expect(Manual.new(id: "1234-5678-9012-3456", ever_been_published: true)).to have_ever_been_published
+    end
+  end
+
   describe "#publish" do
     it "returns self" do
       expect(manual.publish).to be(manual)

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -140,6 +140,10 @@ describe SpecialistDocument do
     it "is not published" do
       expect(doc).not_to be_published
     end
+
+    it "has never been published" do
+      expect(doc).not_to have_ever_been_published
+    end
   end
 
   context "with one published edition" do
@@ -152,6 +156,10 @@ describe SpecialistDocument do
     it "is not in draft" do
       expect(doc).not_to be_draft
     end
+
+    it "has ever been published" do
+      expect(doc).to have_ever_been_published
+    end
   end
 
   context "with one published edition and one draft edition" do
@@ -160,6 +168,42 @@ describe SpecialistDocument do
     it "is published and in draft" do
       expect(doc).to be_draft
       expect(doc).to be_published
+    end
+
+    it "has ever been published" do
+      expect(doc).to have_ever_been_published
+    end
+  end
+
+  context "with two draft editions" do
+    let(:editions) { [draft_edition_v1, draft_edition_v2] }
+
+    it "is in draft" do
+      expect(doc).to be_draft
+    end
+
+    it "is not published" do
+      expect(doc).not_to be_published
+    end
+
+    it "has never been published" do
+      expect(doc).not_to have_ever_been_published
+    end
+  end
+
+  context "with one draft edition and a withdrawn edition" do
+    let(:editions) { [draft_edition_v1, withdrawn_edition_v2] }
+
+    it "is not in draft" do
+      expect(doc).not_to be_draft
+    end
+
+    it "is not published" do
+      expect(doc).not_to be_published
+    end
+
+    it "has never been published" do
+      expect(doc).not_to have_ever_been_published
     end
   end
 

--- a/spec/repositories/manual_repository_spec.rb
+++ b/spec/repositories/manual_repository_spec.rb
@@ -34,6 +34,7 @@ describe ManualRepository do
       body: "body",
       organisation_slug: "organisation_slug",
       slug: manual_slug,
+      ever_been_published: true,
     }
   }
 
@@ -48,6 +49,7 @@ describe ManualRepository do
       :"slug=" => nil,
       latest_edition: nil,
       save!: nil,
+      has_ever_been_published?: true,
     )
   }
 
@@ -67,6 +69,7 @@ describe ManualRepository do
       state: "draft",
       slug: manual_slug,
       version_number: 1,
+      ever_been_published: true,
     }
   }
 


### PR DESCRIPTION
When republishing manuals for #778 after deploying #780 some of the republishes failed with a 500 error from publishing-api (see: https://errbit.integration.publishing.service.gov.uk/apps/552637940da1157bfa000399/problems/585908a76578636a1ecc0000).  Turns out publishing-api doesn't like it if the first edition of a content item has update_type of "minor".  This is on the publishing-api backlog to turn into a proper error (see: https://trello.com/c/3S4m5wAJ/251-throw-an-error-if-the-first-publish-does-not-use-a-major-update-type) but we need to handle it in manuals publisher.  Turns out that's painful because manuals-publisher doesn't really keep things in lock-step with what is in publisher.

There are more notes in the commits if you're interested.