### PR TITLE
Require test-unit gem for all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,11 @@ gem "sidekiq-statsd", "0.1.5"
 gem "state_machine", "1.2.0"
 gem "unicorn", "4.8.2"
 
+# We only need this for tests and rails 3.2 and ruby 2.2
+# however, it can't be in a gem group that isn't installed
+# on production environments or the console won't load
+gem 'test-unit', require: false
+
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
@@ -69,8 +74,6 @@ group :test do
   gem "rspec", "~> 3.2.0"
   gem "rspec-rails", "~> 3.2.0"
   gem "simplecov"
-  # we need test-unit for rails 3.2 and ruby 2.2
-  gem 'test-unit', require: false
   gem "timecop"
   gem "webmock"
 end


### PR DESCRIPTION
Technically part of: https://trello.com/c/0eULwcEE/106-upgrade-ruby-version-on-manuals-publisher

We only really need it for running tests, and only because we're using
rails 3.2 (which relies on test-unit) and ruby 2.2 (which no longer
bundles a test-unit shim).  However, if it's in the development or test
groups it isn't installed on our deployed environments and this somehow
stops the rails console from booting (but not the server).

Moving it outside these groups makes the console work again.

FWIW: I've deployed this to integration and checked it works.  Without it you get:

```
/data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `require': Please add test-unit gem to your Gemfile: `gem 'test-unit', '~> 3.0'` (cannot load such file -- test/unit/testcase) (LoadError)
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `block in require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/test_case.rb:2:in `<top (required)>'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `block in require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/railties-3.2.22.3/lib/rails/console/app.rb:2:in `<top (required)>'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `block in require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/dependencies.rb:251:in `require'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/railties-3.2.22.3/lib/rails/application.rb:312:in `initialize_console'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/railties-3.2.22.3/lib/rails/application.rb:152:in `load_console'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/railties-3.2.22.3/lib/rails/commands/console.rb:27:in `start'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/railties-3.2.22.3/lib/rails/commands/console.rb:8:in `start'
	from /data/apps/manuals-publisher/shared/bundle/ruby/2.2.0/gems/railties-3.2.22.3/lib/rails/commands.rb:41:in `<top (required)>'
	from script/rails:4:in `require'
	from script/rails:4:in `<main>'
```