### PR TITLE
Remove SpecialistDocumentEdition#document_type field

### DIFF
--- a/db/migrate/20170313132656_remove_document_type_field_from_section_editions.rb
+++ b/db/migrate/20170313132656_remove_document_type_field_from_section_editions.rb
@@ -1,0 +1,13 @@
+class RemoveDocumentTypeFieldFromSectionEditions < Mongoid::Migration
+  def self.up
+    SectionEdition.collection.update(
+      {},
+      { '$unset' => { 'document_type' => true } },
+      { multi: true }
+    )
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This removes the `document_type` field from all existing persisted instances using the `$unset` operator on the entire collection.

Fixes #850.