### PR TITLE
Require manual_builder in abstract_manual_service_registry

### DIFF
--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -9,6 +9,7 @@ require "republish_manual_service"
 require "withdraw_manual_service"
 require "publish_manual_worker"
 require "manual_observers_registry"
+require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
   def list(context)


### PR DESCRIPTION
The absence of this specific `require` statement meant that we were
seeing the following error in the development environment:

    NameError: uninitialized constant
      AbstractManualServiceRegistry::ManualBuilder

You could see this problem by either visiting
http://manuals-publisher.dev.gov.uk/manuals/new or by executing
`AbstractManualServiceRegistry.new.new({}).call` in the rails console.

We've investigated writing a failing test but it doesn't seem to be
possible because `ManualBuilder` is available in the test environment
but not in the development environment. This appears to be related to
the fact that `cache_classes` is `true` in test and `false` in
development.

We're fairly confident that this won't be a problem in production as
`cache_classes` is `true`.