### PR TITLE
Fix typo in export_recipent -> export_recipient

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,8 +1,8 @@
 class ManualPublishingAPIExporter
   include PublishingAPIUpdateTypes
 
-  def initialize(export_recipent, organisation, manual_renderer, publication_logs, manual, update_type: nil)
-    @export_recipent = export_recipent
+  def initialize(export_recipient, organisation, manual_renderer, publication_logs, manual, update_type: nil)
+    @export_recipient = export_recipient
     @organisation = organisation
     @manual_renderer = manual_renderer
     @publication_logs = publication_logs
@@ -12,13 +12,13 @@ class ManualPublishingAPIExporter
   end
 
   def call
-    export_recipent.call(content_id, exportable_attributes)
+    export_recipient.call(content_id, exportable_attributes)
   end
 
 private
 
   attr_reader(
-    :export_recipent,
+    :export_recipient,
     :organisation,
     :manual_renderer,
     :publication_logs,

--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -1,17 +1,17 @@
 class ManualPublishingAPILinksExporter
-  def initialize(export_recipent, organisation, manual)
-    @export_recipent = export_recipent
+  def initialize(export_recipient, organisation, manual)
+    @export_recipient = export_recipient
     @organisation = organisation
     @manual = manual
   end
 
   def call
-    export_recipent.call(content_id, exportable_attributes)
+    export_recipient.call(content_id, exportable_attributes)
   end
 
 private
 
-  attr_reader :export_recipent, :organisation, :manual
+  attr_reader :export_recipient, :organisation, :manual
 
   def content_id
     manual.id

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -1,8 +1,8 @@
 class ManualSectionPublishingAPIExporter
   include PublishingAPIUpdateTypes
 
-  def initialize(export_recipent, organisation, document_renderer, manual, document, update_type: nil)
-    @export_recipent = export_recipent
+  def initialize(export_recipient, organisation, document_renderer, manual, document, update_type: nil)
+    @export_recipient = export_recipient
     @organisation = organisation
     @document_renderer = document_renderer
     @manual = manual
@@ -12,12 +12,12 @@ class ManualSectionPublishingAPIExporter
   end
 
   def call
-    export_recipent.call(content_id, exportable_attributes)
+    export_recipient.call(content_id, exportable_attributes)
   end
 
 private
 
-  attr_reader :export_recipent, :document_renderer, :organisation, :manual, :document
+  attr_reader :export_recipient, :document_renderer, :organisation, :manual, :document
 
   def content_id
     document.id

--- a/app/exporters/manual_section_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_links_exporter.rb
@@ -1,18 +1,18 @@
 class ManualSectionPublishingAPILinksExporter
-  def initialize(export_recipent, organisation, manual, document)
-    @export_recipent = export_recipent
+  def initialize(export_recipient, organisation, manual, document)
+    @export_recipient = export_recipient
     @organisation = organisation
     @manual = manual
     @document = document
   end
 
   def call
-    export_recipent.call(content_id, exportable_attributes)
+    export_recipient.call(content_id, exportable_attributes)
   end
 
 private
 
-  attr_reader :export_recipent, :organisation, :manual, :document
+  attr_reader :export_recipient, :organisation, :manual, :document
 
   def content_id
     document.id

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -7,7 +7,7 @@ require "manual_publishing_api_exporter"
 describe ManualPublishingAPIExporter do
   subject {
     described_class.new(
-      export_recipent,
+      export_recipient,
       organisation,
       manual_renderer,
       publication_logs_collection,
@@ -15,7 +15,7 @@ describe ManualPublishingAPIExporter do
     )
   }
 
-  let(:export_recipent) { double(:export_recipent, call: nil) }
+  let(:export_recipient) { double(:export_recipient, call: nil) }
   let(:manual_renderer) { ->(_) { double(:rendered_manual, attributes: rendered_manual_attributes) } }
 
   let(:manual) {
@@ -109,7 +109,7 @@ describe ManualPublishingAPIExporter do
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
-        export_recipent,
+        export_recipient,
         organisation,
         manual_renderer,
         publication_logs_collection,
@@ -123,7 +123,7 @@ describe ManualPublishingAPIExporter do
     %w(major minor republish).each do |update_type|
       expect {
         described_class.new(
-          export_recipent,
+          export_recipient,
           organisation,
           manual_renderer,
           publication_logs_collection,
@@ -137,7 +137,7 @@ describe ManualPublishingAPIExporter do
   it "accepts explicitly setting nil as the option for update_type" do
     expect {
       described_class.new(
-        export_recipent,
+        export_recipient,
         organisation,
         manual_renderer,
         publication_logs_collection,
@@ -154,7 +154,7 @@ describe ManualPublishingAPIExporter do
   it "exports the serialized document attributes" do
     subject.call
 
-    expect(export_recipent).to have_received(:call).with(
+    expect(export_recipient).to have_received(:call).with(
       "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       all_of(
         hash_including(
@@ -192,7 +192,7 @@ describe ManualPublishingAPIExporter do
     it "adds it as the value for first_published_at in the serialized attributes" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(
           first_published_at: previously_published_date.iso8601,
@@ -204,7 +204,7 @@ describe ManualPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(true)
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(
           public_updated_at: previously_published_date.iso8601,
@@ -216,7 +216,7 @@ describe ManualPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(false)
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_excluding(:public_updated_at)
       )
@@ -226,7 +226,7 @@ describe ManualPublishingAPIExporter do
   it "exports section metadata for the manual" do
     subject.call
 
-    expect(export_recipent).to have_received(:call).with(
+    expect(export_recipient).to have_received(:call).with(
       "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       hash_including(
         details: {
@@ -284,7 +284,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -294,7 +294,7 @@ describe ManualPublishingAPIExporter do
   shared_examples_for "obeying the provided update_type" do
     subject {
       described_class.new(
-        export_recipent,
+        export_recipient,
         organisation,
         manual_renderer,
         publication_logs_collection,
@@ -307,7 +307,7 @@ describe ManualPublishingAPIExporter do
       let(:explicit_update_type) { "republish" }
       it "exports with the update_type set to republish" do
         subject.call
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
           hash_including(update_type: "republish")
         )
@@ -318,7 +318,7 @@ describe ManualPublishingAPIExporter do
       let(:explicit_update_type) { "minor" }
       it "exports with the update_type set to minor" do
         subject.call
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
           hash_including(update_type: "minor")
         )
@@ -329,7 +329,7 @@ describe ManualPublishingAPIExporter do
       let(:explicit_update_type) { "major" }
       it "exports with the update_type set to major" do
         subject.call
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
           hash_including(update_type: "major")
         )
@@ -362,7 +362,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to minor" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "minor")
       )
@@ -397,7 +397,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to minor" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "minor")
       )
@@ -432,7 +432,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -466,7 +466,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -501,7 +501,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to minor" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "minor")
       )
@@ -536,7 +536,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -569,7 +569,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -604,7 +604,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -6,13 +6,13 @@ require "manual_publishing_api_links_exporter"
 describe ManualPublishingAPILinksExporter do
   subject {
     ManualPublishingAPILinksExporter.new(
-      export_recipent,
+      export_recipient,
       organisation,
       manual
     )
   }
 
-  let(:export_recipent) { double(:export_recipent, call: nil) }
+  let(:export_recipient) { double(:export_recipient, call: nil) }
 
   let(:organisation) {
     {
@@ -44,7 +44,7 @@ describe ManualPublishingAPILinksExporter do
   it "exports links for the manual" do
     subject.call
 
-    expect(export_recipent).to have_received(:call).with(
+    expect(export_recipient).to have_received(:call).with(
       manual.id,
       hash_including(
         links: {

--- a/spec/exporters/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_section_publishing_api_exporter_spec.rb
@@ -7,7 +7,7 @@ require "manual_section_publishing_api_exporter"
 describe ManualSectionPublishingAPIExporter do
   subject {
     described_class.new(
-      export_recipent,
+      export_recipient,
       organisation,
       document_renderer,
       manual,
@@ -15,7 +15,7 @@ describe ManualSectionPublishingAPIExporter do
     )
   }
 
-  let(:export_recipent) { double(:export_recipent, call: nil) }
+  let(:export_recipient) { double(:export_recipient, call: nil) }
   let(:document_renderer) { ->(_) { double(:rendered_document, attributes: rendered_attributes) } }
 
   let(:organisation) {
@@ -84,7 +84,7 @@ describe ManualSectionPublishingAPIExporter do
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
-        export_recipent,
+        export_recipient,
         organisation,
         document_renderer,
         manual,
@@ -98,7 +98,7 @@ describe ManualSectionPublishingAPIExporter do
     %w(major minor republish).each do |update_type|
       expect {
         described_class.new(
-          export_recipent,
+          export_recipient,
           organisation,
           document_renderer,
           manual,
@@ -112,7 +112,7 @@ describe ManualSectionPublishingAPIExporter do
   it "accepts explicitly setting nil as the option for update_type" do
     expect {
       described_class.new(
-        export_recipent,
+        export_recipient,
         organisation,
         document_renderer,
         manual,
@@ -129,7 +129,7 @@ describe ManualSectionPublishingAPIExporter do
   it "exports the serialized document attributes" do
     subject.call
 
-    expect(export_recipent).to have_received(:call).with(
+    expect(export_recipient).to have_received(:call).with(
       document.id,
       all_of(
         hash_including(
@@ -162,7 +162,7 @@ describe ManualSectionPublishingAPIExporter do
     it "adds it as the value for first_published_at in the serialized attributes" do
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         document.id,
         hash_including(
           first_published_at: previously_published_date.iso8601,
@@ -174,7 +174,7 @@ describe ManualSectionPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(true)
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         document.id,
         hash_including(
           public_updated_at: previously_published_date.iso8601,
@@ -186,7 +186,7 @@ describe ManualSectionPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(false)
       subject.call
 
-      expect(export_recipent).to have_received(:call).with(
+      expect(export_recipient).to have_received(:call).with(
         document.id,
         hash_excluding(:public_updated_at)
       )
@@ -208,7 +208,7 @@ describe ManualSectionPublishingAPIExporter do
     shared_examples_for "obeying the provided update_type" do
       subject {
         described_class.new(
-          export_recipent,
+          export_recipient,
           organisation,
           document_renderer,
           manual,
@@ -221,7 +221,7 @@ describe ManualSectionPublishingAPIExporter do
         let(:explicit_update_type) { "republish" }
         it "exports with the update_type set to republish" do
           subject.call
-          expect(export_recipent).to have_received(:call).with(
+          expect(export_recipient).to have_received(:call).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
             hash_including(update_type: "republish")
           )
@@ -232,7 +232,7 @@ describe ManualSectionPublishingAPIExporter do
         let(:explicit_update_type) { "minor" }
         it "exports with the update_type set to minor" do
           subject.call
-          expect(export_recipent).to have_received(:call).with(
+          expect(export_recipient).to have_received(:call).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
             hash_including(update_type: "minor")
           )
@@ -243,7 +243,7 @@ describe ManualSectionPublishingAPIExporter do
         let(:explicit_update_type) { "major" }
         it "exports with the update_type set to major" do
           subject.call
-          expect(export_recipent).to have_received(:call).with(
+          expect(export_recipient).to have_received(:call).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
             hash_including(update_type: "major")
           )
@@ -263,7 +263,7 @@ describe ManualSectionPublishingAPIExporter do
         update_type_attributes[:ever_been_published] = false
         subject.call
 
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "major")
         )
@@ -272,7 +272,7 @@ describe ManualSectionPublishingAPIExporter do
       it "sets it to minor if the document has been published before" do
         subject.call
 
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "minor")
         )
@@ -293,7 +293,7 @@ describe ManualSectionPublishingAPIExporter do
         update_type_attributes[:ever_been_published] = false
         subject.call
 
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "major")
         )
@@ -302,7 +302,7 @@ describe ManualSectionPublishingAPIExporter do
       it "sets it to major if the document has been published before" do
         subject.call
 
-        expect(export_recipent).to have_received(:call).with(
+        expect(export_recipient).to have_received(:call).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "major")
         )
@@ -315,7 +315,7 @@ describe ManualSectionPublishingAPIExporter do
   it "exports section metadata for the document" do
     subject.call
 
-    expect(export_recipent).to have_received(:call).with(
+    expect(export_recipient).to have_received(:call).with(
       document.id,
       hash_including(
         details: {

--- a/spec/exporters/manual_section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_section_publishing_api_links_exporter_spec.rb
@@ -6,14 +6,14 @@ require "manual_section_publishing_api_links_exporter"
 describe ManualSectionPublishingAPILinksExporter do
   subject {
     ManualSectionPublishingAPILinksExporter.new(
-      export_recipent,
+      export_recipient,
       organisation,
       manual,
       document
     )
   }
 
-  let(:export_recipent) { double(:export_recipent, call: nil) }
+  let(:export_recipient) { double(:export_recipient, call: nil) }
 
   let(:organisation) {
     {
@@ -47,7 +47,7 @@ describe ManualSectionPublishingAPILinksExporter do
   it "exports links for the document" do
     subject.call
 
-    expect(export_recipent).to have_received(:call).with(
+    expect(export_recipient).to have_received(:call).with(
       document.id,
       hash_including(
         links: {


### PR DESCRIPTION
This typo is present in many, but not *all* cases which made things doubly confusing.