### PR TITLE
Use Ruby keyword args instead of custom code

### DIFF
--- a/app/lib/slug_generator.rb
+++ b/app/lib/slug_generator.rb
@@ -1,6 +1,6 @@
 class SlugGenerator
-  def initialize(dependencies)
-    @prefix = dependencies.fetch(:prefix)
+  def initialize(prefix:)
+    @prefix = prefix
   end
 
   def call(title)

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -1,9 +1,9 @@
 require "securerandom"
 
 class ManualBuilder
-  def initialize(dependencies)
-    @slug_generator = dependencies.fetch(:slug_generator)
-    @factory = dependencies.fetch(:factory)
+  def initialize(slug_generator:, factory:)
+    @slug_generator = slug_generator
+    @factory = factory
   end
 
   def call(attrs)

--- a/app/models/builders/manual_document_builder.rb
+++ b/app/models/builders/manual_document_builder.rb
@@ -1,8 +1,8 @@
 require "securerandom"
 
 class ManualDocumentBuilder
-  def initialize(dependencies)
-    @factory_factory = dependencies.fetch(:factory_factory)
+  def initialize(factory_factory:)
+    @factory_factory = factory_factory
   end
 
   def call(manual, attrs)

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -1,10 +1,10 @@
 require "delegate"
 
 class ManualWithDocuments < SimpleDelegator
-  def initialize(document_builder, manual, attrs)
+  def initialize(document_builder, manual, documents:, removed_documents: [])
     @manual = manual
-    @documents = attrs.fetch(:documents)
-    @removed_documents = attrs.fetch(:removed_documents, [])
+    @documents = documents
+    @removed_documents = removed_documents
     @document_builder = document_builder
     super(manual)
   end

--- a/app/models/manual_with_publish_tasks.rb
+++ b/app/models/manual_with_publish_tasks.rb
@@ -2,9 +2,9 @@ require "delegate"
 
 class ManualWithPublishTasks < SimpleDelegator
 
-  def initialize(manual, attrs)
+  def initialize(manual, publish_tasks:)
     super(manual)
-    @publish_tasks = attrs.fetch(:publish_tasks)
+    @publish_tasks = publish_tasks
   end
 
   def publish_tasks

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -5,10 +5,10 @@ class ManualRepository
 
   NotFoundError = Module.new
 
-  def initialize(dependencies = {})
-    @collection = dependencies.fetch(:collection)
-    @factory = dependencies.fetch(:factory)
-    @association_marshallers = dependencies.fetch(:association_marshallers, [])
+  def initialize(collection:, factory:, association_marshallers: [])
+    @collection = collection
+    @factory = factory
+    @association_marshallers = association_marshallers
   end
 
   def fetch(*args, &block)

--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -1,7 +1,7 @@
 class DocumentAssociationMarshaller
-  def initialize(dependencies = {})
-    @decorator = dependencies.fetch(:decorator)
-    @manual_specific_document_repository_factory = dependencies.fetch(:manual_specific_document_repository_factory)
+  def initialize(decorator:, manual_specific_document_repository_factory:)
+    @decorator = decorator
+    @manual_specific_document_repository_factory = manual_specific_document_repository_factory
   end
 
   def load(manual, record)

--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -1,7 +1,7 @@
 class ManualPublishTaskAssociationMarshaller
-  def initialize(dependencies = {})
-    @decorator = dependencies.fetch(:decorator)
-    @collection = dependencies.fetch(:collection)
+  def initialize(decorator:, collection:)
+    @decorator = decorator
+    @collection = collection
   end
 
   def load(manual, _record)

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -11,9 +11,9 @@ class SpecialistDocumentRepository
     raise e.extend(NotFoundError)
   end
 
-  def initialize(dependencies)
-    @document_type = dependencies.fetch(:document_type)
-    @document_factory = dependencies.fetch(:document_factory)
+  def initialize(document_type:, document_factory:)
+    @document_type = document_type
+    @document_factory = document_factory
   end
 
   def all(limit = -1, offset = 0)

--- a/app/services/create_manual_document_service.rb
+++ b/app/services/create_manual_document_service.rb
@@ -1,8 +1,8 @@
 class CreateManualDocumentService
-  def initialize(dependencies)
-    @manual_repository = dependencies.fetch(:manual_repository)
-    @listeners = dependencies.fetch(:listeners)
-    @context = dependencies.fetch(:context)
+  def initialize(manual_repository:, listeners:, context:)
+    @manual_repository = manual_repository
+    @listeners = listeners
+    @context = context
   end
 
   def call

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -1,9 +1,9 @@
 class CreateManualService
