### PR TITLE
Removed unused ApplicationController#current_user_can_edit?

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,11 +14,6 @@ class ApplicationController < ActionController::Base
     redirect_to(manuals_path, flash: { error: "Manual not found" })
   end
 
-  def current_user_can_edit?(format)
-    permission_checker.can_edit?(format)
-  end
-  helper_method :current_user_can_edit?
-
   def current_user_can_publish?(format)
     permission_checker.can_publish?(format)
   end


### PR DESCRIPTION
This has not been used since [this commit][1].

[1]: https://github.com/alphagov/manuals-publisher/commit/3162f0e72fd53bfd1cf87f5661bb198ff785940e