### PR TITLE
Inline service registries into SectionsController

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,8 +1,14 @@
+require "show_section_service"
+
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
 
   def show
-    manual, section = services.show(self).call
+    service = ShowSectionService.new(
+      services.manual_repository,
+      self,
+    )
+    manual, section = service.call
 
     render(:show, locals: {
       manual: manual,
@@ -33,7 +39,11 @@ class SectionsController < ApplicationController
   end
 
   def edit
-    manual, section = services.show(self).call
+    service = ShowSectionService.new(
+      services.manual_repository,
+      self,
+    )
+    manual, section = service.call
 
     render(:edit, locals: {
       manual: ManualViewAdapter.new(manual),
@@ -95,7 +105,11 @@ class SectionsController < ApplicationController
   end
 
   def withdraw
-    manual, section = services.show(self).call
+    service = ShowSectionService.new(
+      services.manual_repository,
+      self,
+    )
+    manual, section = service.call
 
     render(:withdraw, locals: {
       manual: ManualViewAdapter.new(manual),

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,5 +1,6 @@
 require "show_section_service"
 require "new_section_service"
+require "create_section_service"
 
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
@@ -31,7 +32,15 @@ class SectionsController < ApplicationController
   end
 
   def create
-    manual, section = services.create(self).call
+    service = CreateSectionService.new(
+      manual_repository: services.manual_repository,
+      listeners: [
+        services.publishing_api_draft_manual_exporter,
+        services.publishing_api_draft_section_exporter
+      ],
+      context: self,
+    )
+    manual, section = service.call
 
     if section.valid?
       redirect_to(manual_path(manual))

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -165,7 +165,7 @@ class SectionsController < ApplicationController
       self,
       listeners: [
         PublishingApiDraftManualExporter.new(services),
-        services.publishing_api_draft_section_discarder
+        PublishingApiDraftSectionDiscarder.new(services)
       ]
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -4,6 +4,7 @@ require "create_section_service"
 require "update_section_service"
 require "preview_section_service"
 require "list_sections_service"
+require "reorder_sections_service"
 
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
@@ -129,7 +130,12 @@ class SectionsController < ApplicationController
   end
 
   def update_order
-    manual, _sections = services.update_order(self).call
+    service = ReorderSectionsService.new(
+      services.manual_repository,
+      self,
+      listeners: [services.publishing_api_draft_manual_exporter]
+    )
+    manual, _sections = service.call
 
     redirect_to(
       manual_path(manual),

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -40,7 +40,7 @@ class SectionsController < ApplicationController
     service = CreateSectionService.new(
       manual_repository: services.manual_repository,
       listeners: [
-        services.publishing_api_draft_manual_exporter,
+        PublishingApiDraftManualExporter.new(services),
         services.publishing_api_draft_section_exporter
       ],
       context: self,
@@ -75,7 +75,7 @@ class SectionsController < ApplicationController
       manual_repository: services.manual_repository,
       context: self,
       listeners: [
-        services.publishing_api_draft_manual_exporter,
+        PublishingApiDraftManualExporter.new(services),
         services.publishing_api_draft_section_exporter
       ],
     )
@@ -134,7 +134,7 @@ class SectionsController < ApplicationController
     service = ReorderSectionsService.new(
       services.manual_repository,
       self,
-      listeners: [services.publishing_api_draft_manual_exporter]
+      listeners: [PublishingApiDraftManualExporter.new(services)]
     )
     manual, _sections = service.call
 
@@ -164,7 +164,7 @@ class SectionsController < ApplicationController
       services.manual_repository,
       self,
       listeners: [
-        services.publishing_api_draft_manual_exporter,
+        PublishingApiDraftManualExporter.new(services),
         services.publishing_api_draft_section_discarder
       ]
     )

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -12,7 +12,7 @@ class SectionsController < ApplicationController
 
   def show
     service = ShowSectionService.new(
-      services.manual_repository,
+      manual_repository,
       self,
     )
     manual, section = service.call
@@ -25,7 +25,7 @@ class SectionsController < ApplicationController
 
   def new
     service = NewSectionService.new(
-      services.manual_repository,
+      manual_repository,
       self,
     )
     manual, section = service.call
@@ -38,7 +38,7 @@ class SectionsController < ApplicationController
 
   def create
     service = CreateSectionService.new(
-      manual_repository: services.manual_repository,
+      manual_repository: manual_repository,
       listeners: [
         PublishingApiDraftManualExporter.new,
         PublishingApiDraftSectionExporter.new
@@ -59,7 +59,7 @@ class SectionsController < ApplicationController
 
   def edit
     service = ShowSectionService.new(
-      services.manual_repository,
+      manual_repository,
       self,
     )
     manual, section = service.call
@@ -72,7 +72,7 @@ class SectionsController < ApplicationController
 
   def update
     service = UpdateSectionService.new(
-      manual_repository: services.manual_repository,
+      manual_repository: manual_repository,
       context: self,
       listeners: [
         PublishingApiDraftManualExporter.new,
@@ -93,7 +93,7 @@ class SectionsController < ApplicationController
 
   def preview
     service = PreviewSectionService.new(
-      services.manual_repository,
+      manual_repository,
       SectionBuilder.create,
       SectionRenderer.new,
       self,
@@ -119,7 +119,7 @@ class SectionsController < ApplicationController
 
   def reorder
     service = ListSectionsService.new(
-      services.manual_repository,
+      manual_repository,
       self,
     )
     manual, sections = service.call
@@ -132,7 +132,7 @@ class SectionsController < ApplicationController
 
   def update_order
     service = ReorderSectionsService.new(
-      services.manual_repository,
+      manual_repository,
       self,
       listeners: [PublishingApiDraftManualExporter.new]
     )
@@ -148,7 +148,7 @@ class SectionsController < ApplicationController
 
   def withdraw
     service = ShowSectionService.new(
-      services.manual_repository,
+      manual_repository,
       self,
     )
     manual, section = service.call
@@ -161,7 +161,7 @@ class SectionsController < ApplicationController
 
   def destroy
     service = RemoveSectionService.new(
-      services.manual_repository,
+      manual_repository,
       self,
       listeners: [
         PublishingApiDraftManualExporter.new,
@@ -203,6 +203,10 @@ private
     OrganisationalSectionServiceRegistry.new(
       organisation_slug: current_organisation_slug,
     )
+  end
+
+  def manual_repository
+    services.manual_repository
   end
 
   def authorize_user_for_withdrawing

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -206,7 +206,13 @@ private
   end
 
   def manual_repository
-    services.manual_repository
+    if current_user_is_gds_editor?
+      RepositoryRegistry.create.manual_repository
+    else
+      manual_repository_factory = RepositoryRegistry.create.
+        organisation_scoped_manual_repository_factory
+      manual_repository_factory.call(current_organisation_slug)
+    end
   end
 
   def authorize_user_for_withdrawing

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -95,7 +95,7 @@ class SectionsController < ApplicationController
     service = PreviewSectionService.new(
       services.manual_repository,
       services.section_builder,
-      services.document_renderer,
+      SectionRenderer.new,
       self,
     )
     section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -187,24 +187,6 @@ class SectionsController < ApplicationController
 
 private
 
-  def services
-    if current_user_is_gds_editor?
-      gds_editor_services
-    else
-      organisational_services
-    end
-  end
-
-  def gds_editor_services
-    SectionServiceRegistry.new
-  end
-
-  def organisational_services
-    OrganisationalSectionServiceRegistry.new(
-      organisation_slug: current_organisation_slug,
-    )
-  end
-
   def manual_repository
     if current_user_is_gds_editor?
       RepositoryRegistry.create.manual_repository

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,4 +1,5 @@
 require "show_section_service"
+require "new_section_service"
 
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
@@ -17,7 +18,11 @@ class SectionsController < ApplicationController
   end
 
   def new
-    manual, section = services.new(self).call
+    service = NewSectionService.new(
+      services.manual_repository,
+      self,
+    )
+    manual, section = service.call
 
     render(:new, locals: {
       manual: ManualViewAdapter.new(manual),

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -41,7 +41,7 @@ class SectionsController < ApplicationController
       manual_repository: services.manual_repository,
       listeners: [
         PublishingApiDraftManualExporter.new(services),
-        services.publishing_api_draft_section_exporter
+        PublishingApiDraftSectionExporter.new(services)
       ],
       context: self,
     )
@@ -76,7 +76,7 @@ class SectionsController < ApplicationController
       context: self,
       listeners: [
         PublishingApiDraftManualExporter.new(services),
-        services.publishing_api_draft_section_exporter
+        PublishingApiDraftSectionExporter.new(services)
       ],
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,6 +1,7 @@
 require "show_section_service"
 require "new_section_service"
 require "create_section_service"
+require "update_section_service"
 
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
@@ -66,7 +67,15 @@ class SectionsController < ApplicationController
   end
 
   def update
-    manual, section = services.update(self).call
+    service = UpdateSectionService.new(
+      manual_repository: services.manual_repository,
+      context: self,
+      listeners: [
+        services.publishing_api_draft_manual_exporter,
+        services.publishing_api_draft_section_exporter
+      ],
+    )
+    manual, section = service.call
 
     if section.valid?
       redirect_to(manual_path(manual))

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -2,6 +2,7 @@ require "show_section_service"
 require "new_section_service"
 require "create_section_service"
 require "update_section_service"
+require "preview_section_service"
 
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
@@ -88,7 +89,13 @@ class SectionsController < ApplicationController
   end
 
   def preview
-    section = services.preview(self).call
+    service = PreviewSectionService.new(
+      services.manual_repository,
+      services.section_builder,
+      services.document_renderer,
+      self,
+    )
+    section = service.call
 
     section.valid? # Force validation check or errors will be empty
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -94,7 +94,7 @@ class SectionsController < ApplicationController
   def preview
     service = PreviewSectionService.new(
       services.manual_repository,
-      services.section_builder,
+      SectionBuilder.create,
       SectionRenderer.new,
       self,
     )

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -40,8 +40,8 @@ class SectionsController < ApplicationController
     service = CreateSectionService.new(
       manual_repository: services.manual_repository,
       listeners: [
-        PublishingApiDraftManualExporter.new(services),
-        PublishingApiDraftSectionExporter.new(services)
+        PublishingApiDraftManualExporter.new,
+        PublishingApiDraftSectionExporter.new
       ],
       context: self,
     )
@@ -75,8 +75,8 @@ class SectionsController < ApplicationController
       manual_repository: services.manual_repository,
       context: self,
       listeners: [
-        PublishingApiDraftManualExporter.new(services),
-        PublishingApiDraftSectionExporter.new(services)
+        PublishingApiDraftManualExporter.new,
+        PublishingApiDraftSectionExporter.new
       ],
     )
     manual, section = service.call
@@ -134,7 +134,7 @@ class SectionsController < ApplicationController
     service = ReorderSectionsService.new(
       services.manual_repository,
       self,
-      listeners: [PublishingApiDraftManualExporter.new(services)]
+      listeners: [PublishingApiDraftManualExporter.new]
     )
     manual, _sections = service.call
 
@@ -164,8 +164,8 @@ class SectionsController < ApplicationController
       services.manual_repository,
       self,
       listeners: [
-        PublishingApiDraftManualExporter.new(services),
-        PublishingApiDraftSectionDiscarder.new(services)
+        PublishingApiDraftManualExporter.new,
+        PublishingApiDraftSectionDiscarder.new
       ]
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -3,6 +3,7 @@ require "new_section_service"
 require "create_section_service"
 require "update_section_service"
 require "preview_section_service"
+require "list_sections_service"
 
 class SectionsController < ApplicationController
   before_filter :authorize_user_for_withdrawing, only: [:withdraw, :destroy]
@@ -115,7 +116,11 @@ class SectionsController < ApplicationController
   end
 
   def reorder
-    manual, sections = services.list(self).call
+    service = ListSectionsService.new(
+      services.manual_repository,
+      self,
+    )
+    manual, sections = service.call
 
     render(:reorder, locals: {
       manual: ManualViewAdapter.new(manual),

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -6,13 +6,13 @@ class PublishingApiDraftManualExporter
   def call(_, manual)
     ManualPublishingAPILinksExporter.new(
       Services.publishing_api_v2.method(:patch_links),
-      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       manual
     ).call
 
     ManualPublishingAPIExporter.new(
       Services.publishing_api_v2.method(:put_content),
-      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       ManualRenderer.new,
       PublicationLog,
       manual

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,8 +1,4 @@
 class PublishingApiDraftManualExporter
-  def initialize(services)
-    @services = services
-  end
-
   def call(_, manual)
     ManualPublishingAPILinksExporter.new(
       Services.publishing_api_v2.method(:patch_links),

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -5,13 +5,13 @@ class PublishingApiDraftManualExporter
 
   def call(_, manual)
     ManualPublishingAPILinksExporter.new(
-      @services.publishing_api_v2.method(:patch_links),
+      Services.publishing_api_v2.method(:patch_links),
       @services.organisation(manual.attributes.fetch(:organisation_slug)),
       manual
     ).call
 
     ManualPublishingAPIExporter.new(
-      @services.publishing_api_v2.method(:put_content),
+      Services.publishing_api_v2.method(:put_content),
       @services.organisation(manual.attributes.fetch(:organisation_slug)),
       ManualRenderer.new,
       PublicationLog,

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,0 +1,21 @@
+class PublishingApiDraftManualExporter
+  def initialize(services)
+    @services = services
+  end
+
+  def call(_, manual)
+    ManualPublishingAPILinksExporter.new(
+      @services.publishing_api_v2.method(:patch_links),
+      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      manual
+    ).call
+
+    ManualPublishingAPIExporter.new(
+      @services.publishing_api_v2.method(:put_content),
+      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      ManualRenderer.new,
+      PublicationLog,
+      manual
+    ).call
+  end
+end

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,0 +1,12 @@
+class PublishingApiDraftSectionDiscarder
+  def initialize(services)
+    @services = services
+  end
+
+  def call(section, _manual)
+    begin
+      @services.publishing_api_v2.discard_draft(section.id)
+    rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
+    end
+  end
+end

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,8 +1,4 @@
 class PublishingApiDraftSectionDiscarder
-  def initialize(services)
-    @services = services
-  end
-
   def call(section, _manual)
     Services.publishing_api_v2.discard_draft(section.id)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -4,7 +4,7 @@ class PublishingApiDraftSectionDiscarder
   end
 
   def call(section, _manual)
-    @services.publishing_api_v2.discard_draft(section.id)
+    Services.publishing_api_v2.discard_draft(section.id)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end
 end

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -4,9 +4,7 @@ class PublishingApiDraftSectionDiscarder
   end
 
   def call(section, _manual)
-    begin
-      @services.publishing_api_v2.discard_draft(section.id)
-    rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
-    end
+    @services.publishing_api_v2.discard_draft(section.id)
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end
 end

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -1,0 +1,20 @@
+class PublishingApiDraftSectionExporter
+  def initialize(services)
+    @services = services
+  end
+
+  def call(section, manual)
+    SectionPublishingAPILinksExporter.new(
+      @services.publishing_api_v2.method(:patch_links),
+      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      manual,
+      section
+    ).call
+
+    SectionPublishingAPIExporter.new(
+      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      manual,
+      section
+    ).call
+  end
+end

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -5,7 +5,7 @@ class PublishingApiDraftSectionExporter
 
   def call(section, manual)
     SectionPublishingAPILinksExporter.new(
-      @services.publishing_api_v2.method(:patch_links),
+      Services.publishing_api_v2.method(:patch_links),
       @services.organisation(manual.attributes.fetch(:organisation_slug)),
       manual,
       section

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -1,8 +1,4 @@
 class PublishingApiDraftSectionExporter
-  def initialize(services)
-    @services = services
-  end
-
   def call(section, manual)
     SectionPublishingAPILinksExporter.new(
       Services.publishing_api_v2.method(:patch_links),

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -6,13 +6,13 @@ class PublishingApiDraftSectionExporter
   def call(section, manual)
     SectionPublishingAPILinksExporter.new(
       Services.publishing_api_v2.method(:patch_links),
-      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       manual,
       section
     ).call
 
     SectionPublishingAPIExporter.new(
-      @services.organisation(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       manual,
       section
     ).call

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,10 +1,6 @@
 require "services"
 
 class AbstractSectionServiceRegistry
-  def section_builder
-    SectionBuilder.create
-  end
-
   def manual_repository
     raise NotImplementedError
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,7 +1,6 @@
 require "preview_section_service"
 require "create_section_service"
 require "update_section_service"
-require "new_section_service"
 require "list_sections_service"
 require "reorder_sections_service"
 require "remove_section_service"
@@ -36,13 +35,6 @@ class AbstractSectionServiceRegistry
         publishing_api_draft_manual_exporter,
         publishing_api_draft_section_exporter
       ],
-    )
-  end
-
-  def new(context)
-    NewSectionService.new(
-      manual_repository,
-      context,
     )
   end
 

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,10 +1,6 @@
 require "services"
 
 class AbstractSectionServiceRegistry
-  def document_renderer
-    SectionRenderer.new
-  end
-
   def section_builder
     SectionBuilder.create
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -80,8 +80,6 @@ class AbstractSectionServiceRegistry
     )
   end
 
-private
-
   def document_renderer
     SectionRenderer.new
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,5 +1,3 @@
-require "services"
-
 class AbstractSectionServiceRegistry
   def manual_repository
     raise NotImplementedError
@@ -7,9 +5,5 @@ class AbstractSectionServiceRegistry
 
   def organisation(slug)
     OrganisationFetcher.instance.call(slug)
-  end
-
-  def publishing_api_v2
-    Services.publishing_api_v2
   end
 end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -18,12 +18,7 @@ class AbstractSectionServiceRegistry
   end
 
   def publishing_api_draft_section_discarder
-    ->(section, _manual) {
-      begin
-        publishing_api_v2.discard_draft(section.id)
-      rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
-      end
-    }
+    PublishingApiDraftSectionDiscarder.new(self)
   end
 
   def publishing_api_v2

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,16 +1,8 @@
-require "list_sections_service"
 require "reorder_sections_service"
 require "remove_section_service"
 require "services"
 
 class AbstractSectionServiceRegistry
-  def list(context)
-    ListSectionsService.new(
-      manual_repository,
-      context,
-    )
-  end
-
   def update_order(context)
     ReorderSectionsService.new(
       manual_repository,

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,18 +1,6 @@
-require "remove_section_service"
 require "services"
 
 class AbstractSectionServiceRegistry
-  def remove(context)
-    RemoveSectionService.new(
-      manual_repository,
-      context,
-      listeners: [
-        publishing_api_draft_manual_exporter,
-        publishing_api_draft_section_discarder
-      ]
-    )
-  end
-
   def document_renderer
     SectionRenderer.new
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -9,10 +9,6 @@ class AbstractSectionServiceRegistry
     OrganisationFetcher.instance.call(slug)
   end
 
-  def publishing_api_draft_section_exporter
-    PublishingApiDraftSectionExporter.new(self)
-  end
-
   def publishing_api_draft_section_discarder
     PublishingApiDraftSectionDiscarder.new(self)
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,19 +1,9 @@
-require "preview_section_service"
 require "list_sections_service"
 require "reorder_sections_service"
 require "remove_section_service"
 require "services"
 
 class AbstractSectionServiceRegistry
-  def preview(context)
-    PreviewSectionService.new(
-      manual_repository,
-      section_builder,
-      document_renderer,
-      context,
-    )
-  end
-
   def list(context)
     ListSectionsService.new(
       manual_repository,

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -2,8 +2,4 @@ class AbstractSectionServiceRegistry
   def manual_repository
     raise NotImplementedError
   end
-
-  def organisation(slug)
-    OrganisationFetcher.instance.call(slug)
-  end
 end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,16 +1,7 @@
-require "reorder_sections_service"
 require "remove_section_service"
 require "services"
 
 class AbstractSectionServiceRegistry
-  def update_order(context)
-    ReorderSectionsService.new(
-      manual_repository,
-      context,
-      listeners: [publishing_api_draft_manual_exporter]
-    )
-  end
-
   def remove(context)
     RemoveSectionService.new(
       manual_repository,

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -9,10 +9,6 @@ class AbstractSectionServiceRegistry
     OrganisationFetcher.instance.call(slug)
   end
 
-  def publishing_api_draft_manual_exporter
-    PublishingApiDraftManualExporter.new(self)
-  end
-
   def publishing_api_draft_section_exporter
     PublishingApiDraftSectionExporter.new(self)
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,5 +1,4 @@
 require "preview_section_service"
-require "update_section_service"
 require "list_sections_service"
 require "reorder_sections_service"
 require "remove_section_service"
@@ -12,17 +11,6 @@ class AbstractSectionServiceRegistry
       section_builder,
       document_renderer,
       context,
-    )
-  end
-
-  def update(context)
-    UpdateSectionService.new(
-      manual_repository: manual_repository,
-      context: context,
-      listeners: [
-        publishing_api_draft_manual_exporter,
-        publishing_api_draft_section_exporter
-      ],
     )
   end
 

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,7 +1,6 @@
 require "preview_section_service"
 require "create_section_service"
 require "update_section_service"
-require "show_section_service"
 require "new_section_service"
 require "list_sections_service"
 require "reorder_sections_service"
@@ -37,13 +36,6 @@ class AbstractSectionServiceRegistry
         publishing_api_draft_manual_exporter,
         publishing_api_draft_section_exporter
       ],
-    )
-  end
-
-  def show(context)
-    ShowSectionService.new(
-      manual_repository,
-      context,
     )
   end
 

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -14,20 +14,7 @@ class AbstractSectionServiceRegistry
   end
 
   def publishing_api_draft_section_exporter
-    ->(section, manual) {
-      SectionPublishingAPILinksExporter.new(
-        publishing_api_v2.method(:patch_links),
-        organisation(manual.attributes.fetch(:organisation_slug)),
-        manual,
-        section
-      ).call
-
-      SectionPublishingAPIExporter.new(
-        organisation(manual.attributes.fetch(:organisation_slug)),
-        manual,
-        section
-      ).call
-    }
+    PublishingApiDraftSectionExporter.new(self)
   end
 
   def publishing_api_draft_section_discarder

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,5 +1,4 @@
 require "preview_section_service"
-require "create_section_service"
 require "update_section_service"
 require "list_sections_service"
 require "reorder_sections_service"
@@ -13,17 +12,6 @@ class AbstractSectionServiceRegistry
       section_builder,
       document_renderer,
       context,
-    )
-  end
-
-  def create(context)
-    CreateSectionService.new(
-      manual_repository: manual_repository,
-      listeners: [
-        publishing_api_draft_manual_exporter,
-        publishing_api_draft_section_exporter
-      ],
-      context: context,
     )
   end
 

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,5 +1,2 @@
 class AbstractSectionServiceRegistry
-  def manual_repository
-    raise NotImplementedError
-  end
 end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -10,21 +10,7 @@ class AbstractSectionServiceRegistry
   end
 
   def publishing_api_draft_manual_exporter
-    ->(_, manual) {
-      ManualPublishingAPILinksExporter.new(
-        publishing_api_v2.method(:patch_links),
-        organisation(manual.attributes.fetch(:organisation_slug)),
-        manual
-      ).call
-
-      ManualPublishingAPIExporter.new(
-        publishing_api_v2.method(:put_content),
-        organisation(manual.attributes.fetch(:organisation_slug)),
-        ManualRenderer.new,
-        PublicationLog,
-        manual
-      ).call
-    }
+    PublishingApiDraftManualExporter.new(self)
   end
 
   def publishing_api_draft_section_exporter

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -1,2 +1,0 @@
-class AbstractSectionServiceRegistry
-end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -9,10 +9,6 @@ class AbstractSectionServiceRegistry
     OrganisationFetcher.instance.call(slug)
   end
 
-  def publishing_api_draft_section_discarder
-    PublishingApiDraftSectionDiscarder.new(self)
-  end
-
   def publishing_api_v2
     Services.publishing_api_v2
   end

--- a/app/services/abstract_section_service_registry.rb
+++ b/app/services/abstract_section_service_registry.rb
@@ -12,8 +12,4 @@ class AbstractSectionServiceRegistry
   def publishing_api_v2
     Services.publishing_api_v2
   end
-
-  def organisations_api
-    Services.organisations
-  end
 end

--- a/app/services/organisational_section_service_registry.rb
+++ b/app/services/organisational_section_service_registry.rb
@@ -1,2 +1,0 @@
-class OrganisationalSectionServiceRegistry < AbstractSectionServiceRegistry
-end

--- a/app/services/organisational_section_service_registry.rb
+++ b/app/services/organisational_section_service_registry.rb
@@ -1,5 +1,2 @@
 class OrganisationalSectionServiceRegistry < AbstractSectionServiceRegistry
-  def initialize(organisation_slug:)
-    @organisation_slug = organisation_slug
-  end
 end

--- a/app/services/organisational_section_service_registry.rb
+++ b/app/services/organisational_section_service_registry.rb
@@ -4,10 +4,4 @@ class OrganisationalSectionServiceRegistry < AbstractSectionServiceRegistry
   end
 
   attr_reader :organisation_slug
-
-  def manual_repository
-    manual_repository_factory = RepositoryRegistry.create.
-      organisation_scoped_manual_repository_factory
-    manual_repository_factory.call(organisation_slug)
-  end
 end

--- a/app/services/organisational_section_service_registry.rb
+++ b/app/services/organisational_section_service_registry.rb
@@ -5,12 +5,9 @@ class OrganisationalSectionServiceRegistry < AbstractSectionServiceRegistry
 
   attr_reader :organisation_slug
 
-  def manual_repository_factory
-    RepositoryRegistry.create.
-      organisation_scoped_manual_repository_factory
-  end
-
   def manual_repository
+    manual_repository_factory = RepositoryRegistry.create.
+      organisation_scoped_manual_repository_factory
     manual_repository_factory.call(organisation_slug)
   end
 end

--- a/app/services/organisational_section_service_registry.rb
+++ b/app/services/organisational_section_service_registry.rb
@@ -3,8 +3,6 @@ class OrganisationalSectionServiceRegistry < AbstractSectionServiceRegistry
     @organisation_slug = organisation_slug
   end
 
-private
-
   attr_reader :organisation_slug
 
   def manual_repository_factory

--- a/app/services/organisational_section_service_registry.rb
+++ b/app/services/organisational_section_service_registry.rb
@@ -2,6 +2,4 @@ class OrganisationalSectionServiceRegistry < AbstractSectionServiceRegistry
   def initialize(organisation_slug:)
     @organisation_slug = organisation_slug
   end
-
-  attr_reader :organisation_slug
 end

--- a/app/services/section_service_registry.rb
+++ b/app/services/section_service_registry.rb
@@ -1,6 +1,4 @@
 class SectionServiceRegistry < AbstractSectionServiceRegistry
-private
-
   def manual_repository
     RepositoryRegistry.create.manual_repository
   end

--- a/app/services/section_service_registry.rb
+++ b/app/services/section_service_registry.rb
@@ -1,5 +1,2 @@
 class SectionServiceRegistry < AbstractSectionServiceRegistry
-  def manual_repository
-    RepositoryRegistry.create.manual_repository
-  end
 end

--- a/app/services/section_service_registry.rb
+++ b/app/services/section_service_registry.rb
@@ -1,2 +1,0 @@
-class SectionServiceRegistry < AbstractSectionServiceRegistry
-end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -53,8 +53,8 @@ module ManualHelpers
     service = CreateSectionService.new(
       manual_repository: section_services.manual_repository,
       listeners: [
-        PublishingApiDraftManualExporter.new(section_services),
-        PublishingApiDraftSectionExporter.new(section_services)
+        PublishingApiDraftManualExporter.new,
+        PublishingApiDraftSectionExporter.new
       ],
       context: create_service_context,
     )
@@ -114,8 +114,8 @@ module ManualHelpers
       manual_repository: section_services.manual_repository,
       context: service_context,
       listeners: [
-        PublishingApiDraftManualExporter.new(section_services),
-        PublishingApiDraftSectionExporter.new(section_services)
+        PublishingApiDraftManualExporter.new,
+        PublishingApiDraftSectionExporter.new
       ],
     )
     _, document = service.call

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -53,7 +53,7 @@ module ManualHelpers
     service = CreateSectionService.new(
       manual_repository: section_services.manual_repository,
       listeners: [
-        section_services.publishing_api_draft_manual_exporter,
+        PublishingApiDraftManualExporter.new(section_services),
         section_services.publishing_api_draft_section_exporter
       ],
       context: create_service_context,
@@ -114,7 +114,7 @@ module ManualHelpers
       manual_repository: section_services.manual_repository,
       context: service_context,
       listeners: [
-        section_services.publishing_api_draft_manual_exporter,
+        PublishingApiDraftManualExporter.new(section_services),
         section_services.publishing_api_draft_section_exporter
       ],
     )

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -39,10 +39,9 @@ module ManualHelpers
   end
 
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
-    section_services = OrganisationalSectionServiceRegistry.new(
-      organisation_slug: organisation_slug,
-    )
-    organisational_manual_repository = section_services.manual_repository
+    manual_repository_factory = RepositoryRegistry.create.
+      organisation_scoped_manual_repository_factory
+    organisational_manual_repository = manual_repository_factory.call(organisation_slug)
 
     create_service_context = OpenStruct.new(
       params: {
@@ -99,10 +98,9 @@ module ManualHelpers
   end
 
   def edit_section_without_ui(manual, document, fields, organisation_slug: "ministry-of-tea")
-    section_services = OrganisationalSectionServiceRegistry.new(
-      organisation_slug: organisation_slug,
-    )
-    organisational_manual_repository = section_services.manual_repository
+    manual_repository_factory = RepositoryRegistry.create.
+      organisation_scoped_manual_repository_factory
+    organisational_manual_repository = manual_repository_factory.call(organisation_slug)
 
     service_context = OpenStruct.new(
       params: {

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -54,7 +54,7 @@ module ManualHelpers
       manual_repository: section_services.manual_repository,
       listeners: [
         PublishingApiDraftManualExporter.new(section_services),
-        section_services.publishing_api_draft_section_exporter
+        PublishingApiDraftSectionExporter.new(section_services)
       ],
       context: create_service_context,
     )
@@ -115,7 +115,7 @@ module ManualHelpers
       context: service_context,
       listeners: [
         PublishingApiDraftManualExporter.new(section_services),
-        section_services.publishing_api_draft_section_exporter
+        PublishingApiDraftSectionExporter.new(section_services)
       ],
     )
     _, document = service.call

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -1,4 +1,5 @@
 require "create_section_service"
+require "update_section_service"
 
 module ManualHelpers
   def manual_repository
@@ -109,7 +110,15 @@ module ManualHelpers
       }
     )
 
-    _, document = section_services.update(service_context).call
+    service = UpdateSectionService.new(
+      manual_repository: section_services.manual_repository,
+      context: service_context,
+      listeners: [
+        section_services.publishing_api_draft_manual_exporter,
+        section_services.publishing_api_draft_section_exporter
+      ],
+    )
+    _, document = service.call
 
     document
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -1,3 +1,5 @@
+require "create_section_service"
+
 module ManualHelpers
   def manual_repository
     RepositoryRegistry.create.manual_repository
@@ -47,7 +49,15 @@ module ManualHelpers
       }
     )
 
-    _, document = section_services.create(create_service_context).call
+    service = CreateSectionService.new(
+      manual_repository: section_services.manual_repository,
+      listeners: [
+        section_services.publishing_api_draft_manual_exporter,
+        section_services.publishing_api_draft_section_exporter
+      ],
+      context: create_service_context,
+    )
+    _, document = service.call
 
     document
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -42,6 +42,7 @@ module ManualHelpers
     section_services = OrganisationalSectionServiceRegistry.new(
       organisation_slug: organisation_slug,
     )
+    organisational_manual_repository = section_services.manual_repository
 
     create_service_context = OpenStruct.new(
       params: {
@@ -51,7 +52,7 @@ module ManualHelpers
     )
 
     service = CreateSectionService.new(
-      manual_repository: section_services.manual_repository,
+      manual_repository: organisational_manual_repository,
       listeners: [
         PublishingApiDraftManualExporter.new,
         PublishingApiDraftSectionExporter.new
@@ -101,6 +102,7 @@ module ManualHelpers
     section_services = OrganisationalSectionServiceRegistry.new(
       organisation_slug: organisation_slug,
     )
+    organisational_manual_repository = section_services.manual_repository
 
     service_context = OpenStruct.new(
       params: {
@@ -111,7 +113,7 @@ module ManualHelpers
     )
 
     service = UpdateSectionService.new(
-      manual_repository: section_services.manual_repository,
+      manual_repository: organisational_manual_repository,
       context: service_context,
       listeners: [
         PublishingApiDraftManualExporter.new,

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -81,7 +81,7 @@ private
       manual_repository: services.manual_repository,
       context: context_for_section_edition_update,
       listeners: [
-        services.publishing_api_draft_manual_exporter,
+        PublishingApiDraftManualExporter.new(services),
         services.publishing_api_draft_section_exporter
       ],
     )

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -75,7 +75,8 @@ private
   end
 
   def new_edition_for_slug_change
-    _manual, document = SectionServiceRegistry.new.update(context_for_section_edition_update).call
+    services = SectionServiceRegistry.new
+    _manual, document = services.update(context_for_section_edition_update).call
     document.latest_edition
   end
 

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -77,8 +77,9 @@ private
 
   def new_edition_for_slug_change
     services = SectionServiceRegistry.new
+    manual_repository = services.manual_repository
     service = UpdateSectionService.new(
-      manual_repository: services.manual_repository,
+      manual_repository: manual_repository,
       context: context_for_section_edition_update,
       listeners: [
         PublishingApiDraftManualExporter.new,

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -1,6 +1,7 @@
 require "gds_api/content_store"
 require "manual_service_registry"
 require "services"
+require "update_section_service"
 
 class SectionReslugger
   RUMMAGER_FORMAT = "manual_section".freeze
@@ -76,7 +77,15 @@ private
 
   def new_edition_for_slug_change
     services = SectionServiceRegistry.new
-    _manual, document = services.update(context_for_section_edition_update).call
+    service = UpdateSectionService.new(
+      manual_repository: services.manual_repository,
+      context: context_for_section_edition_update,
+      listeners: [
+        services.publishing_api_draft_manual_exporter,
+        services.publishing_api_draft_section_exporter
+      ],
+    )
+    _manual, document = service.call
     document.latest_edition
   end
 

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -82,7 +82,7 @@ private
       context: context_for_section_edition_update,
       listeners: [
         PublishingApiDraftManualExporter.new(services),
-        services.publishing_api_draft_section_exporter
+        PublishingApiDraftSectionExporter.new(services)
       ],
     )
     _manual, document = service.call

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -76,8 +76,7 @@ private
   end
 
   def new_edition_for_slug_change
-    services = SectionServiceRegistry.new
-    manual_repository = services.manual_repository
+    manual_repository = RepositoryRegistry.create.manual_repository
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
       context: context_for_section_edition_update,

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -81,8 +81,8 @@ private
       manual_repository: services.manual_repository,
       context: context_for_section_edition_update,
       listeners: [
-        PublishingApiDraftManualExporter.new(services),
-        PublishingApiDraftSectionExporter.new(services)
+        PublishingApiDraftManualExporter.new,
+        PublishingApiDraftSectionExporter.new
       ],
     )
     _manual, document = service.call

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -4,7 +4,7 @@ describe ManualsController, type: :controller do
   describe "#publish" do
     context "when the user lacks permission to publish" do
       let(:manual_id) { "manual-1" }
-      let(:services) { spy(AbstractSectionServiceRegistry) }
+      let(:services) { spy(AbstractManualServiceRegistry) }
       before do
         login_as_stub_user
         allow_any_instance_of(PermissionChecker).to receive(:can_publish?).and_return(false)

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -32,11 +32,11 @@ describe SectionsController, type: :controller do
   describe "#destroy" do
     let(:manual_id) { "manual-1" }
     let(:document_id) { "section-1" }
-    let(:services) { spy(AbstractSectionServiceRegistry) }
+    let(:service) { spy(RemoveSectionService) }
     before do
       login_as_stub_user
       allow_any_instance_of(PermissionChecker).to receive(:can_withdraw?).and_return(false)
-      allow(controller).to receive(:services).and_return services
+      allow(RemoveSectionService).to receive(:new).and_return(service)
       delete :destroy, manual_id: manual_id, id: document_id
     end
 
@@ -53,7 +53,7 @@ describe SectionsController, type: :controller do
     end
 
     it "does not withdraw the manual" do
-      expect(services).not_to have_received(:remove)
+      expect(service).not_to have_received(:call)
     end
 
     it "sets the authenticated user header" do


### PR DESCRIPTION
This is similar to #865, but for the `SectionsController` instead of the `SectionAttachmentsController`. The overall aim is to reduce the levels of indirection in the code to make it easier to follow. In some cases, this means temporarily introducing duplication, but we're confident that in the long run this will make it easier to identify better abstractions to remove that duplication.

The net effect is to inline most of the methods from `AbstractSsectionServiceRegistry` and its two sub-classes, `SectionServiceRegistry` & `OrganisationalSectionServiceRegistry` into `SectionsController`. I've also extracted three anonymous procs returned by methods in `AbstractSectionServiceRegistry` into new named classes to avoid excessive duplication:

* `PublishingApiDraftManualExporter`
* `PublishingApiDraftSectionExporter`
* `PublishingApiDraftSectionDiscarder`

I've tried hard to break the overall refactoring down into small steps to give as much confidence as possible that I haven't broken anything; the tests all pass after every commit.

Although I've applied the refactorings to the `TidyUpRemovedDocuments` migration, I haven't tested these changes. However, since we're hoping to remove the commits in #868, I think this is OK.

Although I've applied the refactorings to `SectionReslugger`, this class is not tested. However, since the script which uses this class is already broken (see #851), I think this is OK.

