### PR TITLE
Remove redundant condition from case statement in ManualsPublisher.document_services

### DIFF
--- a/app/lib/manuals_publisher.rb
+++ b/app/lib/manuals_publisher.rb
@@ -2,10 +2,9 @@ module ManualsPublisher
   extend self
 
   def document_services(document_type)
-    builder = ManualBuilder.create
     AbstractDocumentServiceRegistry.new(
       repository: document_repositories.for_type(document_type),
-      builder: builder,
+      builder: ManualBuilder.create,
       observers: observer_registry(document_type),
     )
   end

--- a/app/lib/manuals_publisher.rb
+++ b/app/lib/manuals_publisher.rb
@@ -5,8 +5,6 @@ module ManualsPublisher
     builder = case document_type
               when "manual"
                 ManualBuilder.create
-              when "manual_document"
-                ManualDocumentBuilder.create
               end
     AbstractDocumentServiceRegistry.new(
       repository: document_repositories.for_type(document_type),

--- a/app/lib/manuals_publisher.rb
+++ b/app/lib/manuals_publisher.rb
@@ -2,10 +2,7 @@ module ManualsPublisher
   extend self
 
   def document_services(document_type)
-    builder = case document_type
-              when "manual"
-                ManualBuilder.create
-              end
+    builder = ManualBuilder.create
     AbstractDocumentServiceRegistry.new(
       repository: document_repositories.for_type(document_type),
       builder: builder,


### PR DESCRIPTION
Note that this branch is based off the branch in #834.

As far as I can see `ManualsPublisher.document_services` is now only ever invoked from the `bin/republish_withdrawn_document` script. The value of the `document_type` argument passed into it is always obtained from a call to `SpecialistDocumentEdition#document_type` which will never be 'manual_document'; only 'manual' or one of the Specialist Document document types, e.g. 'cma_case'. Indeed since [this commit][1], it will only ever be 'manual'. Thus it's safe to remove this condition and simplify the code.

[1]: https://github.com/alphagov/manuals-publisher/commit/723ce320c9845003bf1aa584d4ea726b587c1891