### PR TITLE
Simplify ui around originally published at

### DIFF
--- a/app/assets/javascripts/toggle_display_with_checked_input.js
+++ b/app/assets/javascripts/toggle_display_with_checked_input.js
@@ -5,14 +5,9 @@
       showElement = args.mode === 'show';
 
     var toggleOnChange = function(){
-      console.log($input);
-      console.log("args.$mode =" + args.$mode);
       if($input.prop("checked")) {
-        console.log("checked - toggle: " + showElement);
         $element.toggle(showElement);
-      }
-      else {
-        console.log("unchecked - toggle: " + !showElement);
+      } else {
         $element.toggle(!showElement);
       }
     }

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -128,13 +128,8 @@ private
   end
 
   def publication_date_manual_params
-    base_manual_params(only: [:previously_published, :use_originally_published_at_for_public_timestamp])
+    base_manual_params(only: [:use_originally_published_at_for_public_timestamp])
       .merge(manual_date_params)
-      .tap do |extracted_params|
-        if extracted_params[:previously_published] == "0"
-          extracted_params[:originally_published_at] = nil
-        end
-      end
   end
 
   def base_manual_params(only: valid_params)

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -69,23 +69,7 @@ private
   end
 
   def update_type
-    # The first edition to be sent to the publishing api must always be sent as
-    # a major update
-    return "major" unless manual.has_ever_been_published?
-
-    # Otherwise our update type status depends on the update type status
-    # of our children if any of them are major we are major (and they
-    # have to send a major for their first edition too).
-    all_documents_are_minor? ? "minor" : "major"
-  end
-
-  def all_documents_are_minor?
-    manual.
-      documents.
-      select(&:needs_exporting?).
-      all? { |d|
-        d.minor_update? && d.has_ever_been_published?
-      }
+    ManualUpdateType.for(manual)
   end
 
   def rendered_manual_attributes

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,13 +2,6 @@
 
 module ApplicationHelper
   def state(document)
-    state, classes = state_for_frontend(document)
-
-    content_tag(:span, state, class: classes).html_safe
-
-  end
-
-  def state_for_frontend(document)
     state = document.publication_state
 
     if %w(published withdrawn).include?(state) && document.draft?
@@ -20,10 +13,9 @@ module ApplicationHelper
     else
       classes = "label label-default"
     end
-    [state, classes]
-  end
 
-  module_function :state_for_frontend
+    content_tag(:span, state, class: classes).html_safe
+  end
 
   def show_preview?(item)
     if item.respond_to?(:documents)
@@ -96,10 +88,6 @@ module ApplicationHelper
 
   def content_preview_url(document)
     "#{Plek.current.find("draft-origin")}/#{document.slug}"
-  end
-
-  def finders_sorted_by_title
-    finders.sort_by {|_, value| value[:title] }
   end
 
   def publish_text(manual, slug_unique)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -102,4 +102,24 @@ module ApplicationHelper
     finders.sort_by {|_, value| value[:title] }
   end
 
+  def publish_text(manual, slug_unique)
+    if manual.state == "published"
+      text = "<p>There are no changes to publish.</p>"
+    elsif manual.state == "withdrawn"
+      text = "<p>The manual is withdrawn. You need to create a new draft before it can be published.</p>"
+    elsif !current_user_can_publish?("manual")
+      text = "<p>You don't have permission to publish this manual.</p>"
+    elsif !slug_unique
+      text = "<p>This manual has a duplicate slug and can't be published.</p>"
+    else
+      update_type = ManualUpdateType.for(manual)
+      if update_type == "minor"
+        text = "<p>You are about to publish a <strong>minor edit</strong>.</p>"
+      elsif update_type == "major" && manual.has_ever_been_published?
+        text = "<p><strong>You are about to publish a major edit with public change notes.</strong></p>"
+      end
+    end
+
+    (text || "").html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,71 +98,8 @@ module ApplicationHelper
     "#{Plek.current.find("draft-origin")}/#{document.slug}"
   end
 
