### PR TITLE
Allow editing of change notes on all sections

### DIFF
--- a/app/views/manual_documents/_form.html.erb
+++ b/app/views/manual_documents/_form.html.erb
@@ -11,7 +11,7 @@
     <div class="preview_button add-vertical-margins"></div>
     <div class="preview_container add-vertical-margins" style="display: none;"></div>
 
-    <% if manual.published? %>
+    <% if manual.has_ever_been_published? %>
       <div class="checkbox add-vertical-margins">
         <%= f.check_box :minor_update %>
       </div>

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -118,3 +118,19 @@ Feature: Creating and editing a manual
     Given a published manual exists
     When I edit one of the manual's documents
     Then I should see a link to preview the manual
+
+  Scenario: Change notes on new manual documents
+    Given a draft manual exists without any documents
+    Then I do not see the change note form when adding a new section
+
+  Scenario: Change notes on published manual documents
+    Given a published manual exists
+    Then I can see the change note form when editing existing sections
+    And I can see the change note form when adding a new section
+    When I create a document for the manual as a minor change
+    Then I can see the change note form when editing existing sections
+    And I can change the document to be a minor change
+    When I publish the manual
+    Then the section is published as a minor update
+    And I can see the change note form when editing existing sections
+    And the change note form for the document is clear

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -550,6 +550,56 @@ Then(/^the section is published as a minor update$/) do
   check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "minor" })
 end
 
+Then(/^I can see the change note form when editing existing sections$/) do
+  @documents.each do |document|
+    go_to_manual_page(@manual.title)
+    click_on document.title
+    click_on "Edit section"
+
+    check_that_change_note_fields_are_present
+  end
+end
+
+Then(/^I can see the change note form when adding a new section$/) do
+  go_to_manual_page(@manual.title)
+  click_on "Add section"
+
+  check_that_change_note_fields_are_present(minor_update: false, note: "New section added.")
+end
+
+Then(/^I do not see the change note form when adding a new section$/) do
+  go_to_manual_page(@manual.title)
+  click_on "Add section"
+
+  expect(page).not_to have_field("Minor update")
+  expect(page).not_to have_field("Change note")
+end
+
+Then(/^the change note form for the document is clear$/) do
+  go_to_manual_page(@manual.title)
+  click_on @updated_document.title
+  click_on "Edit section"
+
+  check_that_change_note_fields_are_present(minor_update: false, note: "")
+end
+
+Then(/^I can change the document to be a minor change$/) do
+  @updated_document = @documents.first
+
+  go_to_manual_page(@manual.title)
+  click_on @updated_document.title
+  click_on "Edit section"
+
+  fill_in "Change note", with: "This is a minor change"
+  check "Minor update"
+  click_on "Save as draft"
+
+  go_to_manual_page(@manual.title)
+  click_on @updated_document.title
+  click_on "Edit section"
+  check_that_change_note_fields_are_present(minor_update: true, note: "This is a minor change")
+end
+
 When(/^I add another section to the manual$/) do
   title = "Section 2"
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -293,6 +293,14 @@ module ManualHelpers
     expect(change_note_field_value).to eq(expected_value)
   end
 
+  def check_that_change_note_fields_are_present(minor_update: false, note: "")
+    expect(page).to have_field("Minor update", checked: minor_update)
+    # the note field is only visible for major updates, so we have to reveal it
+    # if we think it will be a minor update alread
+    check("Minor update") if minor_update
+    expect(page).to have_field("Change note", with: note)
+  end
+
   def check_manual_can_be_created
     @manual_fields = {
       title: "Example Manual Title",


### PR DESCRIPTION
For: https://trello.com/c/CzbxbBNp/84-allow-editing-of-change-notes-in-manuals-publisher

We want to allow change notes on manual sections to be added and edited
throughout the process of editing a manual.  Prior to this change a change
note can only be added to the first section you edit for a manual, and
only on that initial edit.  If you want to a a change not to another
section you have to publish the outstanding changes and draft the manual
afresh.  You weren't then able to change the note you added to the
first section either.

This is obviously not a great workflow, so this commit changes it so
that the only restriction is that you can't add a change note to the
sections you add to the very first draft edition of a manual (this seems
to be the intention), but after that first draft is published you can
add change notes to every section you add or edit and you can go back
to edit them inbetween saves.  When you publish all notes are cleared
again and you can't edit the old ones (but you can add new ones).