### PR TITLE
Use fork of mongoid_rails_migrations to fix build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "govuk_admin_template", "~> 4.0" # higher versions require rails 4
 gem "kaminari", "0.16.1"
 gem "logstasher", "0.4.8"
 gem "mongoid", "2.5.2"
-gem "mongoid_rails_migrations", "1.0.0"
+gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code"
 gem "multi_json", "1.10.0"
 gem "plek", "1.12.0"
 gem "quiet_assets", "1.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/alphagov/mongoid_rails_migrations
+  revision: 4db234408a335d336a45f840e0f72c585031859b
+  branch: avoid-calling-bundler-require-in-library-code
+  specs:
+    mongoid_rails_migrations (1.0.0)
+      activesupport (>= 3.2.0)
+      bundler (>= 1.0.0)
+      rails (>= 3.2.0)
+      railties (>= 3.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -185,11 +196,6 @@ GEM
       activemodel (~> 3.1)
       mongo (~> 1.7)
       tzinfo (~> 0.3.22)
-    mongoid_rails_migrations (1.0.0)
-      activesupport (>= 3.2.0)
-      bundler (>= 1.0.0)
-      rails (>= 3.2.0)
-      railties (>= 3.2.0)
     multi_json (1.10.0)
     multi_test (0.1.2)
     multi_xml (0.6.0)
@@ -401,7 +407,7 @@ DEPENDENCIES
   launchy
   logstasher (= 0.4.8)
   mongoid (= 2.5.2)
-  mongoid_rails_migrations (= 1.0.0)
+  mongoid_rails_migrations!
   multi_json (= 1.10.0)
   phantomjs (>= 1.9.7.1)
   plek (= 1.12.0)
@@ -427,4 +433,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.14.5


### PR DESCRIPTION
* This is an attempt to fix the problem described in #816. It uses a forked version of mongoid_rails_migrations. The branch in that fork was branched off the v1.0.0 tag, which is the version of the gem that was specified in our `Gemfile`. This is so that we keep the changes to our app to a minimum.

* This fix is a bit of a bodge - the proper fix would be along the lines of adacosta/mongoid_rails_migrations#3, but given that the failing build is a significant blocker, it feels as if this is worth a try. If it works OK, we can work on getting the proper fix in place.

* I installed v1.14.5 of Bundler which is the version [now specified in govuk-puppet][1] for Ruby v2.2.4. Hence the change to `BUNDLED WITH` in the `Gemfile`.

* I've run a migration locally to ensure that the gem still works OK even with this patch in place.

[1]: https://github.com/alphagov/govuk-puppet/blob/e2d61705aaf6da180a781b6f46f83235fd890df0/modules/govuk_rbenv/manifests/all.pp#L46