### PR TITLE
Remove SpecialistDocumentEdition#document_type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user_can_publish?
 
   def current_user_can_withdraw?
-    format = PermissionChecker::MANUAL_FORMAT
-    permission_checker.can_withdraw?(format)
+    permission_checker.can_withdraw?
   end
   helper_method :current_user_can_withdraw?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,8 @@ class ApplicationController < ActionController::Base
     redirect_to(manuals_path, flash: { error: "Manual not found" })
   end
 
-  def current_user_can_publish?(format)
+  def current_user_can_publish?
+    format = PermissionChecker::MANUAL_FORMAT
     permission_checker.can_publish?(format)
   end
   helper_method :current_user_can_publish?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,8 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user_can_publish?
 
-  def current_user_can_withdraw?(format)
+  def current_user_can_withdraw?
+    format = PermissionChecker::MANUAL_FORMAT
     permission_checker.can_withdraw?(format)
   end
   helper_method :current_user_can_withdraw?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user_can_publish?
-    format = PermissionChecker::MANUAL_FORMAT
-    permission_checker.can_publish?(format)
+    permission_checker.can_publish?
   end
   helper_method :current_user_can_publish?
 

--- a/app/controllers/manual_documents_controller.rb
+++ b/app/controllers/manual_documents_controller.rb
@@ -142,7 +142,7 @@ private
   end
 
   def authorize_user_for_withdrawing