-  def publish_form(slug_unique, publishable, document)
-    publish_form_text = publish_text_hash(document)
-    if !current_user_can_publish?(document.document_type) || !slug_unique || !publishable
-      if !current_user_can_publish?(document.document_type)
-        publish_locals = publish_form_text[:no_permission]
-      elsif !publishable
-        publish_locals = publish_form_text[:already_published]
-      elsif !slug_unique
-        publish_locals = publish_form_text[:slug_not_unique]
-      end
-    elsif publishable
-      if !document.change_note.blank? && document.change_note != "First published."
-        publish_locals = publish_form_text[:major_update]
-      elsif document.minor_update
-        publish_locals = publish_form_text[:minor_update]
-      else
-        publish_locals = publish_form_text[:new_document]
-      end
-    end
-    render partial: "specialist_documents/publish_form", locals: {
-      warning: publish_locals[:warning],
-      notification: publish_locals[:notification],
-      disabled: publish_locals[:disabled],
-      document: document
-    }
-  end
-
   def finders_sorted_by_title
     finders.sort_by {|_, value| value[:title] }
-  end
-
-private
-  def publish_text_hash(document)
-    {
-      no_permission: {
-        disabled: true,
-        warning: nil,
-        notification: "You don’t have permission to publish this document.",
-      },
-      already_published: {
-        disabled: true,
-        warning: nil,
-        notification: "There are no changes to publish.",
-      },
-      slug_not_unique: {
-        disabled: true,
-        warning: "You can’t publish this document",
-        notification: "This document has a duplicate slug.<br/> You need to #{link_to "edit the document", [:edit, document]} and change the title to be able to be published.",
-      },
-      major_update: {
-        disabled: false,
-        warning: "You are about to publish a <strong>major edit</strong> with a public change note.",
-        notification: "Publishing will email subscribers to #{current_finder[:title]}.",
-      },
-      minor_update: {
-        disabled: false,
-        warning: nil,
-        notification: "You are about to publish a <strong>minor edit</strong>.",
-      },
-      new_document: {
-        disabled: false,
-        warning: nil,
-        notification: "Publishing will email subscribers to #{current_finder[:title]}.",
-      }
-    }
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,11 +100,19 @@ module ApplicationHelper
     elsif !slug_unique
       text = "<p>This manual has a duplicate slug and can't be published.</p>"
     else
+      text = ""
       update_type = ManualUpdateType.for(manual)
       if update_type == "minor"
-        text = "<p>You are about to publish a <strong>minor edit</strong>.</p>"
+        text += "<p>You are about to publish a <strong>minor edit</strong>.</p>"
       elsif update_type == "major" && manual.has_ever_been_published?
-        text = "<p><strong>You are about to publish a major edit with public change notes.</strong></p>"
+        text += "<p><strong>You are about to publish a major edit with public change notes.</strong></p>"
+      end
+      if manual.use_originally_published_at_for_public_timestamp? && manual.originally_published_at.present?
+        text += "<p>The updated timestamp on GOV.UK will be set to the first publication date.</p>"
+      elsif update_type == "minor"
+        text += "<p>The updated timestamp on GOV.UK will not change.</p>"
+      elsif update_type == "major"
+        text += "<p>The updated timestamp on GOV.UK will be set to the time you press the publish button.</p>"
       end
     end
 

--- a/app/lib/manual_update_type.rb
+++ b/app/lib/manual_update_type.rb
@@ -1,0 +1,32 @@
+class ManualUpdateType
+  def self.for(manual)
+    new(manual).update_type
+  end
+
+  def initialize(manual)
+    @manual = manual
+  end
+
+  def update_type
+    # The first edition to be sent to the publishing api must always be sent as
+    # a major update
+    return "major" unless manual.has_ever_been_published?
+
+    # Otherwise our update type status depends on the update type status
+    # of our children if any of them are major we are major (and they
+    # have to send a major for their first edition too).
+    all_documents_are_minor? ? "minor" : "major"
+  end
+
+private
+  attr_reader :manual
+
+  def all_documents_are_minor?
+    manual.
+      documents.
+      select(&:needs_exporting?).
+      all? { |d|
+        d.minor_update? && d.has_ever_been_published?
+      }
+  end
+end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -77,7 +77,13 @@ class Manual
   end
 
   def publication_state
-    state
+    if withdrawn?
+      "withdrawn"
+    elsif has_ever_been_published? || published?
+      "published"
+    else
+      "draft"
+    end
   end
 
   def published?

