### PR TITLE
Remove unused bulk_republishing Sidekiq queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,3 @@
 :concurrency:  2
 :queues:
-  - ["bulk_republishing", 1]
   - ["default", 5]


### PR DESCRIPTION
Like the worker in [this commit][1], I don't think the queue has been used since [this commit][2].

[1]: https://github.com/alphagov/manuals-publisher/commit/b1d5c892c175414821ea83a95a8e9e94cf0ef408
[2]: https://github.com/alphagov/manuals-publisher/commit/43e2e7534da179f92bed2ce7e73bc3f3c4fdfb06
