### PR TITLE
Use class instances instead of anonymous functions

### DIFF
--- a/app/exporters/manual_publishing_api_bulk_draft_exporter.rb
+++ b/app/exporters/manual_publishing_api_bulk_draft_exporter.rb
@@ -61,7 +61,7 @@ private
   end
 
   def manual_renderer
-    ManualRenderer.create
+    ManualRenderer.new
   end
 
   def manual_document_renderer

--- a/app/exporters/manual_publishing_api_bulk_draft_exporter.rb
+++ b/app/exporters/manual_publishing_api_bulk_draft_exporter.rb
@@ -65,6 +65,6 @@ private
   end
 
   def manual_document_renderer
-    ManualDocumentRenderer.create
+    ManualDocumentRenderer.new
   end
 end

--- a/app/lib/govspeak_header_extractor.rb
+++ b/app/lib/govspeak_header_extractor.rb
@@ -1,7 +1,5 @@
 class GovspeakHeaderExtractor
-  def self.create
-    ->(string) {
-      Govspeak::Document.new(string).structured_headers
-    }
+  def call(string)
+    Govspeak::Document.new(string).structured_headers
   end
 end

--- a/app/lib/govspeak_html_converter.rb
+++ b/app/lib/govspeak_html_converter.rb
@@ -1,7 +1,5 @@
 class GovspeakHtmlConverter
-  def self.create
-    ->(string) {
-      Govspeak::Document.new(string).to_html
-    }
+  def call(string)
+    Govspeak::Document.new(string).to_html
   end
 end

--- a/app/lib/manual_document_renderer.rb
+++ b/app/lib/manual_document_renderer.rb
@@ -4,18 +4,16 @@ require "govspeak_to_html_renderer"
 require "footnotes_section_heading_renderer"
 
 class ManualDocumentRenderer