--- a/app/views/manuals/edit_original_publication_date.html.erb
+++ b/app/views/manuals/edit_original_publication_date.html.erb
@@ -1,35 +1,25 @@
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>
-  <li class="active">Edit original publication date</li>
+  <li class="active">Edit first publication date</li>
 <% end %>
 
-<h1 class="page-header">Edit original publication date</h1>
+<h1 class="page-header">Edit first publication date</h1>
 
 <div class="row">
   <div class="col-md-8">
     <%= form_for manual, url: original_publication_date_manual_path(manual), method: :put do |f| %>
       <%= render partial: "shared/form_errors", locals: { object: manual } %>
-      <label class="control-label">This manual</label>
-      <div class="checkbox add-vertical-margins">
-        <%= f.radio_button(:previously_published, 0, tag_type: :p, label: 'was first published on GOV.UK.', checked: !manual.originally_published_at.present?) %>
+      <%= f.label :originally_published_at, "First publication date:" %>
+      <div class="form-inline add-vertical-margins">
+        <%= f.datetime_select :originally_published_at, { include_blank: true, start_year: Date.today.year, end_year: 1945 }, { class: 'date form-control' } %>
       </div>
       <div class="checkbox add-vertical-margins">
-        <%= f.radio_button(:previously_published, 1, tag_type: :p, label: 'was first published on another website.', checked: manual.originally_published_at.present?) %>
+        <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 1, tag_type: :p, label: 'Change the GOV.UK publication date.', checked: manual.use_originally_published_at_for_public_timestamp?) %>
       </div>
-      <%= content_tag :div, class: manual.originally_published_at.present? ? nil : "js-hidden" do %>
-        <%= f.label :originally_published_at, "Its original publication date was" %>
-        <div class="form-inline add-vertical-margins">
-          <%= f.datetime_select :originally_published_at, { include_blank: true, start_year: Date.today.year, end_year: 1945 }, { class: 'date form-control' } %>
-        </div>
-        <label class="control-label">The "updated at" timestamp on GOV.UK</label>
-        <div class="checkbox add-vertical-margins">
-          <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 1, tag_type: :p, label: 'should use the original publication date above.', checked: manual.use_originally_published_at_for_public_timestamp?) %>
-        </div>
-        <div class="checkbox add-vertical-margins">
-          <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 0, tag_type: :p, label: 'should use the actual time of publication.', checked: !manual.use_originally_published_at_for_public_timestamp?) %>
-        </div>
-      <% end %>
+      <div class="checkbox add-vertical-margins">
+        <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 0, tag_type: :p, label: 'Keep the original GOV.UK publication date.', checked: !manual.use_originally_published_at_for_public_timestamp?) %>
+      </div>
 
       <div class="actions">
         <button name="draft" class="btn btn-danger" data-disable-with="Saving...">Save as draft</button>
@@ -38,17 +28,3 @@
     <% end %>
   </div>
 </div>
-
-<%= content_for :document_ready do %>
-  window.toggleDisplayWithCheckedInput({
-    $input: $("#manual_previously_published_0"),
-    $element: $("#manual_originally_published_at_1i").parent().parent(),
-    mode: 'hide'
-  });
-  window.toggleDisplayWithCheckedInput({
-    $input: $("#manual_previously_published_1"),
-    $element: $("#manual_originally_published_at_1i").parent().parent(),
-    mode: 'show'
-  });
-  $('.js-hidden').hide();
-<% end %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -88,13 +88,16 @@
       <%= link_to 'Edit first publication date', original_publication_date_manual_path(manual), class: 'btn btn-default' %>
     </div>
 
-    <% if manual.draft? && manual.documents.any? && current_user_can_publish?("manual") && slug_unique %>
-      <%= form_tag(publish_manual_path(manual), method: :post, class: 'panel panel-default') do %>
-        <div class="panel-heading"><h3>Publish manual</h3></div>
-        <div class="panel-body">
-          <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
-        </div>
-      <% end -%>
-    <% end %>
+    <div class="panel panel-default">
+      <div class="panel-heading"><h3>Publish manual</h3></div>
+      <div class="panel-body">
+        <%= publish_text(manual, slug_unique) %>
+        <% if manual.draft? && manual.documents.any? && current_user_can_publish?("manual") && slug_unique %>
+          <%= form_tag(publish_manual_path(manual), method: :post) do %>
+            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
+          <% end -%>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -63,10 +63,9 @@
 <div class="row">
   <div class="col-md-8">
     <h2>Sections</h2>
