### PR TITLE
Fix and add tests for a couple of scripts

### DIFF
--- a/bin/republish_manuals
+++ b/bin/republish_manuals
@@ -1,26 +1,11 @@
 #!/usr/bin/env ruby
 
 require File.expand_path("../../config/environment", __FILE__)
-require "manual_service_registry"
-require "marshallers/document_association_marshaller"
+require "manuals_republisher"
 require "logger"
 
 logger = Logger.new(STDOUT)
 logger.formatter = Logger::Formatter.new
 
-manual_records = ManualRecord.all
-count = manual_records.count
-
-logger.info "Republishing #{count} manuals..."
-
-manual_records.to_a.each.with_index do |manual_record, i|
-  begin
-    logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
-    ManualServiceRegistry.new.republish(manual_record.manual_id).call
-  rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError => e
-    logger.error("Did not publish manual with id=#{manual_record.manual_id} slug=#{manual_record.slug}. It has at least one removed document which was not found: #{e.message}")
-    next
-  end
-end
-
-logger.info "Republishing of #{count} manuals complete."
+republisher = ManualsRepublisher.new(logger)
+republisher.execute

--- a/bin/republish_manuals
+++ b/bin/republish_manuals
@@ -2,6 +2,7 @@
 
 require File.expand_path("../../config/environment", __FILE__)
 require "manual_service_registry"
+require "marshallers/document_association_marshaller"
 require "logger"
 
 logger = Logger.new(STDOUT)

--- a/bin/withdraw_manual
+++ b/bin/withdraw_manual
@@ -1,20 +1,13 @@
 #!/usr/bin/env ruby
 
 require File.expand_path("../../config/environment", __FILE__)
-require "manual_service_registry"
+require "manual_withdrawer"
+require "logger"
+
+logger = Logger.new(STDOUT)
+logger.formatter = Logger::Formatter.new
 
 manual_id = ARGV.any? ? ARGV.fetch(0) : nil
 
-begin
-  manual = ManualServiceRegistry.new.withdraw(manual_id).call
-
-  if manual.withdrawn?
-    STDOUT.puts "SUCCESS: Manual `#{manual.slug}` withdrawn"
-  else
-    STDERR.puts "FAILURE: Manual `#{manual.slug}` could not be withdrawn"
-    exit 1
-  end
-rescue WithdrawManualService::ManualNotFoundError
-  STDERR.puts "ERROR: Manual not found for manual_id `#{manual_id}`"
-  exit 1
-end
+withdrawer = ManualWithdrawer.new(logger)
+withdrawer.execute(manual_id)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -1,6 +1,7 @@
 require "create_section_service"
 require "update_section_service"
 require "manuals_republisher"
+require "manual_withdrawer"
 
 module ManualHelpers
   def manual_repository
@@ -468,8 +469,9 @@ module ManualHelpers
   def withdraw_manual_without_ui(manual)
     stub_manual_withdrawal_observers
 
-    manual_services = ManualServiceRegistry.new
-    manual_services.withdraw(manual.id).call
+    logger = Logger.new(nil)
+    withdrawer = ManualWithdrawer.new(logger)
+    withdrawer.execute(manual.id)
   end
 
   def check_manual_is_withdrawn(manual, documents)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -1,5 +1,6 @@
 require "create_section_service"
 require "update_section_service"
+require "manuals_republisher"
 
 module ManualHelpers
   def manual_repository
@@ -652,6 +653,12 @@ module ManualHelpers
       number_of_drafts: how_many_times
     )
     check_manual_was_published(manual)
+  end
+
+  def republish_manuals_without_ui
+    logger = Logger.new(nil)
+    republisher = ManualsRepublisher.new(logger)
+    republisher.execute
   end
 end
 RSpec.configuration.include ManualHelpers, type: :feature

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -461,14 +461,7 @@ module ManualHelpers
     expect(page).to have_content("Warning: There are duplicate section slugs in this manual")
   end
 
-  def stub_manual_withdrawal_observers
-    stub_rummager
-    stub_publishing_api
-  end
-
   def withdraw_manual_without_ui(manual)
