### PR TITLE
Rework republishing

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,5 +1,5 @@
 class ManualPublishingAPIExporter
-  UPDATE_TYPES = %w(minor major republish).freeze
+  include PublishingAPIUpdateTypes
 
   def initialize(export_recipent, organisation, manual_renderer, publication_logs, manual, update_type: nil)
     @export_recipent = export_recipent
@@ -7,8 +7,8 @@ class ManualPublishingAPIExporter
     @manual_renderer = manual_renderer
     @publication_logs = publication_logs
     @manual = manual
-    raise ArgumentError, "update_type '#{update_type}' not recognised" if update_type.present? && !UPDATE_TYPES.include?(update_type)
     @update_type = update_type
+    check_update_type!(@update_type)
   end
 
   def call
@@ -22,7 +22,7 @@ private
     :organisation,
     :manual_renderer,
     :publication_logs,
-    :manual
+    :manual,
   )
 
   def base_path

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,11 +1,14 @@
 class ManualPublishingAPIExporter
+  UPDATE_TYPES = %w(minor major republish).freeze
 
-  def initialize(export_recipent, organisation, manual_renderer, publication_logs, manual)
+  def initialize(export_recipent, organisation, manual_renderer, publication_logs, manual, update_type: nil)
     @export_recipent = export_recipent
     @organisation = organisation
     @manual_renderer = manual_renderer
     @publication_logs = publication_logs
     @manual = manual
+    raise ArgumentError, "update_type '#{update_type}' not recognised" if update_type.present? && !UPDATE_TYPES.include?(update_type)
+    @update_type = update_type
   end
 
   def call
@@ -69,6 +72,7 @@ private
   end
 
   def update_type
+    return @update_type if @update_type.present?
     ManualUpdateType.for(manual)
   end
 

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -1,5 +1,5 @@
 class ManualSectionPublishingAPIExporter
-  UPDATE_TYPES = %w(minor major republish).freeze
+  include PublishingAPIUpdateTypes
 
   def initialize(export_recipent, organisation, document_renderer, manual, document, update_type: nil)
     @export_recipent = export_recipent
@@ -7,8 +7,8 @@ class ManualSectionPublishingAPIExporter
     @document_renderer = document_renderer
     @manual = manual
     @document = document
-    raise ArgumentError, "update_type '#{update_type}' not recognised" if update_type.present? && !UPDATE_TYPES.include?(update_type)
     @update_type = update_type
+    check_update_type!(@update_type)
   end
 
   def call

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -1,11 +1,14 @@
 class ManualSectionPublishingAPIExporter
+  UPDATE_TYPES = %w(minor major republish).freeze
 
-  def initialize(export_recipent, organisation, document_renderer, manual, document)
+  def initialize(export_recipent, organisation, document_renderer, manual, document, update_type: nil)
     @export_recipent = export_recipent
     @organisation = organisation
     @document_renderer = document_renderer
     @manual = manual
     @document = document
+    raise ArgumentError, "update_type '#{update_type}' not recognised" if update_type.present? && !UPDATE_TYPES.include?(update_type)
+    @update_type = update_type
   end
 
   def call
@@ -99,6 +102,7 @@ private
   end
 
   def update_type
+    return @update_type if @update_type.present?
     # The first edition to be sent to the publishing-api must always be sent as
     # a major update
     return "major" unless document.has_ever_been_published?

--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -1,11 +1,15 @@
 class PublishingAPIPublisher
-  def initialize(publishing_api:, entity:)
+  UPDATE_TYPES = %w(minor major republish).freeze
+
+  def initialize(publishing_api:, entity:, update_type: nil)
     @publishing_api = publishing_api
     @entity = entity
+    @update_type = update_type
+    raise ArgumentError, "update_type '#{update_type}' not recognised" if update_type.present? && !UPDATE_TYPES.include?(update_type)
   end
 
   def call
-    publishing_api.publish(entity.id, nil)
+    publishing_api.publish(entity.id, update_type)
   end
 
 private
@@ -13,5 +17,6 @@ private
   attr_reader(
     :publishing_api,
     :entity,
+    :update_type,
   )
 end

--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -1,11 +1,11 @@
 class PublishingAPIPublisher
-  UPDATE_TYPES = %w(minor major republish).freeze
+  include PublishingAPIUpdateTypes
 
   def initialize(publishing_api:, entity:, update_type: nil)
     @publishing_api = publishing_api
     @entity = entity
     @update_type = update_type
-    raise ArgumentError, "update_type '#{update_type}' not recognised" if update_type.present? && !UPDATE_TYPES.include?(update_type)
+    check_update_type!(@update_type)
   end
 
   def call

