### PR TITLE
Register Document Type with Rummager

### DIFF
--- a/app/exporters/formatters/abstract_indexable_formatter.rb
+++ b/app/exporters/formatters/abstract_indexable_formatter.rb
@@ -25,6 +25,7 @@ private
       link: link,
       indexable_content: indexable_content,
       public_timestamp: public_timestamp,
+      content_store_document_type: type,
     }
   end
 


### PR DESCRIPTION
We need to be able to filter Rummager on document_type for Guidance content, so this change updates Searchable to present the document type for all "Editions".

This has been tested locally by publishing a draft Manual and checking that the content_store_document_type was present on a given manual and one of its sections.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager