### PR TITLE
Remove references to CMA and DCLG

### DIFF
--- a/features/access_control.feature
+++ b/features/access_control.feature
@@ -5,7 +5,7 @@ Feature: Access control
 
   Scenario: Editor only sees manuals created by their organisation
     Given there are manuals created by multiple organisations
-    And I am logged in as a non-CMA editor
+    And I am logged in as an editor
     When I view my list of manuals
     Then I only see manuals created by my organisation
 

--- a/features/access_control.feature
+++ b/features/access_control.feature
@@ -11,7 +11,7 @@ Feature: Access control
 
   Scenario: GDS Editor sees manuals created by all organisations
     Given there are manuals created by multiple organisations
-    And I am logged in as a "GDS" editor
+    And I am logged in as a GDS editor
     When I view my list of manuals
     Then I see manuals created by all organisations
 

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -4,8 +4,8 @@ Feature: Attachments
   So that users can access the supporting documents
 
   @regression
-  Scenario: CMA editor can add and replace attachment to manual
-    Given I am logged in as a CMA editor
+  Scenario: editor can add and replace attachment to manual
+    Given I am logged in as an editor
     And a draft manual exists without any documents
     And a draft document exists for the manual
     When I attach a file and give it a title

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -16,7 +16,7 @@ Feature: Attachments
   @regression
   Scenario: GDS editor can add attachment to manual from another Org
     Given a draft manual exists belonging to "ministry-of-tea"
-    And I am logged in as a "GDS" editor
+    And I am logged in as a GDS editor
     And a draft document exists for the manual
     When I attach a file and give it a title
     Then I see the attached file

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -5,7 +5,7 @@ Feature: Attachments
 
   @regression
   Scenario: CMA editor can add and replace attachment to manual
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
     And a draft manual exists without any documents
     And a draft document exists for the manual
     When I attach a file and give it a title

--- a/features/creating-and-editing-a-manual-as-a-gds-editor.feature
+++ b/features/creating-and-editing-a-manual-as-a-gds-editor.feature
@@ -4,14 +4,14 @@ Feature: Creating and editing manuals
   And edit manuals belonging to any organisation
 
   Scenario: Create a new manual
-    Given I am logged in as a "GDS" editor
+    Given I am logged in as a GDS editor
     When I create a manual
     Then the manual should exist
     And the manual should belong to "government-digital-service"
 
   Scenario: Edit a draft manual
     Given a draft manual exists belonging to "ministry-of-tea"
-    And I am logged in as a "GDS" editor
+    And I am logged in as a GDS editor
     When I edit a manual
     Then the manual should have been updated
     And the manual should still belong to "ministry-of-tea"

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -4,7 +4,7 @@ Feature: Creating and editing a manual
   So that I can start moving my content to gov.uk
 
   Background:
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
 
   Scenario: Create a new manual
     When I create a manual

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -1,10 +1,10 @@
 Feature: Creating and editing a manual
-  As a CMA editor
+  As an editor
   I want to create and edit a manual and see it in the publisher
   So that I can start moving my content to gov.uk
 
   Background:
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
 
   Scenario: Create a new manual
     When I create a manual

--- a/features/deleting-a-manual.feature
+++ b/features/deleting-a-manual.feature
@@ -3,7 +3,7 @@ Feature: Script to delete a manual
   documents and its slug is no longer reserved
 
   Background:
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
 
   Scenario: Deleting a manual
     Given a draft manual exists without any documents

--- a/features/deleting-a-manual.feature
+++ b/features/deleting-a-manual.feature
@@ -3,7 +3,7 @@ Feature: Script to delete a manual
   documents and its slug is no longer reserved
 
   Background:
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
 
   Scenario: Deleting a manual
     Given a draft manual exists without any documents

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -4,7 +4,7 @@ Feature: Publishing a manual
   So that they are available on GOV.UK
 
   Background:
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
 
   Scenario: Publish a manual
     Given a draft manual exists with some documents

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -4,7 +4,7 @@ Feature: Publishing a manual
   So that they are available on GOV.UK
 
   Background:
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
 
   Scenario: Publish a manual
     Given a draft manual exists with some documents

--- a/features/removing-a-manual-section.feature
+++ b/features/removing-a-manual-section.feature
@@ -14,7 +14,7 @@ Feature: Removing a section from a manual
     And the removed document is archived
 
   Scenario: Removing a draft section as an editor
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
     And a draft manual exists without any documents
     And a draft document exists for the manual
     When I remove the document from the manual
@@ -40,7 +40,7 @@ Feature: Removing a section from a manual
     And the removed document is archived
 
   Scenario: Removing a previously published section from a draft manual as an editor
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
     And a published manual exists
     And I edit one of the manual's documents
     When I remove the edited document from the manual
