### PR TITLE
Publish change notes along with relevant manual edition

### DIFF
--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -9,8 +9,13 @@ class ManualObserversRegistry
   def publication
     # The order here is important. For example content exporting
     # should happen before publishing to search.
+    #
+    # A draft export step follows publication logging as this ensures that
+    # change notes that relate to the current draft are pushed straight to the
+    # publishing API rather than on the subsequent draft-publish cycle.
     [
       publication_logger,
+      publishing_api_draft_exporter,
       publishing_api_publisher,
       rummager_exporter,
     ]

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -131,6 +131,6 @@ Feature: Creating and editing a manual
     Then I can see the change note form when editing existing sections
     And I can change the document to be a minor change
     When I publish the manual
-    Then the section is published as a minor update
+    Then the section is published as a minor update including a change note draft
     And I can see the change note form when editing existing sections
     And the change note form for the document is clear

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -30,7 +30,7 @@ Feature: Publishing a manual
     Given a published manual exists
     When I create a new draft of a section with a change note
     And I publish the manual
-    Then the manual is published as a major update
+    Then the manual is published as a major update including a change note draft
 
   Scenario: Omit the change note
     Given a published manual exists
@@ -40,7 +40,7 @@ Feature: Publishing a manual
     When I indicate that the change is minor
     Then the document is updated without a change note
     When I publish the manual
-    Then the manual is published as a minor update
+    Then the manual is published as a minor update including a change note draft
 
   Scenario: Minor changes are published as major for first editions
     Given a published manual exists
@@ -50,8 +50,8 @@ Feature: Publishing a manual
     And the section is published as a major update
     When I edit one of the manual's documents as a minor change
     And I publish the manual
-    Then the manual is published as a minor update
-    And the section is published as a minor update
+    Then the manual is published as a minor update including a change note draft
+    And the section is published as a minor update including a change note draft
 
   Scenario: A manual fails to publish from the queue due to an unrecoverable error
     Given a draft manual exists without any documents

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -526,28 +526,52 @@ Then(/^the document is updated without a change note$/) do
   )
 end
 
+Then(/^the manual is published as a major update including a change note draft$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
+end
+
+Then(/^the manual is published as a minor update including a change note draft$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
+end
+
 Then(/^the manual is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "major" })
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
 end
 
 Then(/^the manual is published as a minor update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "minor" })
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "minor" }, number_of_drafts: 1)
+end
+
+Then(/^the section is published as a major update including a change note draft$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
 end
 
 Then(/^the section is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "major" })
+  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
 end
 
 Then(/^the section is published as a minor update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "minor" })
+  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 1)
+end
+
+Then(/^the section is published as a minor update including a change note draft$/) do
+  # We don't use the update_type on the publish API, we fallback to what we set
+  # when drafting the content
+  check_manual_document_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
 end
 
 Then(/^I can see the change note form when editing existing sections$/) do

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -63,7 +63,8 @@ Then(/^the removed document change note is included$/) do
 
   check_manual_is_drafted_to_publishing_api(
     @manual.id,
-    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_document)
+    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_document),
+    number_of_drafts: 3
   )
 end
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -225,14 +225,14 @@ module ManualHelpers
     assert_publishing_api_discard_draft(content_id)
   end
 
-  def check_manual_document_is_drafted_to_publishing_api(content_id, extra_attributes: {})
+  def check_manual_document_is_drafted_to_publishing_api(content_id, extra_attributes: {}, number_of_drafts: 1)
     attributes = {
       "schema_name" => "manual_section",
       "document_type" => "manual_section",
       "rendering_app" => "manuals-frontend",
       "publishing_app" => "manuals-publisher",
     }.merge(extra_attributes)
-    assert_publishing_api_put_content(content_id, request_json_including(attributes))
+    assert_publishing_api_put_content(content_id, request_json_including(attributes), number_of_drafts)
   end
 
   def check_manual_document_is_published_to_publishing_api(content_id)

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -31,10 +31,13 @@ RSpec.describe "Publishing manuals", type: :feature do
       Timecop.freeze(publish_time) do
         publish_manual_without_ui(@manual)
       end
+
+      check_manual_is_drafted_to_publishing_api(@manual.id, number_of_drafts: 4)
     end
 
-    it "sends the manual and the sections to the Publishing API" do
+    it "drafts the manual and sections and publishes them to the Publishing API" do
       @documents.each do |document|
+        check_manual_document_is_drafted_to_publishing_api(document.id, number_of_drafts: 2)
         check_manual_and_documents_were_published(@manual, document, manual_fields, document_fields(document))
       end
     end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Republishing manuals", type: :feature do
       publish_manual_without_ui(@manual)
     end
 
-    check_manual_is_drafted_to_publishing_api(@manual.id, number_of_drafts: 3)
+    check_manual_is_drafted_to_publishing_api(@manual.id, number_of_drafts: 4)
     check_manual_is_published_to_publishing_api(@manual.id)
 
     WebMock::RequestRegistry.instance.reset!


### PR DESCRIPTION
[Trello card](https://trello.com/c/WpgrE9ge/71-change-notes-in-manuals-publisher-are-sent-to-the-publishing-api-on-the-wrong-publish-event)

Adds an additional manual draft export step at the point of
publishing a manual. This was done in order to address the problem of
a change note only being sent to the publishing API following
a second, subsequent creation of a manual draft and its publication. In
other words, the change notes always lagged "one step behind" the
publication of the content changes that they described.

By adding a draft export step to the publication of a manual we ensure
that the change notes that were added to the current draft are then sent
through to the publishing API.

Also:
  - Modified some publishing specs to take account of this additional
  draft export step.