-    <div class="add-bottom-margin">
+    <div class="well add-bottom-margin">
       <%= link_to 'Reorder sections', reorder_manual_documents_path(manual), class: 'btn btn-default add-right-margin' %>
-      <%= link_to 'Add section', new_manual_document_path(manual), class: 'btn btn-default add-right-margin' %>
-      <%= link_to 'Edit original publication date', original_publication_date_manual_path(manual), class: 'btn btn-default' %>
+      <%= link_to 'Add section', new_manual_document_path(manual), class: 'btn btn-default' %>
     </div>
     <% if manual.documents.any? %>
     <ul class="document-list">
@@ -83,13 +82,18 @@
       <p class='no-content-message'>You haven&rsquo;t added any sections to this manual yet.</p>
     <% end %>
 
+    <h2>Actions</h2>
     <div class="well">
-      <%= link_to 'Edit manual', edit_manual_path(manual), class: 'btn btn-success' %>
+      <%= link_to 'Edit manual', edit_manual_path(manual), class: 'btn btn-success add-right-margin' %>
+      <%= link_to 'Edit first publication date', original_publication_date_manual_path(manual), class: 'btn btn-default' %>
     </div>
 
     <% if manual.draft? && manual.documents.any? && current_user_can_publish?("manual") && slug_unique %>
-      <%= form_tag(publish_manual_path(manual), method: :post, class: 'well') do %>
-        <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
+      <%= form_tag(publish_manual_path(manual), method: :post, class: 'panel panel-default') do %>
+        <div class="panel-heading"><h3>Publish manual</h3></div>
+        <div class="panel-body">
+          <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
+        </div>
       <% end -%>
     <% end %>
   </div>

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -18,6 +18,14 @@ Feature: Creating and editing a manual
     Then the manual should have been updated
     And the edited manual should have been sent to the draft publishing api
 
+  Scenario: Checking publication state of a manual
+    Given a draft manual exists with some documents
+    Then the manual is listed as draft
+    When I publish the manual
+    Then the manual is listed as published
+    When I edit the manual
+    Then the manual is listed as published with new draft
+
   @javascript
   Scenario: Previewing a draft manual
     Given a draft manual exists without any documents

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -82,9 +82,10 @@ Given(/^a draft manual exists belonging to "(.*?)"$/) do |organisation_slug|
   WebMock::RequestRegistry.instance.reset!
 end
 
-When(/^I edit a manual$/) do
+When(/^I edit (?:a|the) manual$/) do
   @new_title = "Edited Example Manual"
   edit_manual(@manual_fields[:title], title: @new_title)
+  @manual = most_recently_created_manual
 end
 
 Then(/^the manual should have been updated$/) do
@@ -715,4 +716,14 @@ Then(/^the new order should be visible in the preview environment$/) do
     @manual.id,
     extra_attributes: manual_table_of_contents_attributes,
   )
+end
+
+Then(/^the manual is listed as (draft|published|published with new draft)$/) do |status|
+  visit manuals_path
+
+  expect(page).to have_selector(:xpath, "//li[a[.='#{@manual.title}']]//span[contains(concat(' ', normalize-space(@class), ' '), ' label ')][.='#{status}']")
+
+  click_on @manual.title
+
+  expect(page).to have_selector(:xpath, "//dt[.='State']/following-sibling::dd[.='#{status}']")
 end

