### PR TITLE
Update reference to panopticon

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -6,7 +6,7 @@ development:
 
 test:
   host: localhost
-  # Don't want this interfering with a concurrent Panopticon test run
+  # Don't want this interfering with a concurrent publisher/content_api test run
   database: govuk_content_manuals_publisher_test
   autocreate_indexes: true
 


### PR DESCRIPTION
panopticon has been retired, but there is still the potential of a conflict with a concurrent build of publisher and/or content_api since they share the same database, so update the comment to reflect this.

https://trello.com/c/dGPNmVub