### PR TITLE
Rename SpecialistDocument js to MarkdownPreview

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,7 +4,7 @@
 //= require govuk_toolkit
 //= require ajax_setup
 //= require length_counter
-//= require specialist_documents
+//= require markdown_preview
 //= require toggle_display_with_checked_input
 
 function initPrimaryLinks(){

--- a/app/assets/javascripts/markdown_preview.js
+++ b/app/assets/javascripts/markdown_preview.js
@@ -1,9 +1,9 @@
 (function(jQuery) {
   'use strict';
 
-  var SpecialistDocument = {};
+  var MarkdownPreview = {};
 
-  SpecialistDocument.addPreviewFeature = function addPreviewFeature(args) {
+  MarkdownPreview.addPreviewFeature = function addPreviewFeature(args) {
     insertMarkup();
     addButtonPressListener();
     showMarkup();
@@ -58,5 +58,5 @@
     }
   };
 
-  window.SpecialistDocument = SpecialistDocument;
+  window.MarkdownPreview = MarkdownPreview;
 })($);

--- a/app/views/manual_documents/_form.html.erb
+++ b/app/views/manual_documents/_form.html.erb
@@ -70,7 +70,7 @@
   </div>
 </div>
 <%= content_for :document_ready do %>
-  window.SpecialistDocument.addPreviewFeature({
+  window.MarkdownPreview.addPreviewFeature({
     'url'             : '<%= preview_path_for_manual_document(manual, document) %>',
     'insert_into'     : '.preview_container',
     'insert_button'   : '.preview_button',

--- a/app/views/manuals/_form.html.erb
+++ b/app/views/manuals/_form.html.erb
@@ -44,7 +44,7 @@
 </div>
 
 <%= content_for :document_ready do %>
-  window.SpecialistDocument.addPreviewFeature({
+  window.MarkdownPreview.addPreviewFeature({
     'url'             : '<%= preview_path_for_manual(manual) %>',
     'insert_into'     : '.preview_container',
     'insert_button'   : '.preview_button',


### PR DESCRIPTION
This JavaScript is used to add a markdown preview function to the edit
pages for Manuals and Sections. It feels like `MarkdownPreview` is a
better name for it than `SpecialistDocument`.

We came across this because we're naming `SpecialistDocument` to
`Section` in another branch. When it came to renaming this we felt
that giving it a more generic name made more sense.