-    unless current_user_can_withdraw?(PermissionChecker::MANUAL_FORMAT)
+    unless current_user_can_withdraw?
       redirect_to(
         manual_document_path(params[:manual_id], params[:id]),
         flash: { error: "You don't have permission to withdraw manual sections." },

--- a/app/controllers/manual_documents_controller.rb
+++ b/app/controllers/manual_documents_controller.rb
@@ -142,7 +142,7 @@ private
   end
 
   def authorize_user_for_withdrawing
-    unless current_user_can_withdraw?("manual")
+    unless current_user_can_withdraw?(PermissionChecker::MANUAL_FORMAT)
       redirect_to(
         manual_document_path(params[:manual_id], params[:id]),
         flash: { error: "You don't have permission to withdraw manual sections." },

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -90,7 +90,7 @@ class ManualsController < ApplicationController
   end
 
   def preview
-    manual = services.preview(params["id"], update_manual_params).call
+    manual = services.preview(params[:id], update_manual_params).call
 
     manual.valid? # Force validation check or errors will be empty
 
@@ -112,7 +112,7 @@ class ManualsController < ApplicationController
 private
 
   def manual_id
-    params.fetch("id")
+    params.fetch(:id)
   end
 
   def create_manual_params
@@ -135,7 +135,7 @@ private
 
   def base_manual_params(only: valid_params)
     params
-      .fetch("manual", {})
+      .fetch(:manual, {})
       .slice(*only)
       .symbolize_keys
   end
@@ -150,7 +150,7 @@ private
 
   def manual_date_params
     date_param_names = [:originally_published_at]
-    manual_params = params.fetch("manual", {})
+    manual_params = params.fetch(:manual, {})
     date_params = date_param_names.map do |date_param_name|
       [
         date_param_name,

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -195,7 +195,7 @@ private
   end
 
   def authorize_user_for_publishing
-    unless current_user_can_publish?(PermissionChecker::MANUAL_FORMAT)
+    unless current_user_can_publish?
       redirect_to(
         manual_path(manual_id),
         flash: { error: "You don't have permission to publish." },

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -195,7 +195,7 @@ private
   end
 
   def authorize_user_for_publishing
-    unless current_user_can_publish?("manual")
+    unless current_user_can_publish?(PermissionChecker::MANUAL_FORMAT)
       redirect_to(
         manual_path(manual_id),
         flash: { error: "You don't have permission to publish." },

--- a/app/exporters/formatters/manual_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_indexable_formatter.rb
@@ -1,8 +1,10 @@
 require "formatters/abstract_indexable_formatter"
 
 class ManualIndexableFormatter < AbstractIndexableFormatter
+  RUMMAGER_DOCUMENT_TYPE = "manual".freeze
+
   def type
-    "manual"
+    RUMMAGER_DOCUMENT_TYPE
   end
 
 private

--- a/app/exporters/formatters/manual_section_indexable_formatter.rb
+++ b/app/exporters/formatters/manual_section_indexable_formatter.rb
@@ -1,13 +1,15 @@
 require "formatters/abstract_indexable_formatter"
 
 class ManualSectionIndexableFormatter < AbstractIndexableFormatter
+  RUMMAGER_DOCUMENT_TYPE = "manual_section".freeze
+
   def initialize(section, manual)
     @entity = section
     @manual = manual
   end
 
   def type
-    "manual_section"
+    RUMMAGER_DOCUMENT_TYPE
   end
 
 private

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,6 +1,9 @@
 class ManualPublishingAPIExporter
   include PublishingAPIUpdateTypes
 
+  PUBLISHING_API_SCHEMA_NAME = "manual".freeze
+  PUBLISHING_API_DOCUMENT_TYPE = "manual".freeze
+
   def initialize(export_recipient, organisation, manual_renderer, publication_logs, manual, update_type: nil)
     @export_recipient = export_recipient
     @organisation = organisation
@@ -40,8 +43,8 @@ private
   def exportable_attributes
     {
       base_path: base_path,
-      schema_name: "manual",
-      document_type: "manual",
+      schema_name: PUBLISHING_API_SCHEMA_NAME,
+      document_type: PUBLISHING_API_DOCUMENT_TYPE,
       title: rendered_manual_attributes.fetch(:title),
       description: rendered_manual_attributes.fetch(:summary),
       update_type: update_type,

--- a/app/exporters/manual_section_publishing_api_exporter.rb
+++ b/app/exporters/manual_section_publishing_api_exporter.rb
@@ -1,6 +1,9 @@
 class ManualSectionPublishingAPIExporter
   include PublishingAPIUpdateTypes
 
+  PUBLISHING_API_SCHEMA_NAME = "manual_section".freeze
+  PUBLISHING_API_DOCUMENT_TYPE = "manual_section".freeze
+
   def initialize(export_recipient, organisation, document_renderer, manual, document, update_type: nil)
     @export_recipient = export_recipient
     @organisation = organisation
@@ -30,8 +33,8 @@ private
   def exportable_attributes
     {
       base_path: base_path,
-      schema_name: "manual_section",
-      document_type: "manual_section",
+      schema_name: PUBLISHING_API_SCHEMA_NAME,
+      document_type: PUBLISHING_API_DOCUMENT_TYPE,
       title: rendered_document_attributes.fetch(:title),
       description: rendered_document_attributes.fetch(:summary),
       update_type: update_type,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,7 +95,7 @@ module ApplicationHelper
       text = "<p>There are no changes to publish.</p>"
     elsif manual.state == "withdrawn"
       text = "<p>The manual is withdrawn. You need to create a new draft before it can be published.</p>"
-    elsif !current_user_can_publish?(PermissionChecker::MANUAL_FORMAT)
+    elsif !current_user_can_publish?
       text = "<p>You don't have permission to publish this manual.</p>"
     elsif !slug_unique
       text = "<p>This manual has a duplicate slug and can't be published.</p>"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,7 +95,7 @@ module ApplicationHelper
       text = "<p>There are no changes to publish.</p>"
     elsif manual.state == "withdrawn"
       text = "<p>The manual is withdrawn. You need to create a new draft before it can be published.</p>"
-    elsif !current_user_can_publish?("manual")
+    elsif !current_user_can_publish?(PermissionChecker::MANUAL_FORMAT)
       text = "<p>You don't have permission to publish this manual.</p>"
     elsif !slug_unique
       text = "<p>This manual has a duplicate slug and can't be published.</p>"

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -12,7 +12,8 @@ class PermissionChecker
     is_gds_editor? || can_access_format?(format)
   end
 
-  def can_publish?(format)
+  def can_publish?
+    format = MANUAL_FORMAT
     is_gds_editor? || is_editor? && can_access_format?(format)
   end
 

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -8,10 +8,6 @@ class PermissionChecker
     @user = user
   end
 
-  def can_edit?(format)
-    is_gds_editor? || can_access_format?(format)
-  end
-
   def can_publish?
     format = MANUAL_FORMAT
     is_gds_editor? || is_editor? && can_access_format?(format)

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -10,7 +10,7 @@ class PermissionChecker
 
   def can_publish?
     format = MANUAL_FORMAT
-    is_gds_editor? || is_editor? && can_access_format?(format)
+    is_gds_editor? || is_editor? && (format == MANUAL_FORMAT)
   end
 
   def can_withdraw?
@@ -27,9 +27,5 @@ private
 
   def is_editor?
     user.has_permission?(EDITOR_PERMISSION)
-  end
-
-  def can_access_format?(format)
-    format == MANUAL_FORMAT
   end
 end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -2,6 +2,8 @@ class PermissionChecker
   GDS_EDITOR_PERMISSION = "gds_editor".freeze
   EDITOR_PERMISSION = "editor".freeze
 
+  MANUAL_FORMAT = "manual".freeze
+
   def initialize(user)
     @user = user
   end
@@ -31,6 +33,6 @@ private
   end
 
   def can_access_format?(format)
-    format == "manual"
+    format == MANUAL_FORMAT
   end
 end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -2,8 +2,6 @@ class PermissionChecker
   GDS_EDITOR_PERMISSION = "gds_editor".freeze
   EDITOR_PERMISSION = "editor".freeze
 
-  MANUAL_FORMAT = "manual".freeze
-
   def initialize(user)
     @user = user
   end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -17,7 +17,7 @@ class PermissionChecker
     is_gds_editor? || is_editor? && can_access_format?(format)
   end
 
-  def can_withdraw?(_format)
+  def can_withdraw?
     is_gds_editor? || is_editor?
   end
 

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -9,8 +9,7 @@ class PermissionChecker
   end
 
   def can_publish?
-    format = MANUAL_FORMAT
-    is_gds_editor? || is_editor? && (format == MANUAL_FORMAT)
+    is_gds_editor? || is_editor?
   end
 
   def can_withdraw?

--- a/app/models/builders/manual_document_builder.rb
+++ b/app/models/builders/manual_document_builder.rb
@@ -23,7 +23,6 @@ private
 
   def defaults
     {
-      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       minor_update: false,
       change_note: "New section added.",
     }

--- a/app/models/builders/manual_document_builder.rb
+++ b/app/models/builders/manual_document_builder.rb
@@ -23,7 +23,7 @@ private
 
   def defaults
     {
-      document_type: "manual",
+      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       minor_update: false,
       change_note: "New section added.",
     }

--- a/app/models/specialist_document.rb
+++ b/app/models/specialist_document.rb
@@ -11,7 +11,6 @@ class SpecialistDocument
       :slug,
       :summary,
       :body,
-      :document_type,
       :updated_at,
       :version_number,
       # TODO: These fields expose the edition a little too directly, rethink?
@@ -182,7 +181,6 @@ protected
       .merge(
         version_number: current_version_number + 1,
         slug: slug,
-        document_type: document_type,
         attachments: attachments,
       )
 

--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -7,7 +7,7 @@ class SpecialistDocumentEdition
   MANUAL_DOCUMENT_TYPE = "manual".freeze
 
   field :document_id,          type: String
-  field :document_type,        type: String
+  field :document_type,        type: String, default: MANUAL_DOCUMENT_TYPE
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String

--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -7,7 +7,6 @@ class SpecialistDocumentEdition
   MANUAL_DOCUMENT_TYPE = "manual".freeze
 
   field :document_id,          type: String
-  field :document_type,        type: String, default: MANUAL_DOCUMENT_TYPE
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String
@@ -20,7 +19,6 @@ class SpecialistDocumentEdition
   field :exported_at, type: DateTime
 
   validates :document_id, presence: true
-  validates :document_type, presence: true
   validates :slug, presence: true
 
   embeds_many :attachments, cascade_callbacks: true

--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -4,6 +4,8 @@ class SpecialistDocumentEdition
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  MANUAL_DOCUMENT_TYPE = "manual".freeze
+
   field :document_id,          type: String
   field :document_type,        type: String
   field :version_number,       type: Integer, default: 1

--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -4,8 +4,6 @@ class SpecialistDocumentEdition
   include Mongoid::Document
   include Mongoid::Timestamps
 
-  MANUAL_DOCUMENT_TYPE = "manual".freeze
-
   field :document_id,          type: String
   field :version_number,       type: Integer, default: 1
   field :title,                type: String

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -61,7 +61,7 @@ class RepositoryRegistry
       document_factory = entity_factories.manual_document_factory_factory.call(manual)
 
       SpecialistDocumentRepository.new(
-        document_type: "manual",
+        document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
         document_factory: document_factory,
       )
     }

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -61,7 +61,6 @@ class RepositoryRegistry
       document_factory = entity_factories.manual_document_factory_factory.call(manual)
 
       SpecialistDocumentRepository.new(
-        document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
         document_factory: document_factory,
       )
     }

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -11,8 +11,8 @@ class SpecialistDocumentRepository
     raise e.extend(NotFoundError)
   end
 
-  def initialize(document_type:, document_factory:)
-    @document_type = document_type
+  def initialize(document_factory:)
+    @document_type = SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE
     @document_factory = document_factory
   end
 
@@ -77,7 +77,6 @@ class SpecialistDocumentRepository
 private
 
   attr_reader(
-    :document_type,
     :document_factory,
   )
 

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -12,7 +12,6 @@ class SpecialistDocumentRepository
   end
 
   def initialize(document_factory:)
-    @document_type = SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE
     @document_factory = document_factory
   end
 
@@ -118,6 +117,6 @@ private
   end
 
   def specialist_document_editions
-    SpecialistDocumentEdition.where(document_type: document_type)
+    SpecialistDocumentEdition.where(document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE)
   end
 end

--- a/app/repositories/specialist_document_repository.rb
+++ b/app/repositories/specialist_document_repository.rb
@@ -117,6 +117,6 @@ private
   end
 
   def specialist_document_editions
-    SpecialistDocumentEdition.where(document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE)
+    SpecialistDocumentEdition.all
   end
 end

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -94,7 +94,7 @@ private
   end
 
   def build_specialist_document(document_id)
-    all_editions = SpecialistDocumentEdition.where(document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE, document_id: document_id).order_by([:version_number, :desc]).to_a
+    all_editions = SpecialistDocumentEdition.where(document_id: document_id).order_by([:version_number, :desc]).to_a
     SpecialistDocument.new(
       ->(_title) { raise RuntimeError, "read only manual" },
       document_id,

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -94,7 +94,7 @@ private
   end
 
   def build_specialist_document(document_id)
-    all_editions = SpecialistDocumentEdition.where(document_type: "manual", document_id: document_id).order_by([:version_number, :desc]).to_a
+    all_editions = SpecialistDocumentEdition.where(document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE, document_id: document_id).order_by([:version_number, :desc]).to_a
     SpecialistDocument.new(
       ->(_title) { raise RuntimeError, "read only manual" },
       document_id,

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -92,7 +92,7 @@
       <div class="panel-heading"><h3>Publish manual</h3></div>
       <div class="panel-body">
         <%= publish_text(manual, slug_unique) %>
-        <% if manual.draft? && manual.documents.any? && current_user_can_publish?("manual") && slug_unique %>
+        <% if manual.draft? && manual.documents.any? && current_user_can_publish?(PermissionChecker::MANUAL_FORMAT) && slug_unique %>
           <%= form_tag(publish_manual_path(manual), method: :post) do %>
             <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
           <% end -%>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -92,7 +92,7 @@
       <div class="panel-heading"><h3>Publish manual</h3></div>
       <div class="panel-body">
         <%= publish_text(manual, slug_unique) %>
-        <% if manual.draft? && manual.documents.any? && current_user_can_publish?(PermissionChecker::MANUAL_FORMAT) && slug_unique %>
+        <% if manual.draft? && manual.documents.any? && current_user_can_publish? && slug_unique %>
           <%= form_tag(publish_manual_path(manual), method: :post) do %>
             <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
           <% end -%>

--- a/db/migrate/20170224113808_remove_specialist_document_editions_with_non_manual_document_type.rb
+++ b/db/migrate/20170224113808_remove_specialist_document_editions_with_non_manual_document_type.rb
@@ -1,6 +1,6 @@
 class RemoveSpecialistDocumentEditionsWithNonManualDocumentType < Mongoid::Migration
   def self.up
-    SpecialistDocumentEdition.where(:document_type.ne => SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE).delete_all
+    SpecialistDocumentEdition.where(:document_type.ne => 'manual').delete_all
   end
 
   def self.down

--- a/db/migrate/20170224113808_remove_specialist_document_editions_with_non_manual_document_type.rb
+++ b/db/migrate/20170224113808_remove_specialist_document_editions_with_non_manual_document_type.rb
@@ -1,6 +1,6 @@
 class RemoveSpecialistDocumentEditionsWithNonManualDocumentType < Mongoid::Migration
   def self.up
-    SpecialistDocumentEdition.where(:document_type.ne => 'manual').delete_all
+    SpecialistDocumentEdition.where(:document_type.ne => SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE).delete_all
   end
 
   def self.down

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -243,7 +243,7 @@ module ManualHelpers
   def check_manual_is_published_to_rummager(slug, attrs)
     expect(fake_rummager).to have_received(:add_document)
       .with(
-        "manual",
+        ManualIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: attrs.fetch(:title),
@@ -256,7 +256,7 @@ module ManualHelpers
   def check_manual_is_not_published_to_rummager(slug)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        "manual",
+        ManualIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{slug}",
         anything
       )
@@ -265,7 +265,7 @@ module ManualHelpers
   def check_manual_is_not_published_to_rummager_with_attrs(slug, attrs)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        "manual",
+        ManualIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: attrs.fetch(:title),
@@ -332,7 +332,7 @@ module ManualHelpers
   def check_manual_section_is_published_to_rummager(slug, attrs, manual_attrs)
     expect(fake_rummager).to have_received(:add_document)
       .with(
-        "manual_section",
+        ManualSectionIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: "#{manual_attrs.fetch(:title)}: #{attrs.fetch(:section_title)}",
@@ -345,7 +345,7 @@ module ManualHelpers
   def check_manual_section_is_not_published_to_rummager(slug)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        "manual_section",
+        ManualSectionIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{slug}",
         anything
       )
@@ -354,7 +354,7 @@ module ManualHelpers
   def check_manual_section_is_not_published_to_rummager_with_attrs(slug, attrs, manual_attrs)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        "manual_section",
+        ManualSectionIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: "#{manual_attrs.fetch(:title)}: #{attrs.fetch(:section_title)}",
@@ -461,14 +461,14 @@ module ManualHelpers
   def check_manual_is_withdrawn_from_rummager(manual, documents)
     expect(fake_rummager).to have_received(:delete_document)
       .with(
-        "manual",
+        ManualIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{manual.slug}",
       )
 
     documents.each do |document|
       expect(fake_rummager).to have_received(:delete_document)
         .with(
-          "manual_section",
+          ManualSectionIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
           "/#{document.slug}",
         )
     end
@@ -477,7 +477,7 @@ module ManualHelpers
   def check_manual_document_is_withdrawn_from_rummager(document)
     expect(fake_rummager).to have_received(:delete_document)
       .with(
-        "manual_section",
+        ManualSectionIndexableFormatter::RUMMAGER_DOCUMENT_TYPE,
         "/#{document.slug}",
       )
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -280,8 +280,8 @@ module ManualHelpers
 
     if with_matcher.nil?
       attributes = {
-        "schema_name" => "manual",
-        "document_type" => "manual",
+        "schema_name" => ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
+        "document_type" => ManualPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
         "rendering_app" => "manuals-frontend",
         "publishing_app" => "manuals-publisher",
       }.merge(extra_attributes)
@@ -307,8 +307,8 @@ module ManualHelpers
 
     if with_matcher.nil?
       attributes = {
-        "schema_name" => "manual_section",
-        "document_type" => "manual_section",
+        "schema_name" => ManualSectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
+        "document_type" => ManualSectionPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
         "rendering_app" => "manuals-frontend",
         "publishing_app" => "manuals-publisher",
       }.merge(extra_attributes)

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -7,7 +7,6 @@ describe ManualsController, type: :controller do
       let(:services) { spy(AbstractManualDocumentServiceRegistry) }
       before do
         login_as_stub_user
-        allow_any_instance_of(PermissionChecker).to receive(:can_edit?).and_return(true)
         allow_any_instance_of(PermissionChecker).to receive(:can_publish?).and_return(false)
         allow(controller).to receive(:services).and_return services
         post :publish, id: manual_id

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -148,7 +148,7 @@ describe ManualPublishingAPIExporter do
   end
 
   it "exports a manual valid against the schema" do
-    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema("manual")
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema(ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME)
   end
 
   it "exports the serialized document attributes" do
@@ -159,8 +159,8 @@ describe ManualPublishingAPIExporter do
       all_of(
         hash_including(
           base_path: "/guidance/my-first-manual",
-          schema_name: "manual",
-          document_type: "manual",
+          schema_name: ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
+          document_type: ManualPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
           title: "My first manual",
           description: "This is my first manual",
           update_type: "major",

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -56,6 +56,6 @@ describe ManualPublishingAPILinksExporter do
   end
 
   it "exports links valid against the schema" do
-    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_links_schema("manual")
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_links_schema(ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME)
   end
 end

--- a/spec/exporters/manual_section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_section_publishing_api_exporter_spec.rb
@@ -134,8 +134,8 @@ describe ManualSectionPublishingAPIExporter do
       all_of(
         hash_including(
           base_path: document_base_path,
-          schema_name: "manual_section",
-          document_type: "manual_section",
+          schema_name: ManualSectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
+          document_type: ManualSectionPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
           title: "Document title",
           description: "This is the first section",
           update_type: "minor",

--- a/spec/exporters/manual_section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_section_publishing_api_links_exporter_spec.rb
@@ -59,6 +59,6 @@ describe ManualSectionPublishingAPILinksExporter do
   end
 
   it "exports links valid against the schema" do
-    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_links_schema("manual_section")
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_links_schema(ManualSectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME)
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -48,7 +48,7 @@ FactoryGirl.define do
     sequence(:title) { |n| "Test Specialist Document #{n}" }
     summary "My summary"
     body "My body"
-    document_type "manual"
+    document_type SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE
   end
 
   factory :specialist_document do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -48,7 +48,6 @@ FactoryGirl.define do
     sequence(:title) { |n| "Test Specialist Document #{n}" }
     summary "My summary"
     body "My body"
-    document_type SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE
   end
 
   factory :specialist_document do

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -10,7 +10,6 @@ describe DuplicateDraftDeleter do
     FactoryGirl.create(:specialist_document_edition,
       slug: "cma-cases/a-case",
       document_id: original_content_id,
-      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       state: "draft",
     )
     publishing_api_has_item(content_id: original_content_id)
@@ -19,13 +18,11 @@ describe DuplicateDraftDeleter do
     FactoryGirl.create(:specialist_document_edition,
       slug: "cma-cases/a-case",
       document_id: duplicate_content_id,
-      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       state: "draft",
     )
     FactoryGirl.create(:specialist_document_edition,
       slug: "cma-cases/a-case",
       document_id: duplicate_content_id,
-      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       state: "archived",
     )
     publishing_api_does_not_have_item(duplicate_content_id)

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -10,7 +10,7 @@ describe DuplicateDraftDeleter do
     FactoryGirl.create(:specialist_document_edition,
       slug: "cma-cases/a-case",
       document_id: original_content_id,
-      document_type: "manual",
+      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       state: "draft",
     )
     publishing_api_has_item(content_id: original_content_id)
@@ -19,13 +19,13 @@ describe DuplicateDraftDeleter do
     FactoryGirl.create(:specialist_document_edition,
       slug: "cma-cases/a-case",
       document_id: duplicate_content_id,
-      document_type: "manual",
+      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       state: "draft",
     )
     FactoryGirl.create(:specialist_document_edition,
       slug: "cma-cases/a-case",
       document_id: duplicate_content_id,
-      document_type: "manual",
+      document_type: SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE,
       state: "archived",
     )
     publishing_api_does_not_have_item(duplicate_content_id)

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -56,25 +56,23 @@ describe PermissionChecker do
       subject(:checker) { PermissionChecker.new(cma_writer) }
 
       it "prevents withdrawal" do
-        expect(checker.can_withdraw?(PermissionChecker::MANUAL_FORMAT)).to be false
+        expect(checker.can_withdraw?).to be false
       end
     end
 
     context "an editor" do
       subject(:checker) { PermissionChecker.new(dclg_editor) }
 
-      context "withdrawing a manual" do
-        it "allows withdrawing" do
-          expect(checker.can_withdraw?(PermissionChecker::MANUAL_FORMAT)).to be true
-        end
+      it "allows withdrawal" do
+        expect(checker.can_withdraw?).to be true
       end
     end
 
     context "a GDS editor" do
       subject(:checker) { PermissionChecker.new(gds_editor) }
 
-      it "allows withdrawal of any format" do
-        expect(checker.can_withdraw?("tea_and_biscuits")).to be true
+      it "allows withdrawal" do
+        expect(checker.can_withdraw?).to be true
       end
     end
   end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -11,7 +11,7 @@ describe PermissionChecker do
 
       context "editing a manual" do
         it "allows editing" do
-          expect(checker.can_edit?("manual")).to be true
+          expect(checker.can_edit?(PermissionChecker::MANUAL_FORMAT)).to be true
         end
       end
     end
@@ -30,7 +30,7 @@ describe PermissionChecker do
       subject(:checker) { PermissionChecker.new(cma_writer) }
 
       it "prevents publishing" do
-        expect(checker.can_publish?("manual")).to be false
+        expect(checker.can_publish?(PermissionChecker::MANUAL_FORMAT)).to be false
       end
     end
 
@@ -39,7 +39,7 @@ describe PermissionChecker do
 
       context "publishing a manual" do
         it "allows publishing" do
-          expect(checker.can_publish?("manual")).to be true
+          expect(checker.can_publish?(PermissionChecker::MANUAL_FORMAT)).to be true
         end
       end
     end
@@ -58,7 +58,7 @@ describe PermissionChecker do
       subject(:checker) { PermissionChecker.new(cma_writer) }
 
       it "prevents withdrawal" do
-        expect(checker.can_withdraw?("manual")).to be false
+        expect(checker.can_withdraw?(PermissionChecker::MANUAL_FORMAT)).to be false
       end
     end
 
@@ -67,7 +67,7 @@ describe PermissionChecker do
 
       context "withdrawing a manual" do
         it "allows withdrawing" do
-          expect(checker.can_withdraw?("manual")).to be true
+          expect(checker.can_withdraw?(PermissionChecker::MANUAL_FORMAT)).to be true
         end
       end
     end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -30,25 +30,23 @@ describe PermissionChecker do
       subject(:checker) { PermissionChecker.new(cma_writer) }
 
       it "prevents publishing" do
-        expect(checker.can_publish?(PermissionChecker::MANUAL_FORMAT)).to be false
+        expect(checker.can_publish?).to be false
       end
     end
 
     context "an editor" do
       subject(:checker) { PermissionChecker.new(dclg_editor) }
 
-      context "publishing a manual" do
-        it "allows publishing" do
-          expect(checker.can_publish?(PermissionChecker::MANUAL_FORMAT)).to be true
-        end
+      it "allows publishing" do
+        expect(checker.can_publish?).to be true
       end
     end
 
     context "a GDS editor" do
       subject(:checker) { PermissionChecker.new(gds_editor) }
 
-      it "allows publishing of any format" do
-        expect(checker.can_publish?("tea_and_biscuits")).to be true
+      it "allows publishing" do
+        expect(checker.can_publish?).to be true
       end
     end
   end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -5,26 +5,6 @@ describe PermissionChecker do
   let(:dclg_editor)  { FactoryGirl.build(:dclg_editor) }
   let(:gds_editor)   { FactoryGirl.build(:gds_editor) }
 
-  describe "#can_edit?" do
-    context "a user who is not an editor" do
-      subject(:checker) { PermissionChecker.new(cma_writer) }
-
-      context "editing a manual" do
-        it "allows editing" do
-          expect(checker.can_edit?(PermissionChecker::MANUAL_FORMAT)).to be true
-        end
-      end
-    end
-
-    context "a GDS editor" do
-      subject(:checker) { PermissionChecker.new(gds_editor) }
-
-      it "allows editing of any format" do
-        expect(checker.can_edit?("tea_and_cake")).to be true
-      end
-    end
-  end
-
   describe "#can_publish?" do
     context "a user who is not an editor" do
       subject(:checker) { PermissionChecker.new(cma_writer) }

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -10,7 +10,7 @@ describe SpecialistDocument do
   end
 
   let(:document_id)         { "a-document-id" }
-  let(:document_type)       { "manual" }
+  let(:document_type)       { SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE }
   let(:slug)                { double(:slug) }
   let(:published_slug)      { double(:published_slug) }
   let(:slug_generator)      { double(:slug_generator, call: slug) }

--- a/spec/models/specialist_document_spec.rb
+++ b/spec/models/specialist_document_spec.rb
@@ -10,7 +10,6 @@ describe SpecialistDocument do
   end
 
   let(:document_id)         { "a-document-id" }
-  let(:document_type)       { SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE }
   let(:slug)                { double(:slug) }
   let(:published_slug)      { double(:published_slug) }
   let(:slug_generator)      { double(:slug_generator, call: slug) }
@@ -44,7 +43,6 @@ describe SpecialistDocument do
         published?: false,
         archived?: false,
         version_number: 1,
-        document_type: document_type,
         exported_at: nil,
       )
     )
@@ -59,7 +57,6 @@ describe SpecialistDocument do
         published?: false,
         archived?: false,
         version_number: 2,
-        document_type: document_type,
         exported_at: nil,
       )
     )
@@ -74,7 +71,6 @@ describe SpecialistDocument do
         published?: false,
         archived?: false,
         version_number: 3,
-        document_type: document_type,
         exported_at: nil,
       )
     )
@@ -90,7 +86,6 @@ describe SpecialistDocument do
         archived?: false,
         slug: published_slug,
         version_number: 1,
-        document_type: document_type,
       )
     )
   }
@@ -105,7 +100,6 @@ describe SpecialistDocument do
         archived?: true,
         slug: published_slug,
         version_number: 2,
-        document_type: document_type,
       )
     )
   }

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 describe SpecialistDocumentRepository do
   let(:specialist_document_repository) do
     SpecialistDocumentRepository.new(
-      document_type: document_type,
       document_factory: document_factory,
     )
   end
