### PR TITLE
Add migration to republish a manual with an older published date

### DIFF
--- a/db/migrate/20170112102016_change_published_date_for_manual_originally_published_elsewhere.rb
+++ b/db/migrate/20170112102016_change_published_date_for_manual_originally_published_elsewhere.rb
@@ -1,0 +1,86 @@
+# The history
+# ===========
+#
+# The National Planning Policy Framework manual was originally published
+# in March 2012, and recently migrated over to GOV.UK.  The version now
+# published says it was updated on in Dec 2016 as that's when it was
+# first published to GOV.UK, however, no changes were made to the content
+# and this date is causing users of the manual to get in touch to find
+# out what has changed.  The app doesn't (yet) have the ability to override
+# the dates in the UI, nor does it have the ability to set the change
+# notes for sections when they are first created.
+#
+# What we'll do here is edit the change notes to read "Imported to GOV.UK"
+# instead of "New section added" and republish the manual and it's sections
+# so that the public_updated_at is explicitly set to the original publication
+# date in March 2012.
+class ChangePublishedDateForManualOriginallyPublishedElsewhere < Mongoid::Migration
+  def self.up
+    manual = ManualRecord.find_by(slug: "guidance/national-planning-policy-framework")
+    document_ids = manual.editions.flat_map(&:document_ids).uniq
+
+    # Get all the document_editions
+    all_sections = SpecialistDocumentEdition.where(:document_id.in => document_ids)
+    first_editions, other_editions = all_sections.partition { |edition| edition.version_number == 1 }
+
+    # Set change note for all first editions to "Imported to GOV.UK"
+    first_editions.map do |edition|
+      edition.update_attributes(change_note: "Imported to GOV.UK.")
+      log = PublicationLog.where(slug: edition.slug, version_number: edition.version_number).first
+      log.update_attributes(change_note: "Imported to GOV.UK.") if log.present?
+    end
+
+    # Set all other editions to minor and remove their change notes, if they're
+    # major and the change note is the default "New section added."
+    other_editions.map do |edition|
+      if (!edition.minor_update) && (edition.change_note == "New section added.")
+        edition.update_attributes(minor_update: true, change_note: "")
+        log = PublicationLog.where(slug: edition.slug, version_number: edition.version_number).first
+        log.destroy if log.present?
+      end
+    end
+
+    # Do all the prep work to make it so we can republish the manual and its
+    # sections, while injecting the old publish date
+    original_publish_date = Date.new(2012, 3, 27).to_time
+    publishing_api = ManualsPublisherWiring.get(:publishing_api_v2)
+    organisation = ManualsPublisherWiring.get(:organisation_fetcher).call(manual.organisation_slug)
+    manual_renderer = ManualsPublisherWiring.get(:manual_renderer)
+    manual_document_renderer = ManualsPublisherWiring.get(:manual_document_renderer)
+
+    manual_for_publishing, _metadata_we_dont_need_here = ManualServiceRegistry.new.show(manual.manual_id).call
+
+    # Inject the original publish date as the first_published_at and make the
+    # new draft a minor update (so publishing-api doesn't get any ideas about
+    # timestamps itself).
+    put_content = ->(content_id, payload) do
+      publishing_api.put_content(content_id, payload.merge(
+        public_updated_at: original_publish_date,
+        first_published_at: original_publish_date,
+        update_type: "minor"
+      ))
+    end
+
+    # Write new drafts of the manual and it's documents
+    ManualPublishingAPIExporter.new(
+      put_content, organisation, manual_renderer, PublicationLog, manual_for_publishing
+    ).call
+    manual_for_publishing.documents.each do |manual_document|
+      ManualSectionPublishingAPIExporter.new(
+        put_content, organisation, manual_document_renderer, manual_for_publishing, manual_document
+      ).call
+    end
+
+    # Publish these new drafts
+    publishing_api.publish(manual_for_publishing.id, "republish")
+    manual_for_publishing.documents.each do |manual_document|
+      publishing_api.publish(manual_document.id, "republish")
+    end
+  end
+
+  def self.down
+    # It's not really possible to reverse this as some of the above
+    # changes are destructive.
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
We got a zendesk ticket complaining about the updated at date on a manual
that had been recently added to manuals publisher.  The manual was
originally published in March 2012, and the Dec 2016 version had no
changes other than it appearing on gov.uk, but the updated at date listed
Dec 2016 making some users get in touch with the authors asking what had
changed.

This PR adds a migration that does a one-off republishing of the manual
to:

1. update the first published at dates, and public timestamps to the
   March 2012 date of original publication
2. change the default change notes on the sections to "Imported to GOV.UK"
   instead of "New section added"

In a separate PR we'll add the functionality that would let a user of the
system manage this themselves.

# Content Store JSON versions 

## Before

What is currently live, having been published on Dec 29th.

