### PR TITLE
Only gather test coverage data in Jenkins CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def setupDb() {
 
 def runTests() {
   echo 'Running tests'
-  sh("bundle exec rake")
+  sh("TEST_COVERAGE=true bundle exec rake")
 }
 
 node {

--- a/features/support/simplecov.rb
+++ b/features/support/simplecov.rb
@@ -1,2 +1,4 @@
-require "simplecov"
-SimpleCov.start
+if ENV["TEST_COVERAGE"]
+  require "simplecov"
+  SimpleCov.start
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), "..")
 
-require "simplecov"
-SimpleCov.start
+if ENV["TEST_COVERAGE"]
+  require "simplecov"
+  SimpleCov.start
+end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= "test"


### PR DESCRIPTION
There's not much point in running this by default in development, especially as it slows the build down. This commit means you have to define the `TEST_COVERAGE` environment variable if you want to gather coverage data in your development environment. However, the data will be gathered by default in the Jenkins CI build.

c.f. alphagov/smart-answers@0c23a273195c3e2ec73880697c61cf9c75027ff3