@@ -67,7 +67,7 @@ Feature: Removing a section from a manual
     And the removed document is archived
 
   Scenario: Removing a section from a published manual as an editor
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
     And a published manual exists
     When I remove one of the documents from the manual
     Then the document is removed from the manual

--- a/features/removing-a-manual-section.feature
+++ b/features/removing-a-manual-section.feature
@@ -14,7 +14,7 @@ Feature: Removing a section from a manual
     And the removed document is archived
 
   Scenario: Removing a draft section as an editor
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
     And a draft manual exists without any documents
     And a draft document exists for the manual
     When I remove the document from the manual
@@ -40,7 +40,7 @@ Feature: Removing a section from a manual
     And the removed document is archived
 
   Scenario: Removing a previously published section from a draft manual as an editor
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
     And a published manual exists
     And I edit one of the manual's documents
     When I remove the edited document from the manual
@@ -67,7 +67,7 @@ Feature: Removing a section from a manual
     And the removed document is archived
 
   Scenario: Removing a section from a published manual as an editor
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
     And a published manual exists
     When I remove one of the documents from the manual
     Then the document is removed from the manual

--- a/features/removing-a-manual-section.feature
+++ b/features/removing-a-manual-section.feature
@@ -4,7 +4,7 @@ Feature: Removing a section from a manual
   So that it no longer one of the manual's sections
 
   Scenario: Removing a draft section as a GDS editor
-    Given I am logged in as a "GDS" editor
+    Given I am logged in as a GDS editor
     And a draft manual exists without any documents
     And a draft document exists for the manual
     When I remove the document from the manual
@@ -29,7 +29,7 @@ Feature: Removing a section from a manual
     Then I cannot remove a document from the manual
 
   Scenario: Removing a previously published section from a draft manual as a GDS editor
-    Given I am logged in as a "GDS" editor
+    Given I am logged in as a GDS editor
     And a published manual exists
     And I edit one of the manual's documents
     When I remove the edited document from the manual
@@ -57,7 +57,7 @@ Feature: Removing a section from a manual
     Then I cannot remove a document from the manual
 
   Scenario: Removing a section from a published manual as a GDS editor
-    Given I am logged in as a "GDS" editor
+    Given I am logged in as a GDS editor
     And a published manual exists
     When I remove one of the documents from the manual
     Then the document is removed from the manual
@@ -82,7 +82,7 @@ Feature: Removing a section from a manual
     Then I cannot remove a document from the manual
 
   Scenario: Removing a section with a major update change notes
-    Given I am logged in as a "GDS" editor
+    Given I am logged in as a GDS editor
     And a published manual exists
     When I remove one of the documents from the manual with a major update omitting the note
     Then I see an error requesting that I provide a change note
@@ -92,7 +92,7 @@ Feature: Removing a section from a manual
     Then the removed document change note is included
 
   Scenario: Removing a section with a minor update change notes
-    Given I am logged in as a "GDS" editor
+    Given I am logged in as a GDS editor
     And a published manual exists
     When I remove one of the documents from the manual with a minor update
     Then the document is removed from the manual

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -1,3 +1,8 @@
+Given(/^I am logged in as a GDS editor$/) do
+  login_as(:gds_editor)
+  stub_organisation_details(GDS::SSO.test_user.organisation_slug)
+end
+
 Given(/^I am logged in as a "(.*?)" editor$/) do |editor_type|
   login_as(:"#{editor_type.downcase}_editor")
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -8,11 +8,6 @@ Given(/^I am logged in as an editor$/) do
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 
-Given(/^I am logged in as a non\-CMA editor$/) do
-  login_as(:generic_editor)
-  stub_organisation_details(GDS::SSO.test_user.organisation_slug)
-end
-
 Given(/^there are manuals created by multiple organisations$/) do
   login_as(:cma_editor)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -8,11 +8,6 @@ Given(/^I am logged in as a CMA editor$/) do
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 
-Given(/^I am logged in as a "(.*?)" editor$/) do |editor_type|
-  login_as(:"#{editor_type.downcase}_editor")
-  stub_organisation_details(GDS::SSO.test_user.organisation_slug)
-end
-
 Given(/^I am logged in as a non\-CMA editor$/) do
   login_as(:generic_editor)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -41,7 +41,7 @@ Then(/^I see manuals created by all organisations$/) do
 end
 
 Given(/^I am logged in as a writer$/) do
-  login_as(:cma_writer)
+  login_as(:generic_writer)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -9,13 +9,13 @@ Given(/^I am logged in as an editor$/) do
 end
 
 Given(/^there are manuals created by multiple organisations$/) do
-  login_as(:cma_editor)
+  login_as(:generic_editor_of_another_organisation)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
-  @cma_manual_fields = {
-    title: "Manual on Competition",
+  @coffee_manual_fields = {
+    title: "Manual on Coffee",
     summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
   }
-  create_manual(@cma_manual_fields)
+  create_manual(@coffee_manual_fields)
 
   login_as(:generic_editor)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
@@ -32,12 +32,12 @@ end
 
 Then(/^I only see manuals created by my organisation$/) do
   check_manual_visible(@tea_manual_fields.fetch(:title))
-  check_manual_not_visible(@cma_manual_fields.fetch(:title))
+  check_manual_not_visible(@coffee_manual_fields.fetch(:title))
 end
 
 Then(/^I see manuals created by all organisations$/) do
   check_manual_visible(@tea_manual_fields.fetch(:title))
-  check_manual_visible(@cma_manual_fields.fetch(:title))
+  check_manual_visible(@coffee_manual_fields.fetch(:title))
 end
 
 Given(/^I am logged in as a writer$/) do

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -3,8 +3,8 @@ Given(/^I am logged in as a GDS editor$/) do
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 
-Given(/^I am logged in as a CMA editor$/) do
-  login_as(:cma_editor)
+Given(/^I am logged in as an editor$/) do
+  login_as(:generic_editor)
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -3,6 +3,11 @@ Given(/^I am logged in as a GDS editor$/) do
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)
 end
 
+Given(/^I am logged in as a CMA editor$/) do
+  login_as(:cma_editor)
+  stub_organisation_details(GDS::SSO.test_user.organisation_slug)
+end
+
 Given(/^I am logged in as a "(.*?)" editor$/) do |editor_type|
   login_as(:"#{editor_type.downcase}_editor")
   stub_organisation_details(GDS::SSO.test_user.organisation_slug)

--- a/features/withdrawing-a-manual.feature
+++ b/features/withdrawing-a-manual.feature
@@ -4,7 +4,7 @@ Feature: Script to withdraw published manuals
   So that it is not accessible to the public
 
   Background:
-    Given I am logged in as a CMA editor
+    Given I am logged in as an editor
 
   Scenario:
     Given a published manual exists

--- a/features/withdrawing-a-manual.feature
+++ b/features/withdrawing-a-manual.feature
@@ -4,7 +4,7 @@ Feature: Script to withdraw published manuals
   So that it is not accessible to the public
 
   Background:
-    Given I am logged in as a "CMA" editor
+    Given I am logged in as a CMA editor
 
   Scenario:
     Given a published manual exists

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,10 +21,6 @@ FactoryGirl.define do
     organisation_slug "competition-and-markets-authority"
   end
 
-  factory :dclg_editor, parent: :editor do
-    organisation_slug "department-for-communities-and-local-government"
-  end
-
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,10 +17,6 @@ FactoryGirl.define do
     permissions %w(signin editor)
   end
 
-  factory :cma_writer, parent: :user do
-    organisation_slug "competition-and-markets-authority"
-  end
-
   factory :cma_editor, parent: :editor do
     organisation_slug "competition-and-markets-authority"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -37,6 +37,10 @@ FactoryGirl.define do
     organisation_slug "ministry-of-tea"
   end
 
+  factory :generic_editor_of_another_organisation, parent: :editor do
+    organisation_slug "another-organisation"
+  end
+
   factory :gds_editor, parent: :user do
     permissions %w(signin gds_editor)
     organisation_slug "government-digital-service"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,10 +17,6 @@ FactoryGirl.define do
     permissions %w(signin editor)
   end
 
-  factory :cma_editor, parent: :editor do
-    organisation_slug "competition-and-markets-authority"
-  end
-
   factory :generic_writer, parent: :user do
     organisation_slug "ministry-of-tea"
   end

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -8,7 +8,7 @@ describe DuplicateDraftDeleter do
   it "deletes duplicate editions that aren't present in Publishing API" do
     original_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
-      slug: "cma-cases/a-case",
+      slug: "guidance/manual-slug/section-slug",
       document_id: original_content_id,
       state: "draft",
     )
@@ -16,12 +16,12 @@ describe DuplicateDraftDeleter do
 
     duplicate_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
-      slug: "cma-cases/a-case",
+      slug: "guidance/manual-slug/section-slug",
       document_id: duplicate_content_id,
       state: "draft",
     )
     FactoryGirl.create(:section_edition,
-      slug: "cma-cases/a-case",
+      slug: "guidance/manual-slug/section-slug",
       document_id: duplicate_content_id,
       state: "archived",
     )

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
 describe PermissionChecker do
-  let(:cma_writer)   { FactoryGirl.build(:cma_writer) }
-  let(:dclg_editor)  { FactoryGirl.build(:dclg_editor) }
-  let(:gds_editor)   { FactoryGirl.build(:gds_editor) }
+  let(:generic_writer) { FactoryGirl.build(:generic_writer) }
+  let(:dclg_editor)    { FactoryGirl.build(:dclg_editor) }
+  let(:gds_editor)     { FactoryGirl.build(:gds_editor) }
 
   describe "#can_publish?" do
     context "a user who is not an editor" do
-      subject(:checker) { PermissionChecker.new(cma_writer) }
+      subject(:checker) { PermissionChecker.new(generic_writer) }
 
       it "prevents publishing" do
         expect(checker.can_publish?).to be false
@@ -33,7 +33,7 @@ describe PermissionChecker do
 
   describe "#can_withdraw?" do
     context "a user who is not an editor" do
-      subject(:checker) { PermissionChecker.new(cma_writer) }
+      subject(:checker) { PermissionChecker.new(generic_writer) }
 
       it "prevents withdrawal" do
         expect(checker.can_withdraw?).to be false

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe PermissionChecker do
   let(:generic_writer) { FactoryGirl.build(:generic_writer) }
-  let(:dclg_editor)    { FactoryGirl.build(:dclg_editor) }
+  let(:generic_editor) { FactoryGirl.build(:generic_editor) }
   let(:gds_editor)     { FactoryGirl.build(:gds_editor) }
 
   describe "#can_publish?" do
@@ -15,7 +15,7 @@ describe PermissionChecker do
     end
 
     context "an editor" do
-      subject(:checker) { PermissionChecker.new(dclg_editor) }
+      subject(:checker) { PermissionChecker.new(generic_editor) }
 
       it "allows publishing" do
         expect(checker.can_publish?).to be true
@@ -41,7 +41,7 @@ describe PermissionChecker do
     end
 
     context "an editor" do
-      subject(:checker) { PermissionChecker.new(dclg_editor) }
+      subject(:checker) { PermissionChecker.new(generic_editor) }
 
       it "allows withdrawal" do
         expect(checker.can_withdraw?).to be true
@@ -64,7 +64,7 @@ describe PermissionChecker do
     end
 
     it "is false for a non-GDS editor" do
-      checker = PermissionChecker.new(dclg_editor)
+      checker = PermissionChecker.new(generic_editor)
       expect(checker.is_gds_editor?).to be false
     end
   end

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -80,16 +80,16 @@ describe ManualRecord, hits_db: true do
   end
 
   describe "#find_by_organisation" do
-    let!(:cma_manual) {
-      ManualRecord.create!(organisation_slug: "cma")
+    let!(:org_1_manual) {
+      ManualRecord.create!(organisation_slug: "org-1")
     }
 
-    let!(:tea_manual) {
-      ManualRecord.create!(organisation_slug: "ministry-of-tea")
+    let!(:org_2_manual) {
+      ManualRecord.create!(organisation_slug: "org-2")
     }
 
     it "filters by organisation" do
-      expect(ManualRecord.find_by_organisation("cma").to_a).to eq([cma_manual])
+      expect(ManualRecord.find_by_organisation("org-1").to_a).to eq([org_1_manual])
     end
   end
 

--- a/spec/models/publication_log_spec.rb
+++ b/spec/models/publication_log_spec.rb
@@ -40,8 +40,8 @@ describe PublicationLog, hits_db: true do
 
   describe ".change_notes_for" do
     context "there are some publication log entries" do
-      let(:slug) { "cma-cases/my-slug" }
-      let(:other_slug) { "something-else/another-one" }
+      let(:slug) { "guidance/my-slug" }
+      let(:other_slug) { "not-guidance/another-one" }
 
       let!(:change_notes_for_first_doc) {
         [
@@ -79,7 +79,7 @@ describe PublicationLog, hits_db: true do
       end
 
       context "and some are for documents with similar slugs" do
-        let!(:similar_slug) { "cma-cases/my-slug-belongs-to-me" }
+        let!(:similar_slug) { "guidance/my-slug-belongs-to-me" }
 
         let!(:change_note_for_similar_slug) {
           PublicationLog.create(
@@ -96,7 +96,7 @@ describe PublicationLog, hits_db: true do
       end
 
       context "and some are for child documents of the slug" do
-        let!(:child_slug) { "cma-cases/my-slug/my-lovely-document-slug" }
+        let!(:child_slug) { "guidance/my-slug/my-lovely-document-slug" }
 
         let!(:change_note_for_child_slug) {
           PublicationLog.create(
@@ -130,7 +130,7 @@ describe PublicationLog, hits_db: true do
 
     context "no publication logs exist for a slug" do
       it "returns an empty list" do
-        expect(PublicationLog.change_notes_for("cma-cases/my-slug")).to eq([])
+        expect(PublicationLog.change_notes_for("guidance/my-slug")).to eq([])
       end
     end
   end


### PR DESCRIPTION
This app used to be responsible for publishing CMA (and possibly DCLG?) content. CMA content has now moved to specialist-publisher. I've removed references to CMA and DCLG to make it clear that there's nothing special about those organisations in this app.

This is an expanded version of PR #844.