### PR TITLE
Increase test coverage of attachment reporting

### DIFF
--- a/bin/content_model_pdf_report
+++ b/bin/content_model_pdf_report
@@ -1,69 +1,17 @@
 #!/usr/bin/env ruby
 
 require File.expand_path("../../config/environment", __FILE__)
+require "attachment_reporting"
 require 'csv'
-
-POST_PUBLICATION_STATES = %w(published archived).freeze
 
 first_period_start_date = ENV.fetch('FIRST_PERIOD_START_DATE', Date.parse('2016-01-01'))
 last_time_period_days = ENV.fetch('LAST_TIME_PERIOD_DAYS', 30)
-last_time_period_start_date = last_time_period_days.days.ago
-
-manual_records = ManualRecord.all
-unique_owning_organisation_slugs = manual_records.map(&:organisation_slug).uniq
-
-organisation_published_pdfs_total_counts_hash = Hash[unique_owning_organisation_slugs.map { |o| [o, 0] }]
-organisation_published_pdfs_since_first_period_counts_hash = Hash[unique_owning_organisation_slugs.map { |o| [o, 0] }]
-organisation_published_pdfs_since_second_period_counts_hash = Hash[unique_owning_organisation_slugs.map { |o| [o, 0] }]
-
-def document_published_after_date?(document_edition, date)
-  (document_edition.exported_at || document_edition.updated_at) >= date
-end
-
-def document_edition_never_published?(document_edition)
-  !POST_PUBLICATION_STATES.include?(document_edition.state)
-end
-
-def all_unique_document_ids_for_manual(manual)
-  manual.editions.map(&:document_ids).flatten.uniq
-end
-
-manual_records.to_a.each do |manual|
-  next unless manual.has_ever_been_published?
-
-  unique_pdf_attachment_file_ids_for_manual = Set.new
-
-  # Rather than examine each manual edition and its set of document editions and attachments in turn,
-  # we instead get all unique document ids associated with this manual, then walk through
-  # the editions of these documents in version order to find unique PDF attachments and their
-  # publication times.
-  all_unique_document_ids_for_manual(manual).each do |document_id|
-    document_editions = SpecialistDocumentEdition.where(document_id: document_id).order(:version_number)
-
-    document_editions.each do |document_edition|
-      next if document_edition_never_published?(document_edition)
-
-      document_edition.attachments.each do |attachment|
-        next if unique_pdf_attachment_file_ids_for_manual.include? attachment.file_id
-        next unless /.*\.pdf$/ =~ attachment.filename
-
-        organisation_published_pdfs_total_counts_hash[manual.organisation_slug] += 1
-
-        if document_published_after_date?(document_edition, first_period_start_date)
-          organisation_published_pdfs_since_first_period_counts_hash[manual.organisation_slug] += 1
-        end
-
-        if document_published_after_date?(document_edition, last_time_period_start_date)
-          organisation_published_pdfs_since_second_period_counts_hash[manual.organisation_slug] += 1
-        end
-
-        unique_pdf_attachment_file_ids_for_manual << attachment.file_id
-      end
-    end
-  end
-end
 
 document_report_filename = Rails.root.join("content-operating-report-for-pdf-documents-#{Time.zone.today.strftime('%Y-%m-%d')}.csv")
+
+attachment_reporter = AttachmentReporting.new(first_period_start_date, last_time_period_days, 'pdf')
+
+organisation_attachment_count_hash = attachment_reporter.create_organisation_attachment_count_hash
 
 CSV.open(document_report_filename, 'w') do |document_csv|
   document_csv << [
@@ -73,12 +21,12 @@ CSV.open(document_report_filename, 'w') do |document_csv|
     "Last #{last_time_period_days} days PDF attachments"
   ]
 
