### PR TITLE
Fail fast if the Asset Manager isn't available

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -46,12 +46,12 @@ class Attachment
         response = AttachmentApi.client.update_asset(file_id, file: @uploaded_file)
       end
       self.file_url = response["file_url"]
+    rescue GdsApi::HTTPNotFound => e
+      raise "Error uploading file. Is the Asset Manager service available?\n#{e.message}"
     rescue StandardError
       errors.add(:file_id, "could not be uploaded")
     end
   end
-
-  private :upload_file
 
   class ::ApiClientNotPresent < StandardError; end
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -13,6 +13,16 @@ describe Attachment do
     expect(attachment.snippet).to eq("[InlineAttachment:document.pdf]")
   end
 
+  context "#upload_file" do
+    it "raises an informative exception if the asset manager service can't be found" do
+      client = double('client')
+      allow(client).to receive(:create_asset).and_raise(GdsApi::HTTPNotFound.new(404))
+      allow(AttachmentApi).to receive(:client).and_return(client)
+      attachment = Attachment.new
+      expect { attachment.upload_file }.to raise_error(/Error uploading file. Is the Asset Manager service available\?/)
+    end
+  end
+
   context "#save" do
     let(:edition) do
       FactoryGirl.create(:section_edition)


### PR DESCRIPTION
I was seeing an exception in development when trying to save a Section
with an attachment. I eventually realised that it was because I didn't
have the Asset Manager running and therefore the attachment couldn't be
uploaded. There was no indication of this problem in the user interface.
It looks as though the call to `errors.add` was intended to do something
sensible in the case of an error but it doesn't appear to have any
effect. The result is that errors are essentially swallowed and the user
is led to believe that the attachment has been uploaded successfuly.

In order to add a test for the new behaviour I've made the
`#upload_file` method public.