### PR TITLE
Remove #manual_document_renderer method

### DIFF
--- a/app/services/abstract_manual_document_service_registry.rb
+++ b/app/services/abstract_manual_document_service_registry.rb
@@ -143,10 +143,6 @@ private
     }
   end
 
-  def manual_document_renderer
-    ManualDocumentRenderer.create
-  end
-
   def publishing_api_v2
     PublishingApiV2.instance
   end


### PR DESCRIPTION
This appears to have been added in
1993d7218ae9efce8a055d5697680e3004f7ad04 but was never used.