--- a/features/step_definitions/previously_published_manual_steps.rb
+++ b/features/step_definitions/previously_published_manual_steps.rb
@@ -23,8 +23,7 @@ When(/^I tell the manual to stop using the previously published date as the publ
   WebMock::RequestRegistry.instance.reset!
 
   edit_manual_original_publication_date(@manual.title) do
-    choose("was first published on another website.")
-    choose("should use the actual time of publication.")
+    choose("Keep the original GOV.UK publication date.")
   end
 
   step %{I publish the manual}
@@ -36,8 +35,7 @@ When(/^I update the previously published date to a new one$/) do
   @new_originally_published_at = DateTime.parse("25-Mar-#{Date.today.year - 8} 12:57")
 
   edit_manual_original_publication_date(@manual.title) do
-    choose("was first published on another website.")
-    select_datetime @new_originally_published_at.iso8601, from: "Its original publication date was"
+    select_datetime @new_originally_published_at.to_s, from: "First publication date:"
   end
 
   step %{I publish the manual}
@@ -47,7 +45,7 @@ When(/^I update the manual to clear the previously published date$/) do
   WebMock::RequestRegistry.instance.reset!
 
   edit_manual_original_publication_date(@manual.title) do
-    choose("was first published on GOV.UK.")
+    clear_datetime "First publication date:"
   end
 
   step %{I publish the manual}
@@ -57,8 +55,7 @@ When(/^I tell the manual to start using the previously published date as the pub
   WebMock::RequestRegistry.instance.reset!
 
   edit_manual_original_publication_date(@manual.title) do
-    choose("was first published on another website.")
-    choose("should use the original publication date above.")
+    choose("Change the GOV.UK publication date.")
   end
 
   step %{I publish the manual}

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -14,5 +14,16 @@ module FormHelpers
       fill_in label_text, with: value
     end
   end
+
+  def clear_datetime(label)
+    base_dom_id = find(:xpath, ".//label[contains(., '#{label}')]")["for"].gsub(/(_[1-5]i)$/, "")
+
+    find(:xpath, ".//select[@id='#{base_dom_id}_1i']").select("")
+    find(:xpath, ".//select[@id='#{base_dom_id}_2i']").select("")
+    find(:xpath, ".//select[@id='#{base_dom_id}_3i']").select("")
+
+    find(:xpath, ".//select[@id='#{base_dom_id}_4i']").select("")
+    find(:xpath, ".//select[@id='#{base_dom_id}_5i']").select("")
+  end
 end
 RSpec.configuration.include FormHelpers, type: :feature

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -76,7 +76,7 @@ module ManualHelpers
 
   def edit_manual_original_publication_date(manual_title)
     go_to_manual_page(manual_title)
-    click_on("Edit original publication date")
+    click_on("Edit first publication date")
 
     yield if block_given?
 

--- a/spec/lib/manual_update_type_spec.rb
+++ b/spec/lib/manual_update_type_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+RSpec.describe ManualUpdateType do
+  let(:manual) { double(:manual) }
+  subject { described_class.for(manual) }
+
+  describe "for a manual that has never been published" do
+    before { allow(manual).to receive(:has_ever_been_published?).and_return false }
+
+    it "is 'major'" do
+      expect(subject).to eql "major"
+    end
+  end
+
+  describe "for a manual that has been published before" do
+    before { allow(manual).to receive(:has_ever_been_published?).and_return true }
+
+    context "and has no documents" do
+      before { allow(manual).to receive(:documents).and_return [] }
+
+      it "is 'minor'" do
+        expect(subject).to eql "minor"
+      end
+    end
+
+    context "and has documents" do
+      let(:document_1) { double(:specialist_document) }
+      let(:document_2) { double(:specialist_document) }
+      let(:document_3) { double(:specialist_document) }
+      before { allow(manual).to receive(:documents).and_return [document_1, document_2, document_3] }
+
+      context "none of which need exporting" do
+        before do
+          allow(document_1).to receive(:needs_exporting?).and_return false
+          allow(document_2).to receive(:needs_exporting?).and_return false
+          allow(document_3).to receive(:needs_exporting?).and_return false
+        end
+
+        it "is 'minor'" do
+          expect(subject).to eql "minor"
+        end
+      end
+
+      context "some of which need exporting" do
+        before do
+          allow(document_1).to receive(:needs_exporting?).and_return true
+          allow(document_2).to receive(:needs_exporting?).and_return true
+          allow(document_3).to receive(:needs_exporting?).and_return true
+        end
+
+        it "is 'minor' when all documents are minor updates that have been published before" do
+          allow(document_1).to receive(:minor_update?).and_return true
+          allow(document_2).to receive(:minor_update?).and_return true
+          allow(document_3).to receive(:minor_update?).and_return true
+          allow(document_1).to receive(:has_ever_been_published?).and_return true
+          allow(document_2).to receive(:has_ever_been_published?).and_return true
+          allow(document_3).to receive(:has_ever_been_published?).and_return true
+
+          expect(subject).to eql "minor"
+        end
+
+        it "is 'major' when at least one document is a minor update that has never been published before" do
+          allow(document_1).to receive(:minor_update?).and_return true
+          allow(document_2).to receive(:minor_update?).and_return true
+          allow(document_3).to receive(:minor_update?).and_return true
+          allow(document_1).to receive(:has_ever_been_published?).and_return true
+          allow(document_2).to receive(:has_ever_been_published?).and_return true
+          allow(document_3).to receive(:has_ever_been_published?).and_return false
+
+          expect(subject).to eql "major"
+        end
+
+        it "is 'major' when at least one documents is a major update" do
+          allow(document_1).to receive(:minor_update?).and_return false
+          allow(document_2).to receive(:minor_update?).and_return true
+          allow(document_3).to receive(:minor_update?).and_return true
+          allow(document_1).to receive(:has_ever_been_published?).and_return true
+          allow(document_2).to receive(:has_ever_been_published?).and_return true
+          allow(document_3).to receive(:has_ever_been_published?).and_return true
+
+          expect(subject).to eql "major"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -110,6 +110,50 @@ describe Manual do
     end
   end
 
+  describe "#publication_state" do
+    context "for a manual in the draft state" do
+      let(:state) { "draft" }
+
+      it "is draft for the first edition" do
+        allow(manual).to receive(:has_ever_been_published?).and_return false
+        expect(manual.publication_state).to eql "draft"
+      end
+
+      it "is published if the manual has ever been published" do
+        allow(manual).to receive(:has_ever_been_published?).and_return true
+        expect(manual.publication_state).to eql "published"
+      end
+    end
+
+    context "for a manual in the published state" do
+      let(:state) { "published" }
+
+      it "is published for the first edition" do
+        allow(manual).to receive(:has_ever_been_published?).and_return false
+        expect(manual.publication_state).to eql "published"
+      end
+
+      it "is published if the manual has ever been published" do
+        allow(manual).to receive(:has_ever_been_published?).and_return true
+        expect(manual.publication_state).to eql "published"
+      end
+    end
+
+    context "for a manual in the withdrawn state" do
+      let(:state) { "withdrawn" }
+
+      it "is withdrawn for the first edition" do
+        allow(manual).to receive(:has_ever_been_published?).and_return false
+        expect(manual.publication_state).to eql "withdrawn"
+      end
+
+      it "is withdrawn if the manual has ever been published" do
+        allow(manual).to receive(:has_ever_been_published?).and_return true
+        expect(manual.publication_state).to eql "withdrawn"
+      end
+    end
+  end
+
   describe "#update" do
     it "returns self" do
       expect(manual.update({})).to be(manual)


### PR DESCRIPTION
For: https://trello.com/c/hvHGxTuD/94-change-published-date-in-manuals

As a follow up to the UI in #793 we tweak the UI slightly to simplify it based on feedback from folk better acquainted with the app and its users.

Highlights:

* the state lozenges now include "published with new draft" to distinguish draft manuals that have never been published from those that have been published in a previous edition

<img width="538" alt="manuals publisher" src="https://cloud.githubusercontent.com/assets/608/22512431/e6b39528-e890-11e6-95fc-974f048cb67c.png">

* the publish button now lives in a panel that includes text describing the outcome (major vs. minor, how the updated at timestamp will change) or explaining why the publish button isn't present

<img width="422" alt="manuals publisher-1" src="https://cloud.githubusercontent.com/assets/608/22512466/008836de-e891-11e6-94e9-3a93d1e13bc6.png">

* the create UI for setting the first published at remains the same, but the edit UI no longer has the first choice ("this manual is new" vs "this manual was published elsewhere") and the second choice has been reworded.

<img width="484" alt="manuals publisher-2" src="https://cloud.githubusercontent.com/assets/608/22512606/8921cc8a-e891-11e6-80e3-c06d74d27c62.png">