--- a/app/exporters/publishing_api_update_types.rb
+++ b/app/exporters/publishing_api_update_types.rb
@@ -1,0 +1,7 @@
+module PublishingAPIUpdateTypes
+  UPDATE_TYPES = %w(minor major republish).freeze
+  def check_update_type!(update_type, allow_nil: true)
+    return if update_type.nil? && allow_nil
+    raise ArgumentError, "update_type '#{update_type}' not recognised" unless UPDATE_TYPES.include?(update_type)
+  end
+end

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -1,0 +1,111 @@
+require "manual_repository"
+
+class VersionedManualRepository
+
+  class NotFoundError < StandardError; include ManualRepository::NotFoundError; end
+
+  def self.get_manual(manual_id)
+    new.get_manual(manual_id)
+  end
+
+  def get_manual(manual_id)
+    manual_record = ManualRecord.find_by(manual_id: manual_id)
+    raise NotFoundError if manual_record.nil?
+
+    {
+      draft: get_current_draft_version_of_manual(manual_record),
+      published: get_current_published_version_of_manual(manual_record),
+    }
+  end
+
+private
+
+  def get_current_draft_version_of_manual(manual_record)
+    return nil unless manual_record.latest_edition.state == "draft"
+
+    build_manual_for(manual_record, manual_record.latest_edition) do
+      {
+        documents: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
+        removed_documents: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
+      }
+    end
+  end
+
+  def get_current_published_version_of_manual(manual_record)
+    return nil unless manual_record.has_ever_been_published?
+
+    if manual_record.latest_edition.state == "published"
+      build_manual_for(manual_record, manual_record.latest_edition) do
+        {
+          documents: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
+          removed_documents: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
+        }
+      end
+    elsif manual_record.latest_edition.state == "draft"
+      previous_edition = manual_record.editions.order_by([:version_number, :desc]).limit(2).last
+      if previous_edition.state == "published"
+        build_manual_for(manual_record, previous_edition) do
+          {
+            documents: get_published_version_of_documents(previous_edition.document_ids),
+            removed_documents: get_latest_version_of_documents(previous_edition.removed_document_ids)
+          }
+        end
+      else
+        # This means the previous edition is withdrawn so we shouldn't
+        # expose it as it's not actually published (we've got a new
+        # draft waiting in the wings for a withdrawn manual)
+        return nil
+      end
+    else
+      # This means the current edition is withdrawn so we shouldn't find
+      # the previously published one
+      return nil
+    end
+  end
+
+  def build_manual_for(manual_record, edition, &document_fetcher_block)
+    base_manual = Manual.new(
+      id: manual_record.manual_id,
+      slug: manual_record.slug,
+      title: edition.title,
+      summary: edition.summary,
+      body: edition.body,
+      organisation_slug: manual_record.organisation_slug,
+      state: edition.state,
+      version_number: edition.version_number,
+      updated_at: edition.updated_at,
+      ever_been_published: manual_record.has_ever_been_published?,
+      originally_published_at: edition.originally_published_at,
+      use_originally_published_at_for_public_timestamp: edition.use_originally_published_at_for_public_timestamp,
+    )
+
+    document_attrs = document_fetcher_block.call
+
+    ManualWithDocuments.new(
+      ->(_manual, _attrs) { raise RuntimeError, "read only manaul" },
+      base_manual,
+      document_attrs
+    )
+  end
+
+  def get_latest_version_of_documents(document_ids)
+    (document_ids || []).map do |document_id|
+      build_specialist_document(document_id) { |editions| editions }
+    end
+  end
+
+  def build_specialist_document(document_id, &filter)
+    all_editions = SpecialistDocumentEdition.where(document_type: "manual", document_id: document_id).order_by([:version_number, :desc]).to_a
+    SpecialistDocument.new(
+      ->(_title) { raise RuntimeError, "read only manual" },
+      document_id,
+      filter.call(all_editions).take(2).reverse,
+    )
+  end
+
+  def get_published_version_of_documents(document_ids)
+    (document_ids || []).map do |document_id|
+      build_specialist_document(document_id) { |editions| editions.drop_while { |e| e.state != "published" } }
+    end
+  end
+end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -77,8 +77,8 @@ class AbstractManualServiceRegistry
 
   def republish(manual_id)
     RepublishManualService.new(
-      manual_repository: repository,
-      listeners: observers.republication,
+      draft_listeners: observers.update,
+      published_listeners: observers.republication,
       manual_id: manual_id,
     )
   end

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -1,28 +1,35 @@
 class RepublishManualService