@@ -11,8 +10,6 @@ describe SpecialistDocumentRepository do
   let(:document_factory) { double(:document_factory, call: document) }
 
   let(:document_id) { "document-id" }
-  let(:document_type) { SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE }
-
   let(:document) {
     SpecialistDocument.new(slug_generator, document_id, editions, edition_factory)
   }

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -11,7 +11,7 @@ describe SpecialistDocumentRepository do
   let(:document_factory) { double(:document_factory, call: document) }
 
   let(:document_id) { "document-id" }
-  let(:document_type) { "manual" }
+  let(:document_type) { SpecialistDocumentEdition::MANUAL_DOCUMENT_TYPE }
 
   let(:document) {
     SpecialistDocument.new(slug_generator, document_id, editions, edition_factory)

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -91,7 +91,7 @@ describe SpecialistDocumentRepository do
 
     before do
       allow(SpecialistDocument).to receive(:new).and_return(document)
-      allow(SpecialistDocumentEdition).to receive(:where)
+      allow(SpecialistDocumentEdition).to receive(:all)
         .and_return(editions_proxy)
     end
 

--- a/spec/repositories/specialist_document_repository_spec.rb
+++ b/spec/repositories/specialist_document_repository_spec.rb
@@ -71,7 +71,6 @@ describe SpecialistDocumentRepository do
 
         edition = FactoryGirl.create(:specialist_document_edition,
                                      document_id: document_id,
-                                     document_type: document_type,
                                      updated_at: n.days.ago)
 
         allow(document_factory).to receive(:call)


### PR DESCRIPTION
Since [this commit][1] all editions have had a `document_type` value of 'manual' and so the field had become redundant.

Unfortunately the string literal, 'manual', appeared rather a lot throughout the code, so some of the early commits extract these occurrences out into a number of different constants in order to better express their meaning. A couple of these which internal to the app are then gradually refactored away, leaving only ones relating to the Publishing API and Rummager.

For simplicity I've decided not to take the final step of unsetting the `document_type` field on all existing persisted instances of `SpecialistDocumentEdition` within this pull request, but I would expect to do it very shortly.

[1]: https://github.com/alphagov/manuals-publisher/commit/723ce320c9845003bf1aa584d4ea726b587c1891