### PR TITLE
Rake task for republishing manuals

### DIFF
--- a/lib/tasks/manuals.rake
+++ b/lib/tasks/manuals.rake
@@ -1,0 +1,11 @@
+namespace :manuals do
+  desc "Republishes all published manuals"
+  task republish: :environment do
+    registry = ManualServiceRegistry.new
+
+    registry.list({}).call.select { |manual| manual.published? }.each do |manual|
+      puts "Republishing #{manual.id} #{manual.title}"
+      registry.republish(manual.id)
+    end
+  end
+end


### PR DESCRIPTION
This Rake task will be required to republish all manuals, so that they are re-indexed in Rummager with a populated `content_store_document_type` field.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager?menu=filter&filter=@alec_gibson