-  def initialize(manual_repository:, listeners: [], manual_id:)
-    @manual_repository = manual_repository
-    @listeners = listeners
+  def initialize(published_listeners: [], draft_listeners: [], manual_id:)
+    @published_listeners = published_listeners
+    @draft_listeners = draft_listeners
     @manual_id = manual_id
   end
 
   def call
-    if manual.published?
-      notify_listeners
-    end
+    notify_published_listeners if manual_versions[:published].present?
+    notify_draft_listeners if manual_versions[:draft].present?
 
-    manual
+    manual_versions
   end
 
 private
-  attr_reader :manual_repository, :listeners, :manual_id
+  attr_reader :published_listeners, :draft_listeners, :manual_id
 
-  def notify_listeners
-    listeners.each { |l| l.call(manual, :republish) }
+  def manual_repository
+    VersionedManualRepository
   end
 
-  def manual
-    @manual ||= manual_repository.fetch(manual_id)
-  rescue KeyError => error
+  def notify_published_listeners
+    published_listeners.each { |l| l.call(manual_versions[:published], :republish) }
+  end
+
+  def notify_draft_listeners
+    draft_listeners.each { |l| l.call(manual_versions[:draft], :republish) }
+  end
+
+  def manual_versions
+    @manual_versions ||= manual_repository.get_manual(manual_id)
+  rescue ManualRepository::NotFoundError => error
     raise ManualNotFoundError.new(error)
   end
 

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -1,0 +1,74 @@
+require "fast_spec_helper"
+
+require "publishing_api_publisher"
+
+describe PublishingAPIPublisher do
+  let(:publishing_api) { double(:publishing_api, publish: nil) }
+  let(:document_id) { "12345678-9abc-def0-1234-56789abcdef0" }
+  let(:document) { double(:document, id: document_id) }
+
+  it "raises an argument error if update_type is supplied, but not a valid choice" do
+    expect {
+      described_class.new(
+        publishing_api: publishing_api,
+        entity: document,
+        update_type: "reticulate-splines"
+      )
+    }.to raise_error(ArgumentError, "update_type 'reticulate-splines' not recognised")
+  end
+
+  it "accepts major, minor, and republish as options for update_type" do
+    %w(major minor republish).each do |update_type|
+      expect {
+        described_class.new(
+          publishing_api: publishing_api,
+          entity: document,
+          update_type: update_type
+        )
+      }.not_to raise_error
+    end
+  end
+
+  it "accepts explicitly setting nil as the option for update_type" do
+    expect {
+      described_class.new(
+        publishing_api: publishing_api,
+        entity: document,
+        update_type: nil
+      )
+    }.not_to raise_error
+  end
+
+  describe "#call" do
+    context "when no explicit update_type is given" do
+      subject do
+        described_class.new(
+          publishing_api: publishing_api,
+          entity: document
+        )
+      end
+
+      it "asks the publishing api to publish the document" do
+        subject.call
+
+        expect(publishing_api).to have_received(:publish).with(document_id, nil)
+      end
+    end
+
+    context "when an explicit update_type is given" do
+      subject do
+        described_class.new(
+          publishing_api: publishing_api,
+          entity: document,
+          update_type: "republish"
+        )
+      end
+
+      it "asks the publishing api to publish the document with the specific update_type" do
+        subject.call
+
+        expect(publishing_api).to have_received(:publish).with(document_id, "republish")
+      end
+    end
+  end
+end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -10,20 +10,44 @@ RSpec.describe "Republishing manuals", type: :feature do
 
   let(:original_publish_time) { DateTime.now - 1.day }
   let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
+  let(:edited_manual_fields) { { title: "Editted manual title", summary: "A changed summary" } }
 
-  def create_manual_with_sections
+  def edited_section_fields(section)
+    {
+      title: "I've changed this section: #{section.title}",
+      summary: "And its summary: #{section.summary}",
+    }
+  end
+
+  def create_manual_with_sections(published: true)
     manual = create_manual_without_ui(manual_fields)
     @documents = create_documents_for_manual_without_ui(manual: manual, count: 2)
 
     # Re-fetch manual to include documents
     @manual = manual_repository.fetch(manual.id)
 
-    Timecop.freeze(original_publish_time) do
-      publish_manual_without_ui(@manual)
+    if published
+      Timecop.freeze(original_publish_time) do
+        publish_manual_without_ui(@manual)
+      end
     end
 