-    stub_manual_withdrawal_observers
-
     logger = Logger.new(nil)
     withdrawer = ManualWithdrawer.new(logger)
     withdrawer.execute(manual.id)

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -1,0 +1,25 @@
+require "manual_service_registry"
+
+class ManualWithdrawer
+  attr_reader :logger
+
+  def initialize(logger)
+    @logger = logger
+  end
+
+  def execute(manual_id)
+    manual = ManualServiceRegistry.new.withdraw(manual_id).call
+
+    if manual.withdrawn?
+      logger.info "SUCCESS: Manual `#{manual.slug}` withdrawn"
+    else
+      message = "Manual `#{manual.slug}` could not be withdrawn"
+      logger.error "FAILURE: #{message}"
+      raise message
+    end
+  rescue WithdrawManualService::ManualNotFoundError
+    message = "Manual not found for manual_id `#{manual_id}`"
+    STDERR.puts "ERROR: #{message}"
+    raise message
+  end
+end

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -1,0 +1,29 @@
+require "manual_service_registry"
+require "marshallers/document_association_marshaller"
+
+class ManualsRepublisher
+  attr_reader :logger
+
+  def initialize(logger)
+    @logger = logger
+  end
+
+  def execute
+    manual_records = ManualRecord.all
+    count = manual_records.count
+
+    logger.info "Republishing #{count} manuals..."
+
+    manual_records.to_a.each.with_index do |manual_record, i|
+      begin
+        logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
+        ManualServiceRegistry.new.republish(manual_record.manual_id).call
+      rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError => e
+        logger.error("Did not publish manual with id=#{manual_record.manual_id} slug=#{manual_record.slug}. It has at least one removed document which was not found: #{e.message}")
+        next
+      end
+    end
+
+    logger.info "Republishing of #{count} manuals complete."
+  end
+end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe "Republishing manuals", type: :feature do
     WebMock::RequestRegistry.instance.reset!
   end
 
-  def republish_manuals
-    republish_manuals_without_ui
-  end
-
   def manual_repository
     RepositoryRegistry.create.manual_repository
   end
@@ -64,7 +60,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     before do
       create_manual_with_sections(published: true)
 
-      republish_manuals
+      republish_manuals_without_ui
     end
 
     it "sends the manual and the sections to the Publishing API" do
@@ -93,7 +89,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     before do
       create_manual_with_sections(published: false)
 
-      republish_manuals
+      republish_manuals_without_ui
     end
 
     it "sends the manual and the sections to the Publishing API" do
@@ -124,7 +120,7 @@ RSpec.describe "Republishing manuals", type: :feature do
 
       @edited_document = edit_manual_and_sections
 
-      republish_manuals
+      republish_manuals_without_ui
     end
 
     it "sends the published versions of the manual and its sections to the Publishing API" do

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -53,9 +53,7 @@ RSpec.describe "Republishing manuals", type: :feature do
   end
 
   def republish_manuals
-    manual_repository.all.each do |manual|
-      ManualServiceRegistry.new.republish(manual.id).call
-    end
+    republish_manuals_without_ui
   end
 
   def manual_repository


### PR DESCRIPTION
This fixes a couple of obvious problems in the `republish_manuals` script and adds basic test coverage, but only to the extent that no un-handled exceptions are raised, i.e. there may be more subtle problems with the script. I believe this script is used when changes are made to the content schemas, so we'll probably need to keep it around for a while.

It also improves the testing of the `withdraw_manual` script in that it tests more of the code used in the script itself by extracting it out into a class, as opposed to testing code duplicated from the script which is what was happening previously (with the potential for the two to get out of sync). While it is currently possible to withdraw an individual section of a manual via the user interface it isn't possible to withdraw a whole manual. Thus I think we're going to need to keep this script around for a while too.

While this isn't perfect, I feel as if it's enough of a step forward to do some other refactoring with confidence. What's more, we already have #852 & #854 to take the improvements to the scripts a bit further.