### PR TITLE
Remove CMA and DCLG factories

### DIFF
--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -41,7 +41,7 @@ Then(/^I see manuals created by all organisations$/) do
 end
 
 Given(/^I am logged in as a writer$/) do
-  login_as(:cma_writer)
+  login_as(:generic_writer)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -9,13 +9,13 @@ Given(/^I am logged in as a non\-CMA editor$/) do
 end
 
 Given(/^there are manuals created by multiple organisations$/) do
-  login_as(:cma_editor)
+  login_as(:gds_editor)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
-  @cma_manual_fields = {
+  @gds_manual_fields = {
     title: "Manual on Competition",
     summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
   }
-  create_manual(@cma_manual_fields)
+  create_manual(@gds_manual_fields)
 
   login_as(:generic_editor)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
@@ -32,12 +32,12 @@ end
 
 Then(/^I only see manuals created by my organisation$/) do
   check_manual_visible(@tea_manual_fields.fetch(:title))
-  check_manual_not_visible(@cma_manual_fields.fetch(:title))
+  check_manual_not_visible(@gds_manual_fields.fetch(:title))
 end
 
 Then(/^I see manuals created by all organisations$/) do
   check_manual_visible(@tea_manual_fields.fetch(:title))
-  check_manual_visible(@cma_manual_fields.fetch(:title))
+  check_manual_visible(@gds_manual_fields.fetch(:title))
 end
 
 Given(/^I am logged in as a writer$/) do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,10 +21,6 @@ FactoryGirl.define do
     organisation_slug "competition-and-markets-authority"
   end
 
-  factory :dclg_editor, parent: :editor do
-    organisation_slug "department-for-communities-and-local-government"
-  end
-
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,10 +17,6 @@ FactoryGirl.define do
     permissions %w(signin editor)
   end
 
-  factory :cma_writer, parent: :user do
-    organisation_slug "competition-and-markets-authority"
-  end
-
   factory :cma_editor, parent: :editor do
     organisation_slug "competition-and-markets-authority"
   end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
 describe PermissionChecker do
-  let(:cma_writer)   { FactoryGirl.build(:cma_writer) }
-  let(:dclg_editor)  { FactoryGirl.build(:dclg_editor) }
-  let(:gds_editor)   { FactoryGirl.build(:gds_editor) }
+  let(:generic_writer) { FactoryGirl.build(:generic_writer) }
+  let(:dclg_editor)    { FactoryGirl.build(:dclg_editor) }
+  let(:gds_editor)     { FactoryGirl.build(:gds_editor) }
 
   describe "#can_edit?" do
     context "a user who is not an editor" do
-      subject(:checker) { PermissionChecker.new(cma_writer) }
+      subject(:checker) { PermissionChecker.new(generic_writer) }
 
       context "editing a manual" do
         it "allows editing" do
@@ -27,7 +27,7 @@ describe PermissionChecker do
 
   describe "#can_publish?" do
     context "a user who is not an editor" do
-      subject(:checker) { PermissionChecker.new(cma_writer) }
+      subject(:checker) { PermissionChecker.new(generic_writer) }
 
       it "prevents publishing" do
         expect(checker.can_publish?("manual")).to be false
@@ -55,7 +55,7 @@ describe PermissionChecker do
 
   describe "#can_withdraw?" do
     context "a user who is not an editor" do
-      subject(:checker) { PermissionChecker.new(cma_writer) }
+      subject(:checker) { PermissionChecker.new(generic_writer) }
 
       it "prevents withdrawal" do
         expect(checker.can_withdraw?("manual")).to be false

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe PermissionChecker do
   let(:generic_writer) { FactoryGirl.build(:generic_writer) }
-  let(:dclg_editor)    { FactoryGirl.build(:dclg_editor) }
+  let(:generic_editor) { FactoryGirl.build(:generic_editor) }
   let(:gds_editor)     { FactoryGirl.build(:gds_editor) }
 
   describe "#can_edit?" do
@@ -35,7 +35,7 @@ describe PermissionChecker do
     end
 
     context "an editor" do
-      subject(:checker) { PermissionChecker.new(dclg_editor) }
+      subject(:checker) { PermissionChecker.new(generic_editor) }
 
       context "publishing a manual" do
         it "allows publishing" do
@@ -63,7 +63,7 @@ describe PermissionChecker do
     end
 
     context "an editor" do
-      subject(:checker) { PermissionChecker.new(dclg_editor) }
+      subject(:checker) { PermissionChecker.new(generic_editor) }
 
       context "withdrawing a manual" do
         it "allows withdrawing" do
@@ -88,7 +88,7 @@ describe PermissionChecker do
     end
 
     it "is false for a non-GDS editor" do
-      checker = PermissionChecker.new(dclg_editor)
+      checker = PermissionChecker.new(generic_editor)
       expect(checker.is_gds_editor?).to be false
     end
   end


### PR DESCRIPTION
There doesn't appear to be anything special about writers/editors from CMA or DCLG. We can make that explicit by using the `generic_writer`, `generic_editor` and `gds_editor` factories instead.