-    check_manual_is_drafted_to_publishing_api(@manual.id, number_of_drafts: 4)
-    check_manual_is_published_to_publishing_api(@manual.id)
+    if published
+      check_manual_is_drafted_to_publishing_api(@manual.id, number_of_drafts: 4)
+      check_manual_is_published_to_publishing_api(@manual.id)
+    else
+      check_manual_is_drafted_to_publishing_api(@manual.id, number_of_drafts: 3)
+    end
+
+    WebMock::RequestRegistry.instance.reset!
+  end
+
+  def edit_manual_and_sections
+    @edited_manual = edit_manual_without_ui(@manual, edited_manual_fields)
+
+    @edited_documents = @documents.map do |document|
+      edit_manual_document_without_ui(@manual, document, edited_section_fields(document))
+    end
 
     WebMock::RequestRegistry.instance.reset!
   end
@@ -38,23 +62,119 @@ RSpec.describe "Republishing manuals", type: :feature do
     ManualsPublisherWiring.get(:repository_registry).manual_repository
   end
 
-  describe "republishing a manual with sections" do
+  describe "republishing a published manual with sections" do
     before do
-      create_manual_with_sections
+      create_manual_with_sections(published: true)
 
       republish_manuals
     end
 
     it "sends the manual and the sections to the Publishing API" do
-      check_manual_is_drafted_to_publishing_api(@manual.id)
+      check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: {
+        title: manual_fields[:title],
+        description: manual_fields[:summary],
+      })
+      check_manual_is_published_to_publishing_api(@manual.id)
+      check_manual_is_published_to_rummager(@manual.slug, manual_fields)
       @documents.each do |document|