```json
{
  "analytics_identifier": null,
  "base_path": "/guidance/national-planning-policy-framework",
  "content_id": "29b0144a-5005-4a68-bf5d-985add7d3fc5",
  "document_type": "manual",
  "first_published_at": "2016-12-29T09:31:10.000+00:00",
  "format": "manual",
  "locale": "en",
  "need_ids": [],
  "phase": "live",
  "public_updated_at": "2016-12-29T14:45:47.000+00:00",
  "publishing_app": "manuals-publisher",
  "rendering_app": "manuals-frontend",
  "schema_name": "manual",
  "title": "National Planning Policy Framework",
  "updated_at": "2016-12-29T15:29:19.898Z",
  "withdrawn_notice": {},
  "links": {
    "organisations": [ /*snip*/ ],
    "sections": [
      {
        "analytics_identifier": null,
        "api_path": "/api/content/guidance/national-planning-policy-framework/ministerial-foreword",
        "base_path": "/guidance/national-planning-policy-framework/ministerial-foreword",
        "content_id": "6c77b27c-be11-4833-8c28-30f33fec6d9e",
        "description": "Ministerial foreword by the Rt Hon Greg Clark MP",
        "document_type": "manual_section",
        "locale": "en",
        "public_updated_at": "2016-12-16T11:07:23Z",
        "schema_name": "manual_section",
        "title": "Ministerial foreword",
        "withdrawn": false,
        "links": {},
        "api_url": "http://www.dev.gov.uk/api/content/guidance/national-planning-policy-framework/ministerial-foreword",
        "web_url": "http://www.dev.gov.uk/guidance/national-planning-policy-framework/ministerial-foreword"
      },
      /*snip-remaining*/
    ],
    "available_translations": [ /*snip*/ ]
  },
  "description": "The National Planning Policy Framework was published on 27 March 2012 and sets out the government’s planning policies for England and how these are expected to be applied.",
  "details": {
    "body": "\n",
    "child_section_groups": [
      {
        "title": "Contents",
        "child_sections": [ /*snip*/ ]
      }
    ],
    "change_notes": [
      {
        "base_path": "/guidance/national-planning-policy-framework/ministerial-foreword",
        "title": "Ministerial foreword",
        "change_note": "New section added.",
        "published_at": "2016-12-29T09:31:10Z"
      },
      /*snip-remaining*/
    ],
    "organisations": [
      {
        "title": "Department for Communities and Local Government",
        "abbreviation": "DCLG",
        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government"
      }
    ]
  }
}
```

## After

What we get after running this migration on 12th Jan.

```json
{
  "analytics_identifier": null,
  "base_path": "/guidance/national-planning-policy-framework",
  "content_id": "29b0144a-5005-4a68-bf5d-985add7d3fc5",
  "document_type": "manual",
  "first_published_at": "2012-03-27T00:00:00.000+00:00",
  "format": "manual",
  "locale": "en",
  "need_ids": [],
  "phase": "live",
  "public_updated_at": "2012-03-27T00:00:00.000+00:00",
  "publishing_app": "manuals-publisher",
  "rendering_app": "manuals-frontend",
  "schema_name": "manual",
  "title": "National Planning Policy Framework",
  "updated_at": "2017-01-12T14:10:52.856Z",
  "withdrawn_notice": {},
  "links": {
    "organisations": [ /*snip*/ ],
    "sections": [
      {
        "analytics_identifier": null,
        "api_path": "/api/content/guidance/national-planning-policy-framework/ministerial-foreword",
        "base_path": "/guidance/national-planning-policy-framework/ministerial-foreword",
        "content_id": "6c77b27c-be11-4833-8c28-30f33fec6d9e",
        "description": "Ministerial foreword by the Rt Hon Greg Clark MP",
        "document_type": "manual_section",
        "locale": "en",
        "public_updated_at": "2012-03-27T00:00:00Z",
        "schema_name": "manual_section",
        "title": "Ministerial foreword",
        "withdrawn": false,
        "links": {},
        "api_url": "http://www.dev.gov.uk/api/content/guidance/national-planning-policy-framework/ministerial-foreword",
        "web_url": "http://www.dev.gov.uk/guidance/national-planning-policy-framework/ministerial-foreword"
      }, 
      /*snip-remaining*/
    ],
    "available_translations": [ /*snip*/ ]
  },
  "description": "The National Planning Policy Framework was published on 27 March 2012 and sets out the government’s planning policies for England and how these are expected to be applied.",
  "details": {
    "body": "\n",
    "child_section_groups": [
      {
        "title": "Contents",
        "child_sections": [ /*snip*/ ]
      }
    ],
    "change_notes": [
      {
        "base_path": "/guidance/national-planning-policy-framework/ministerial-foreword",
        "title": "Ministerial foreword",
        "change_note": "Imported to GOV.UK.",
        "published_at": "2016-12-29T09:31:10+00:00"
      }, 
      /*snip-remaining*/
    ]
  }
}
```