### PR TITLE
Change radio labels

### DIFF
--- a/app/views/manuals/edit_original_publication_date.html.erb
+++ b/app/views/manuals/edit_original_publication_date.html.erb
@@ -15,10 +15,10 @@
         <%= f.datetime_select :originally_published_at, { include_blank: true, start_year: Date.today.year, end_year: 1945 }, { class: 'date form-control' } %>
       </div>
       <div class="checkbox add-vertical-margins">
-        <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 1, tag_type: :p, label: 'Change the GOV.UK publication date.', checked: manual.use_originally_published_at_for_public_timestamp?) %>
+        <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 1, tag_type: :p, label: 'Change the first published and last updated date.', checked: manual.use_originally_published_at_for_public_timestamp?) %>
       </div>
       <div class="checkbox add-vertical-margins">
-        <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 0, tag_type: :p, label: 'Keep the original GOV.UK publication date.', checked: !manual.use_originally_published_at_for_public_timestamp?) %>
+        <%= f.radio_button(:use_originally_published_at_for_public_timestamp, 0, tag_type: :p, label: 'Change the first published date.', checked: !manual.use_originally_published_at_for_public_timestamp?) %>
       </div>
 
       <div class="actions">

--- a/features/step_definitions/previously_published_manual_steps.rb
+++ b/features/step_definitions/previously_published_manual_steps.rb
@@ -23,7 +23,7 @@ When(/^I tell the manual to stop using the previously published date as the publ
   WebMock::RequestRegistry.instance.reset!
 
   edit_manual_original_publication_date(@manual.title) do
-    choose("Keep the original GOV.UK publication date.")
+    choose("Change the first published date.")
   end
 
   step %{I publish the manual}
@@ -55,7 +55,7 @@ When(/^I tell the manual to start using the previously published date as the pub
   WebMock::RequestRegistry.instance.reset!
 
   edit_manual_original_publication_date(@manual.title) do
-    choose("Change the GOV.UK publication date.")
+    choose("Change the first published and last updated date.")
   end
 
   step %{I publish the manual}


### PR DESCRIPTION
There's been some confusion over which option to choose. Made it clearer that the second radio button changes both the first published and updated dates. Connected to https://govuk.zendesk.com/agent/tickets/1901209