-        check_manual_document_is_drafted_to_publishing_api(document.id)
-        check_manual_and_documents_were_published(@manual, document, manual_fields, document_fields(document))
+        check_manual_document_is_drafted_to_publishing_api(document.id, extra_attributes: {
+          title: document.attributes[:title],
+          description: document.attributes[:summary],
+        })
+        check_manual_document_is_published_to_publishing_api(document.id)
+        check_manual_section_is_published_to_rummager(document.slug, document_fields(document), manual_fields)
       end
     end
 
     it "does not change the exported timestamp" do
       expect(@documents.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
     end
+  end
+
+  describe "republishing a draft manual with sections" do
+    before do
+      create_manual_with_sections(published: false)
+
+      republish_manuals
+    end
+
+    it "sends the manual and the sections to the Publishing API" do
+      check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: {
+        title: manual_fields[:title],
+        description: manual_fields[:summary],
+      })
+      check_manual_is_not_published_to_publishing_api(@manual.id)
+      check_manual_is_not_published_to_rummager(@manual.slug)
+      @documents.each do |document|
+        check_manual_document_is_drafted_to_publishing_api(document.id, extra_attributes: {
+          title: document.attributes[:title],
+          description: document.attributes[:summary],
+        })
+        check_manual_document_is_not_published_to_publishing_api(document.id)
+        check_manual_section_is_not_published_to_rummager(document.slug)
+      end
+    end
+
+    it "does not change the exported timestamp" do
+      expect(@documents.first.latest_edition.reload.exported_at).to be_nil
+    end
+  end
+
+  describe "republishing a published manual with sections and a new draft waiting" do
+    before do
+      create_manual_with_sections(published: true)
+
+      @edited_document = edit_manual_and_sections
+
+      republish_manuals
+    end
+
+    it "sends the published versions of the manual and its sections to the Publishing API" do
+      check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: {
+        title: manual_fields[:title],
+        description: manual_fields[:summary],
+      })
+      check_manual_is_published_to_publishing_api(@manual.id)
+      check_manual_is_published_to_rummager(@manual.slug, manual_fields)
+      @documents.each do |document|
+        edited_fields = edited_section_fields(document)
+        check_manual_document_is_drafted_to_publishing_api(document.id, extra_attributes: {
+          title: edited_fields[:title],
+          description: edited_fields[:summary],
+        })
+        check_manual_document_is_published_to_publishing_api(document.id)
+        check_manual_section_is_published_to_rummager(document.slug, document_fields(document), manual_fields)
+      end
+    end
+
+    it "sends the draft versions of the manual and its sections to the Publishing API" do
+      check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: {
+        title: edited_manual_fields[:title],
+        description: edited_manual_fields[:summary],
+      })
+      # we can't check that it's not published (because one version will be)
+      # all we can check is that it was only published once
+      check_manual_is_published_to_publishing_api(@manual.id, times: 1)
+      check_manual_is_not_published_to_rummager_with_attrs(@manual.slug, edited_manual_fields)
+      @edited_documents.each do |document|
+        check_manual_document_is_drafted_to_publishing_api(document.id, extra_attributes: {
+          title: document.title,
+          description: document.summary,
+        })
+        # we can't check that it's not published (because one version will be)
+        # all we can check is that it was only published once
+        check_manual_document_is_published_to_publishing_api(document.id, times: 1)
+        check_manual_section_is_not_published_to_rummager_with_attrs(document.slug, document_fields(document), edited_manual_fields)
+      end
+    end
+
+    it "does not set the exported timestamp of the draft version of the section" do
+      expect(@edited_documents.first.latest_edition.reload.exported_at).to be_nil
+    end
+
+    it "does not set the exported timestamp of the previously published version of the section" do
+      expect(@documents.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
+    end
+
   end
 end

--- a/spec/repositories/versioned_manual_repository_spec.rb
+++ b/spec/repositories/versioned_manual_repository_spec.rb
@@ -1,0 +1,353 @@
+require "spec_helper"
+
+RSpec.describe VersionedManualRepository do
+  subject(:repository) { described_class.new }
+
+  context "when the provided id doesn't refer to a manual" do
+    it "raises a Not Found error" do
+      expect { subject.get_manual("i-dont-exist") }.to raise_error(ManualRepository::NotFoundError)
+    end
+  end
+
+  context "when the provided id refers to the first draft of a manual" do
+    let(:manual_id) { SecureRandom.uuid }
+    let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
+    let(:manual_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "draft") }
+    let!(:section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "draft") }
+    let!(:section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "draft") }
+    before do
+      manual.editions << manual_edition
+    end
+
+    context "the published version returned" do
+      subject { repository.get_manual(manual_id)[:published] }
+
+      it "is blank" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "the draft version returned" do
+      subject { repository.get_manual(manual_id)[:draft] }
+
+      it "is the first draft as a ManualWithDocuments instance" do
+        expect(subject).to be_a ::ManualWithDocuments
+        expect(subject.id).to eq manual_id
+        expect(subject.state).to eq "draft"
+        expect(subject.version_number).to eq 1
+        expect(subject.slug).to eq "guidance/my-amazing-manual"
+      end
+
+      it "has the first draft of the specialist document editions as Specialist Document instances attached" do
+        documents = subject.documents.to_a
+        expect(documents.size).to eq 2
+
+        document_1 = documents[0]
+        expect(document_1).to be_a ::SpecialistDocument
+        expect(document_1.id).to eq "12345"
+        expect(document_1).to be_draft
+        expect(document_1.version_number).to eq 1
+        expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+        document_2 = documents[1]
+        expect(document_2).to be_a ::SpecialistDocument
+        expect(document_2.id).to eq "67890"
+        expect(document_2).to be_draft
+        expect(document_2.version_number).to eq 1
+        expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+      end
+    end
+  end
+
+  context "when the provided id refers to manual that has been published once" do
+    let(:manual_id) { SecureRandom.uuid }
+    let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
+    let(:manual_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "published") }
+    let!(:section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
+    let!(:section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
+    before do
+      manual.editions << manual_edition
+    end
+
+    context "the published version returned" do
+      subject { repository.get_manual(manual_id)[:published] }
+
+      it "is the published version as a ManualWithDocuments instance" do
+        expect(subject).to be_a ::ManualWithDocuments
+        expect(subject.id).to eq manual_id
+        expect(subject.state).to eq "published"
+        expect(subject.version_number).to eq 1
+        expect(subject.slug).to eq "guidance/my-amazing-manual"
+      end
+
+      it "has the published version of the specialist document editions as Specialist Document instances attached" do
+        documents = subject.documents.to_a
+        expect(documents.size).to eq 2
+
+        document_1 = documents[0]
+        expect(document_1).to be_a ::SpecialistDocument
+        expect(document_1.id).to eq "12345"
+        expect(document_1).to be_published
+        expect(document_1.version_number).to eq 1
+        expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+        document_2 = documents[1]
+        expect(document_2).to be_a ::SpecialistDocument
+        expect(document_2.id).to eq "67890"
+        expect(document_2).to be_published
+        expect(document_2.version_number).to eq 1
+        expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+      end
+    end
+
+    context "the draft version returned" do
+      subject { repository.get_manual(manual_id)[:draft] }
+
+      it "is blank" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  context "when the provided id refers to manual that has been withdrawn once" do
+    let(:manual_id) { SecureRandom.uuid }
+    let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
+    let(:manual_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "withdrawn") }
+    let!(:section_1) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "archived") }
+    let!(:section_2) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "archived") }
+    before do
+      manual.editions << manual_edition
+    end
+
+    context "the published version returned" do
+      subject { repository.get_manual(manual_id)[:published] }
+
+      it "is blank" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "the draft version returned" do
+      subject { repository.get_manual(manual_id)[:draft] }
+
+      it "is blank" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  context "when the provided id refers to manual that has been published once and has a new draft waiting" do
+    let(:manual_id) { SecureRandom.uuid }
+    let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
+    let(:manual_published_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "published") }
+    let(:manual_draft_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 2, state: "draft") }
+    before do
+      manual.editions << manual_published_edition
+      manual.editions << manual_draft_edition
+    end
+
+    context "including new drafts of all sections" do
+      let!(:section_1_published) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
+      let!(:section_2_published) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
+      let!(:section_1_draft) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 2, state: "draft") }
+      let!(:section_2_draft) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 2, state: "draft") }
+
+      context "the published version returned" do
+        subject { repository.get_manual(manual_id)[:published] }
+
+        it "is the published version as a ManualWithDocuments instance" do
+          expect(subject).to be_a ::ManualWithDocuments
+          expect(subject.id).to eq manual_id
+          expect(subject.state).to eq "published"
+          expect(subject.version_number).to eq 1
+          expect(subject.slug).to eq "guidance/my-amazing-manual"
+        end
+
+        it "has the published versions of the specialist document editions as Specialist Document instances attached" do
+          documents = subject.documents.to_a
+          expect(documents.size).to eq 2
+
+          document_1 = documents[0]
+          expect(document_1).to be_a ::SpecialistDocument
+          expect(document_1.id).to eq "12345"
+          expect(document_1).to be_published
+          expect(document_1.version_number).to eq 1
+          expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+          document_2 = documents[1]
+          expect(document_2).to be_a ::SpecialistDocument
+          expect(document_2.id).to eq "67890"
+          expect(document_2).to be_published
+          expect(document_2.version_number).to eq 1
+          expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+        end
+      end
+
+      context "the draft version returned" do
+        subject { repository.get_manual(manual_id)[:draft] }
+
+        it "is the new draft as a ManualWithDocuments instance" do
+          expect(subject).to be_a ::ManualWithDocuments
+          expect(subject.id).to eq manual_id
+          expect(subject.state).to eq "draft"
+          expect(subject.version_number).to eq 2
+          expect(subject.slug).to eq "guidance/my-amazing-manual"
+        end
+
+        it "has the new drafts of the specialist document editions as Specialist Document instances attached" do
+          documents = subject.documents.to_a
+          expect(documents.size).to eq 2
+
+          document_1 = documents[0]
+          expect(document_1).to be_a ::SpecialistDocument
+          expect(document_1.id).to eq "12345"
+          expect(document_1).to be_draft
+          expect(document_1.version_number).to eq 2
+          expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+          document_2 = documents[1]
+          expect(document_2).to be_a ::SpecialistDocument
+          expect(document_2.id).to eq "67890"
+          expect(document_2).to be_draft
+          expect(document_2.version_number).to eq 2
+          expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+        end
+      end
+    end
+
+    context "without new drafts of any sections" do
+      let!(:section_1_published) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
+      let!(:section_2_published) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
+
+      context "the published version returned" do
+        subject { repository.get_manual(manual_id)[:published] }
+
+        it "is the published version as a ManualWithDocuments instance" do
+          expect(subject).to be_a ::ManualWithDocuments
+          expect(subject.id).to eq manual_id
+          expect(subject.state).to eq "published"
+          expect(subject.version_number).to eq 1
+          expect(subject.slug).to eq "guidance/my-amazing-manual"
+        end
+
+        it "has the published versions of the specialist document editions as Specialist Document instances attached" do
+          documents = subject.documents.to_a
+          expect(documents.size).to eq 2
+
+          document_1 = documents[0]
+          expect(document_1).to be_a ::SpecialistDocument
+          expect(document_1.id).to eq "12345"
+          expect(document_1).to be_published
+          expect(document_1.version_number).to eq 1
+          expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+          document_2 = documents[1]
+          expect(document_2).to be_a ::SpecialistDocument
+          expect(document_2.id).to eq "67890"
+          expect(document_2).to be_published
+          expect(document_2.version_number).to eq 1
+          expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+        end
+      end
+
+      context "the draft version returned" do
+        subject { repository.get_manual(manual_id)[:draft] }
+
+        it "is the new draft as a ManualWithDocuments instance" do
+          expect(subject).to be_a ::ManualWithDocuments
+          expect(subject.id).to eq manual_id
+          expect(subject.state).to eq "draft"
+          expect(subject.version_number).to eq 2
+          expect(subject.slug).to eq "guidance/my-amazing-manual"
+        end
+
+        it "has the published versions of the specialist document editions as Specialist Document instances attached" do
+          documents = subject.documents.to_a
+          expect(documents.size).to eq 2
+
+          document_1 = documents[0]
+          expect(document_1).to be_a ::SpecialistDocument
+          expect(document_1.id).to eq "12345"
+          expect(document_1).to be_published
+          expect(document_1.version_number).to eq 1
+          expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+          document_2 = documents[1]
+          expect(document_2).to be_a ::SpecialistDocument
+          expect(document_2.id).to eq "67890"
+          expect(document_2).to be_published
+          expect(document_2.version_number).to eq 1
+          expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+        end
+      end
+    end
+
+    context "including new drafts of some sections" do
+      let!(:section_1_published) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
+      let!(:section_2_published) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
+      let!(:section_2_draft) { FactoryGirl.create(:specialist_document_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 2, state: "draft") }
+
+      context "the published version returned" do
+        subject { repository.get_manual(manual_id)[:published] }
+
+        it "is the published version as a ManualWithDocuments instance" do
+          expect(subject).to be_a ::ManualWithDocuments
+          expect(subject.id).to eq manual_id
+          expect(subject.state).to eq "published"
+          expect(subject.version_number).to eq 1
+          expect(subject.slug).to eq "guidance/my-amazing-manual"
+        end
+
+        it "has the published versions of the specialist document editions as Specialist Document instances attached" do
+          documents = subject.documents.to_a
+          expect(documents.size).to eq 2
+
+          document_1 = documents[0]
+          expect(document_1).to be_a ::SpecialistDocument
+          expect(document_1.id).to eq "12345"
+          expect(document_1).to be_published
+          expect(document_1.version_number).to eq 1
+          expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+          document_2 = documents[1]
+          expect(document_2).to be_a ::SpecialistDocument
+          expect(document_2.id).to eq "67890"
+          expect(document_2).to be_published
+          expect(document_2.version_number).to eq 1
+          expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+        end
+      end
+
+      context "the draft version returned" do
+        subject { repository.get_manual(manual_id)[:draft] }
+
+        it "is the new draft as a ManualWithDocuments instance" do
+          expect(subject).to be_a ::ManualWithDocuments
+          expect(subject.id).to eq manual_id
+          expect(subject.state).to eq "draft"
+          expect(subject.version_number).to eq 2
+          expect(subject.slug).to eq "guidance/my-amazing-manual"
+        end
+
+        it "has correct draft or published version of the specialist document editions as Specialist Document instances attached" do
+          documents = subject.documents.to_a
+          expect(documents.size).to eq 2
+
+          document_1 = documents[0]
+          expect(document_1).to be_a ::SpecialistDocument
+          expect(document_1.id).to eq "12345"
+          expect(document_1).to be_published
+          expect(document_1.version_number).to eq 1
+          expect(document_1.slug).to eq "guidance/my-amazing-manual/section-1"
+
+          document_2 = documents[1]
+          expect(document_2).to be_a ::SpecialistDocument
+          expect(document_2.id).to eq "67890"
+          expect(document_2).to be_draft
+          expect(document_2.version_number).to eq 2
+          expect(document_2.slug).to eq "guidance/my-amazing-manual/section-2"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -1,46 +1,117 @@
 require "fast_spec_helper"
 require "republish_manual_service"