-  unique_owning_organisation_slugs.each do |organisation_slug|
+  organisation_attachment_count_hash.each_pair do |organisation_name, pdf_count_array|
     document_csv << [
-      organisation_slug.titleize,
-      organisation_published_pdfs_total_counts_hash[organisation_slug],
-      organisation_published_pdfs_since_first_period_counts_hash[organisation_slug],
-      organisation_published_pdfs_since_second_period_counts_hash[organisation_slug]
+      organisation_name,
+      pdf_count_array[0],
+      pdf_count_array[1],
+      pdf_count_array[2]
     ]
   end
 end

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -1,0 +1,85 @@
+class AttachmentReporting
+  POST_PUBLICATION_STATES = %w(published archived).freeze
+
+  def initialize(first_period_start_date, last_time_period_days, attachment_file_extension)
+    @first_period_start_date = first_period_start_date
+    @last_time_period_days = last_time_period_days
+    @attachment_file_extension = attachment_file_extension
+  end
+
+  def create_organisation_attachment_count_hash
+    manual_records = ManualRecord.all
+    unique_owning_organisation_slugs = manual_records.map(&:organisation_slug).uniq
+
+    # Hash of organisation names mapped to three-element arrays of counts of PDFs, one count for each time period
+    organisation_published_pdfs_counts_hash = Hash[unique_owning_organisation_slugs.map { |o| [o, [0, 0, 0]] }]
+
+    manual_records.to_a.each do |manual|
+      next unless manual.has_ever_been_published?
+
+      unique_pdf_attachment_file_ids_for_manual = Set.new
+
+      # Rather than examine each manual edition and its set of document editions and attachments in turn,
+      # we instead get all unique document ids associated with this manual, then walk through
+      # the editions of these documents in version order to find unique PDF attachments and their
+      # publication times.
+      all_unique_document_ids_for_manual(manual).each do |document_id|
+        document_editions = SpecialistDocumentEdition.where(document_id: document_id).order(:version_number)
+
+        document_editions.each do |document_edition|
+          next if document_edition_never_published?(document_edition)
+
+          document_edition.attachments.each do |attachment|
+            next if unique_pdf_attachment_file_ids_for_manual.include? attachment.file_id
+            next unless report_attachment_extension_matches?(attachment.filename)
+
+            organisation_published_pdfs_counts_hash[manual.organisation_slug][0] += 1
+
+            if document_published_after_date?(document_edition, @first_period_start_date)
+              organisation_published_pdfs_counts_hash[manual.organisation_slug][1] += 1
+            end
+
+            if document_published_after_date?(document_edition, last_time_period_start_date)
+              organisation_published_pdfs_counts_hash[manual.organisation_slug][2] += 1
+            end
+
+            unique_pdf_attachment_file_ids_for_manual << attachment.file_id
+          end
+        end
+      end
+    end
+
+    titleize_keys(organisation_published_pdfs_counts_hash)
+
+    organisation_published_pdfs_counts_hash
+  end
+
+private
+
+  def titleize_keys(hash)
+    hash.keys.each do |key|
+      hash[key.titleize] = hash[key]
+      hash.delete(key)
+    end
+  end
+
+  def report_attachment_extension_matches?(filename)
+    /.*\.#{@attachment_file_extension}/ =~ filename
+  end
+
+  def last_time_period_start_date
+    @_last_time_period_start_date ||= @last_time_period_days.days.ago
+  end
+
+  def document_published_after_date?(document_edition, date)
+    (document_edition.exported_at || document_edition.updated_at) >= date
+  end
+
+  def document_edition_never_published?(document_edition)
+    !POST_PUBLICATION_STATES.include?(document_edition.state)
+  end
+
+  def all_unique_document_ids_for_manual(manual)
+    manual.editions.map(&:document_ids).flatten.uniq
+  end
+end