-  def self.create
-    ->(doc) {
-      pipeline = [
-        MarkdownAttachmentProcessor.method(:new),
-        SpecialistDocumentHeaderExtractor.create,
-        GovspeakToHTMLRenderer.create,
-        FootnotesSectionHeadingRenderer.create,
-      ]
+  def call(doc)
+    pipeline = [
+      MarkdownAttachmentProcessor.method(:new),
+      SpecialistDocumentHeaderExtractor.create,
+      GovspeakToHTMLRenderer.create,
+      FootnotesSectionHeadingRenderer.create,
+    ]
 
-      pipeline.reduce(doc) { |current_doc, next_renderer|
-        next_renderer.call(current_doc)
-      }
+    pipeline.reduce(doc) { |current_doc, next_renderer|
+      next_renderer.call(current_doc)
     }
   end
 end

--- a/app/lib/manual_renderer.rb
+++ b/app/lib/manual_renderer.rb
@@ -1,9 +1,7 @@
 require "govspeak_to_html_renderer"
 
 class ManualRenderer
-  def self.create
-    ->(manual) {
-      GovspeakToHTMLRenderer.create.call(manual)
-    }
+  def call(manual)
+    GovspeakToHTMLRenderer.create.call(manual)
   end
 end

--- a/app/lib/specialist_document_renderer.rb
+++ b/app/lib/specialist_document_renderer.rb
@@ -3,17 +3,15 @@ require "specialist_document_header_extractor"
 require "govspeak_to_html_renderer"
 
 class SpecialistDocumentRenderer
-  def self.create
-    ->(doc) {
-      pipeline = [
-        MarkdownAttachmentProcessor.method(:new),
-        SpecialistDocumentHeaderExtractor.create,
-        GovspeakToHTMLRenderer.create,
-      ]
+  def call(doc)
+    pipeline = [
+      MarkdownAttachmentProcessor.method(:new),
+      SpecialistDocumentHeaderExtractor.create,
+      GovspeakToHTMLRenderer.create,
+    ]
 
-      pipeline.reduce(doc) { |current_doc, next_renderer|
-        next_renderer.call(current_doc)
-      }
+    pipeline.reduce(doc) { |current_doc, next_renderer|
+      next_renderer.call(current_doc)
     }
   end
 end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -165,7 +165,7 @@ private
       patch_links = publishing_api_v2.method(:patch_links)
       put_content = publishing_api_v2.method(:put_content)
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
-      manual_renderer = ManualRenderer.create
+      manual_renderer = ManualRenderer.new
       manual_document_renderer = ManualDocumentRenderer.new
 
       ManualPublishingAPILinksExporter.new(

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -166,7 +166,7 @@ private
       put_content = publishing_api_v2.method(:put_content)
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
       manual_renderer = ManualRenderer.create
-      manual_document_renderer = ManualDocumentRenderer.create
+      manual_document_renderer = ManualDocumentRenderer.new
 
       ManualPublishingAPILinksExporter.new(
         patch_links, organisation, manual

--- a/app/services/abstract_manual_document_service_registry.rb
+++ b/app/services/abstract_manual_document_service_registry.rb
@@ -108,7 +108,7 @@ private
       ManualPublishingAPIExporter.new(
         publishing_api_v2.method(:put_content),
         organisation(manual.attributes.fetch(:organisation_slug)),
-        ManualRenderer.create,
+        ManualRenderer.new,
         PublicationLog,
         manual
       ).call

--- a/app/services/abstract_manual_document_service_registry.rb
+++ b/app/services/abstract_manual_document_service_registry.rb
@@ -82,7 +82,7 @@ class AbstractManualDocumentServiceRegistry
 private
 
   def document_renderer
-    SpecialistDocumentRenderer.create
+    SpecialistDocumentRenderer.new
   end
 
   def manual_document_builder

--- a/app/services/abstract_manual_document_service_registry.rb
+++ b/app/services/abstract_manual_document_service_registry.rb
@@ -127,7 +127,7 @@ private
       ManualSectionPublishingAPIExporter.new(
         publishing_api_v2.method(:put_content),
         organisation(manual.attributes.fetch(:organisation_slug)),
-        ManualDocumentRenderer.create,
+        ManualDocumentRenderer.new,
         manual,
         manual_document
       ).call

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -103,7 +103,7 @@ class AbstractManualServiceRegistry
 private
 
   def manual_renderer
-    ManualRenderer.create
+    ManualRenderer.new
   end
 
   def manual_builder

--- a/lib/govspeak_to_html_renderer.rb
+++ b/lib/govspeak_to_html_renderer.rb
@@ -4,7 +4,7 @@ class GovspeakToHTMLRenderer < SimpleDelegator
   def self.create
     ->(doc) {
       GovspeakToHTMLRenderer.new(
-        GovspeakHtmlConverter.create,
+        GovspeakHtmlConverter.new,
         doc,
       )
     }

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -186,7 +186,7 @@ private
   def send_draft(manual)
     put_content = publishing_api.method(:put_content)
     organisation = fetch_organisation(manual.organisation_slug)
-    manual_renderer = ManualRenderer.create
+    manual_renderer = ManualRenderer.new
     manual_document_renderer = ManualDocumentRenderer.new
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -187,7 +187,7 @@ private
     put_content = publishing_api.method(:put_content)
     organisation = fetch_organisation(manual.organisation_slug)
     manual_renderer = ManualRenderer.create
-    manual_document_renderer = ManualDocumentRenderer.create
+    manual_document_renderer = ManualDocumentRenderer.new
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(

--- a/lib/specialist_document_header_extractor.rb
+++ b/lib/specialist_document_header_extractor.rb
@@ -5,7 +5,7 @@ class SpecialistDocumentHeaderExtractor < SimpleDelegator
   def self.create
     ->(doc) {
       SpecialistDocumentHeaderExtractor.new(
-        GovspeakHeaderExtractor.create,
+        GovspeakHeaderExtractor.new,
         doc,
       )
     }


### PR DESCRIPTION
PR #808 introduced a number of class methods that return anonymous functions.

This PR removes those class methods in favour of using instances of the class instead. I think this makes the code easier to follow.