-  def initialize(dependencies)
-    @manual_repository = dependencies.fetch(:manual_repository)
-    @manual_builder = dependencies.fetch(:manual_builder)
-    @listeners = dependencies.fetch(:listeners)
-    @attributes = dependencies.fetch(:attributes)
+  def initialize(manual_repository:, manual_builder:, listeners:, attributes:)
+    @manual_repository = manual_repository
+    @manual_builder = manual_builder
+    @listeners = listeners
+    @attributes = attributes
   end
 
   def call

--- a/app/services/list_manuals_service.rb
+++ b/app/services/list_manuals_service.rb
@@ -1,7 +1,7 @@
 class ListManualsService
-  def initialize(dependencies)
-    @manual_repository = dependencies.fetch(:manual_repository)
-    @context = dependencies.fetch(:context)
+  def initialize(manual_repository:, context:)
+    @manual_repository = manual_repository
+    @context = context
   end
 
   def call

--- a/app/services/organisational_manual_document_attachment_service_registry.rb
+++ b/app/services/organisational_manual_document_attachment_service_registry.rb
@@ -1,6 +1,6 @@
 class OrganisationalManualDocumentAttachmentServiceRegistry < AbstractManualDocumentAttachmentServiceRegistry
-  def initialize(dependencies)
-    @organisation_slug = dependencies.fetch(:organisation_slug)
+  def initialize(organisation_slug:)
+    @organisation_slug = organisation_slug
   end
 
 private

--- a/app/services/organisational_manual_document_service_registry.rb
+++ b/app/services/organisational_manual_document_service_registry.rb
@@ -1,6 +1,6 @@
 class OrganisationalManualDocumentServiceRegistry < AbstractManualDocumentServiceRegistry
-  def initialize(dependencies)
-    @organisation_slug = dependencies.fetch(:organisation_slug)
+  def initialize(organisation_slug:)
+    @organisation_slug = organisation_slug
   end
 
 private

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -1,6 +1,6 @@
 class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
-  def initialize(dependencies)
-    @organisation_slug = dependencies.fetch(:organisation_slug)
+  def initialize(organisation_slug:)
+    @organisation_slug = organisation_slug
   end
 
 private

--- a/app/services/preview_manual_service.rb
+++ b/app/services/preview_manual_service.rb
@@ -1,10 +1,10 @@
 class PreviewManualService
-  def initialize(dependencies = {})
-    @repository = dependencies.fetch(:repository)
-    @builder = dependencies.fetch(:builder)
-    @renderer = dependencies.fetch(:renderer)
-    @manual_id = dependencies.fetch(:manual_id)
-    @attributes = dependencies.fetch(:attributes)
+  def initialize(repository:, builder:, renderer:, manual_id:, attributes:)
+    @repository = repository
+    @builder = builder
+    @renderer = renderer
+    @manual_id = manual_id
+    @attributes = attributes
   end
 
   def call

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -1,9 +1,9 @@
 class PublishManualService
-  def initialize(dependencies)
-    @manual_id = dependencies.fetch(:manual_id)
-    @manual_repository = dependencies.fetch(:manual_repository)
-    @listeners = dependencies.fetch(:listeners)
-    @version_number = dependencies.fetch(:version_number)
+  def initialize(manual_id:, manual_repository:, listeners:, version_number:)
+    @manual_id = manual_id
+    @manual_repository = manual_repository
+    @listeners = listeners
+    @version_number = version_number
   end
 
   def call

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -1,8 +1,8 @@
 class ShowManualService
 
-  def initialize(dependencies = {})
-    @manual_id = dependencies.fetch(:manual_id)
-    @manual_repository = dependencies.fetch(:manual_repository)
+  def initialize(manual_id:, manual_repository:)
+    @manual_id = manual_id
+    @manual_repository = manual_repository
   end
 
   def call

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -1,9 +1,9 @@
 class UpdateManualService
-  def initialize(dependencies)
-    @manual_repository = dependencies.fetch(:manual_repository)
-    @manual_id = dependencies.fetch(:manual_id)
-    @attributes = dependencies.fetch(:attributes)
-    @listeners = dependencies.fetch(:listeners)
+  def initialize(manual_repository:, manual_id:, attributes:, listeners:)
+    @manual_repository = manual_repository
+    @manual_id = manual_id
+    @attributes = attributes
+    @listeners = listeners
   end
 
   def call


### PR DESCRIPTION
A number of `initialize` methods were taking a hash parameter and then manually extracting required/optional parameters. I think it's clearer to use Ruby's keyword arguments to serve this same purpose.

This branch changes all but one instance (`Manual#initialize`) to use Ruby keyword args instead of custom code. I can't immediately see how to change `Manual#initialize` without also having to change the code that calls it.

We already had a mixture of regular args and keyword args in the code but making them more consistent is outside the scope of this PR.