--- a/spec/lib/attachment_reporting_spec.rb
+++ b/spec/lib/attachment_reporting_spec.rb
@@ -1,0 +1,132 @@
+require "spec_helper"
+require "attachment_reporting"
+
+describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
+  let(:start_date) { Date.parse('2015-01-01') }
+  let(:last_time_period_days) { 30 }
+  let(:attachment_file_extension) { 'pdf' }
+
+  let(:highway_code_manual_slug) { "guidance/the-highway-code" }
+  let(:highway_code_organisation_slug) { 'department-for-transport' }
+  let!(:highway_code_manual_record) { ManualRecord.create(slug: highway_code_manual_slug, organisation_slug: highway_code_organisation_slug) }
+
+  # one published before the start date with a PDF
+  let!(:early_document_edition_with_pdf) do
+    FactoryGirl.create(
+      :specialist_document_edition,
+      state: "published",
+      exported_at: start_date - 1.day,
+    ).tap do |document_edition|
+      document_edition.attachments.create!(
+        filename: 'attachy.pdf',
+        file_id: '1'
+      )
+    end
+  end
+
+  # one published before the start date with a non-PDF attachment
+  let!(:early_document_edition_with_non_pdf) do
+    FactoryGirl.create(
+      :specialist_document_edition,
+      state: "published",
+      exported_at: start_date - 1.day,
+    ).tap do |document_edition|
+      document_edition.attachments.create!(
+        filename: 'attachy.txt',
+        file_id: '2'
+      )
+    end
+  end
+
+  # one only drafted before the start date with a PDF attachment
+  let!(:early_document_edition_draft_with_pdf) do
+    FactoryGirl.create(
+      :specialist_document_edition,
+      state: "draft",
+      exported_at: start_date - 1.day,
+    ).tap do |document_edition|
+      document_edition.attachments.create!(
+        filename: 'attachy.pdf',
+        file_id: '3'
+      )
+    end
+  end
+
+  # one created between the start date and the last time period
+  let!(:more_recent_document_edition) do
+    FactoryGirl.create(
+      :specialist_document_edition,
+      state: "published",
+      exported_at: (Date.today - last_time_period_days) - 1.day,
+    ).tap do |document_edition|
+      document_edition.attachments.create!(
+        filename: 'attachy.pdf',
+        file_id: '4'
+      )
+    end
+  end
+
+  # one created after the last time period
+  let!(:very_recent_document_edition) do
+    FactoryGirl.create(
+      :specialist_document_edition,
+      state: "published",
+      exported_at: (Date.today - last_time_period_days) + 1.day,
+    ).tap do |document_edition|
+      document_edition.attachments.create!(
+        filename: 'attachy.pdf',
+        file_id: '5'
+      )
+    end
+  end
+
+  let!(:highway_code_manual_edition) {
+    highway_code_manual_record.editions.create!(
+      state: "published",
+      version_number: 1,
+      document_ids: [
+        early_document_edition_with_pdf.document_id,
+        early_document_edition_with_non_pdf.document_id,
+        early_document_edition_draft_with_pdf.document_id,
+        more_recent_document_edition.document_id,
+        very_recent_document_edition.document_id
+      ],
+    )
+  }
+
+  let(:patent_manual_slug) { 'guidance/manual-of-patent-practice' }
+  let(:patent_manual_organisation_slug) { 'intellectual-property-office' }
+  let!(:patent_manual_record) { ManualRecord.create(slug: patent_manual_slug, organisation_slug: patent_manual_organisation_slug) }
+
+  let!(:very_recent_draft_patent_document_edition) do
+    FactoryGirl.create(
+      :specialist_document_edition,
+      state: "draft",
+      exported_at: Date.today,
+    ).tap do |document_edition|
+      document_edition.attachments.create!(
+        filename: 'attachy.pdf',
+        file_id: '6'
+      )
+    end
+  end
+
+  let!(:patent_practice_manual_edition) {
+    patent_manual_record.editions.create!(
+      state: "published",
+      version_number: 1,
+      document_ids: [
+        very_recent_draft_patent_document_edition.document_id
+      ],
+    )
+  }
+
+  let(:subject) { described_class.new(start_date, last_time_period_days, attachment_file_extension) }
+
+  it "creates a hash of all specified file type attachment counts within the specified periods" do
+    expect(subject.create_organisation_attachment_count_hash).to eq(
+      highway_code_organisation_slug.titleize => [3, 2, 1],
+      patent_manual_organisation_slug.titleize => [0, 0, 0]
+    )
+  end
+end


### PR DESCRIPTION
Following chat with @chrislo, added test coverage to the PDF reporting script that was implemented in https://github.com/alphagov/manuals-publisher/pull/814.