+require "versioned_manual_repository"
 
 RSpec.describe RepublishManualService do
   let(:manual_id) { double(:manual_id) }
-  let(:manual_repository) { double(:manual_repository) }
-  let(:listener) { double(:listener) }
-  let(:listeners) { [listener] }
-  let(:manual) { double(:manual, id: manual_id, slug: "abc") }
+  let(:published_listener) { double(:listener) }
+  let(:published_listeners) { [published_listener] }
+  let(:draft_listener) { double(:listener) }
+  let(:draft_listeners) { [draft_listener] }
+
+  let(:published_manual_version) { double(:manual) }
+  let(:draft_manual_version) { double(:manual) }
 
   subject {
-    RepublishManualService.new(
+    described_class.new(
       manual_id: manual_id,
-      manual_repository: manual_repository,
-      listeners: listeners,
+      published_listeners: published_listeners,
+      draft_listeners: draft_listeners,
     )
   }
 
   before do
-    allow(manual_repository).to receive(:fetch) { manual }
-    allow(manual).to receive(:update)
-    allow(listener).to receive(:call)
+    allow(draft_listener).to receive(:call)
+    allow(published_listener).to receive(:call)
   end
 
   context "(for a published manual)" do
     before do
-      allow(manual).to receive(:published?).and_return(true)
+      allow(VersionedManualRepository).to receive(:get_manual).with(manual_id).and_return({
+        published: published_manual_version,
+        draft: nil,
+      })
     end
 
-    it "republishes the manual" do
+    it "tells the published listeners to republish the published version of the manual" do
       subject.call
-      expect(listener).to have_received(:call).with(manual, :republish)
+      expect(published_listener).to have_received(:call).with(published_manual_version, :republish)
+    end
+
+    it "tells the draft listeners nothing" do
+      subject.call
+      expect(draft_listener).not_to have_received(:call)
     end
   end
 
   context "(for a draft manual)" do
     before do
-      allow(manual).to receive(:published?).and_return(false)
+      allow(VersionedManualRepository).to receive(:get_manual).with(manual_id).and_return({
+        published: nil,
+        draft: draft_manual_version,
+      })
     end
 
-    it "doesn't republish the manual" do
+    it "tells the published listeners nothing" do
       subject.call
-      expect(listener).to_not have_received(:call)
+      expect(published_listener).not_to have_received(:call)
+    end
+
+    it "tells the draft listeners to republish the draft version of the manual" do
+      subject.call
+      expect(draft_listener).to have_received(:call).with(draft_manual_version, :republish)
+    end
+  end
+
+  context "(for a published manual with a new draft waiting)" do
+    before do
+      allow(VersionedManualRepository).to receive(:get_manual).with(manual_id).and_return({
+        published: published_manual_version,
+        draft: draft_manual_version,
+      })
+    end
+
+    it "tells the published listeners to republish the published version of the manual" do
+      subject.call
+      expect(published_listener).to have_received(:call).with(published_manual_version, :republish)
+    end
+
+    it "tells the draft listeners to republish the draft version of the manual" do
+      subject.call
+      expect(draft_listener).to have_received(:call).with(draft_manual_version, :republish)
+    end
+  end
+
+  context "(for a manual that doesn't exist)" do
+    before do
+      allow(VersionedManualRepository).to receive(:get_manual).with(manual_id).and_raise(VersionedManualRepository::NotFoundError.new("uh-oh!"))
+    end
+
+    it "raises an exception" do
+      expect {
+        subject.call
+      }.to raise_error(RepublishManualService::ManualNotFoundError)
+    end
+
+    it "tells none of the listeners to do anything" do
+      begin; subject.call; rescue(RepublishManualService::ManualNotFoundError); end
+      expect(published_listener).not_to have_received(:call)
+      expect(draft_listener).not_to have_received(:call)
+    end
+  end
+
+  context "(for a manual that exists, but is neither published, nor draft)" do
+    before do
+      allow(VersionedManualRepository).to receive(:get_manual).with(manual_id).and_return({
+        published: nil,
+        draft: nil,
+      })
+    end
+
+    it "tells none of the listeners to do anything" do
+      subject.call
+      expect(published_listener).not_to have_received(:call)
+      expect(draft_listener).not_to have_received(:call)
     end
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -36,7 +36,7 @@ FactoryGirl.define do
     sequence(:title) {|n| "Test Specialist Document #{n}" }
     summary "My summary"
     body "My body"
-    document_type "cma_case"
+    document_type "manual"
     extra_fields do
       {
         opened_date: "2013-04-20",


### PR DESCRIPTION
For: https://trello.com/c/w8XMP7h2/73-investigate-potential-bug-with-republishing

We worried that republishing in manuals-publisher wasn't doing the right thing and might end up publishing drafts. Turns out it didn't, but neither did it do a full republish as it only worked on manuals that had been published and didn't have a new draft waiting.  If the intention of republishing is to resend the published version of a manual to the publishing-api we were missing out.  Looking at what some other apps did we realised what we should be doing is:

1. for draft manuals - resend the draft to the publishing api
2. for published manuals - write a new draft of the manual to the publishing api and then publish it
3. for published manuals with a new draft - write a draft of the published version of the manual to the publishing api and then publish it, finally resend the new draft to the publishing api.

If we don't do the last bit then the new draft is lost from the publishing-api and "preview draft" functionality will show the previously published version.

Turns out that extracting the previously published version of a manual is quite hard so we've had to add a new repository for doing this, and change the republishing service to take two sets of listeners because what we want to do with a published manual we are republishing is different to what we want to do with a draft manual we are "republishing".

I haven't tried a full republish of all the manuals locally, but I have tried a single republish of a published with a new draft manual and it all worked properly.  Which is nice. 

Probably best reviewed commit-by-commit.