### PR TITLE
Fixes flappy test for manual_publication_log_filter_spec

### DIFF
--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -128,7 +128,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   it "builds logs for major updates in the 'archived' and 'published' status" do
-    publication_logs_for_supplied_slug = PublicationLog.with_slug_prefix(manual_slug).order_by(:id, :asc)
+    publication_logs_for_supplied_slug = PublicationLog.with_slug_prefix(manual_slug).order_by(:_id, :asc)
 
     expect(publication_logs_for_supplied_slug.count).to eq 5
 


### PR DESCRIPTION
Turns out the previous fixes in #783 weren't enough - although we'd
identified that the ordering was the problem, it wasn't the dates that
were the problem.  The test asks for the publication logs to be ordered
by id, but this does nothing.  Although id is a method on a mongoid object
that does indeed return the id of the object, the db field is actually
called `_id`. Asking to sort by `id` does nothing, which means we get
things back in an indeterminate order.

Asking to sort by `_id` gets the data in the expected order and the test
consistently passes (or so it seems anyway).

fixes #789