### PR TITLE
Remove params from SectionPublishingAPIExporter constructor

### DIFF
--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -4,10 +4,10 @@ class SectionPublishingAPIExporter
   PUBLISHING_API_SCHEMA_NAME = "manual_section".freeze
   PUBLISHING_API_DOCUMENT_TYPE = "manual_section".freeze
 
-  def initialize(organisation, document_renderer, manual, document, update_type: nil)
+  def initialize(organisation, manual, document, update_type: nil)
     @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
-    @document_renderer = document_renderer
+    @document_renderer = ManualDocumentRenderer.new
     @manual = manual
     @document = document
     @update_type = update_type

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -5,7 +5,6 @@ class SectionPublishingAPIExporter
   PUBLISHING_API_DOCUMENT_TYPE = "manual_section".freeze
 
   def initialize(organisation, manual, document, update_type: nil)
-    @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
     @document_renderer = ManualDocumentRenderer.new
     @manual = manual
@@ -15,12 +14,12 @@ class SectionPublishingAPIExporter
   end
 
   def call
-    export_recipient.call(content_id, exportable_attributes)
+    Services.publishing_api_v2.put_content(content_id, exportable_attributes)
   end
 
 private
 
-  attr_reader :export_recipient, :document_renderer, :organisation, :manual, :document
+  attr_reader :document_renderer, :organisation, :manual, :document
 
   def content_id
     document.id

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -6,7 +6,6 @@ class SectionPublishingAPIExporter
 
   def initialize(organisation, manual, document, update_type: nil)
     @organisation = organisation
-    @document_renderer = ManualDocumentRenderer.new
     @manual = manual
     @document = document
     @update_type = update_type
@@ -19,7 +18,7 @@ class SectionPublishingAPIExporter
 
 private
 
-  attr_reader :document_renderer, :organisation, :manual, :document
+  attr_reader :organisation, :manual, :document
 
   def content_id
     document.id
@@ -113,7 +112,7 @@ private
   end
 
   def rendered_document_attributes
-    @rendered_document_attributes ||= document_renderer.call(document).attributes
+    @rendered_document_attributes ||= ManualDocumentRenderer.new.call(document).attributes
   end
 
   def organisation_info

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -4,8 +4,8 @@ class SectionPublishingAPIExporter
   PUBLISHING_API_SCHEMA_NAME = "manual_section".freeze
   PUBLISHING_API_DOCUMENT_TYPE = "manual_section".freeze
 
-  def initialize(export_recipient, organisation, document_renderer, manual, document, update_type: nil)
-    @export_recipient = export_recipient
+  def initialize(organisation, document_renderer, manual, document, update_type: nil)
+    @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
     @document_renderer = document_renderer
     @manual = manual

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -185,7 +185,7 @@ private
         ).call
 
         SectionPublishingAPIExporter.new(
-          put_content, organisation, manual_document_renderer, manual, document, update_type: update_type
+          organisation, manual_document_renderer, manual, document, update_type: update_type
         ).call
       end
     }

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -167,7 +167,6 @@ private
       put_content = publishing_api_v2.method(:put_content)
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
       manual_renderer = ManualRenderer.new
-      manual_document_renderer = ManualDocumentRenderer.new
 
       ManualPublishingAPILinksExporter.new(
         patch_links, organisation, manual
@@ -185,7 +184,7 @@ private
         ).call
 
         SectionPublishingAPIExporter.new(
-          organisation, manual_document_renderer, manual, document, update_type: update_type
+          organisation, manual, document, update_type: update_type
         ).call
       end
     }

--- a/app/services/abstract_manual_document_service_registry.rb
+++ b/app/services/abstract_manual_document_service_registry.rb
@@ -127,7 +127,6 @@ private
 
       SectionPublishingAPIExporter.new(
         organisation(manual.attributes.fetch(:organisation_slug)),
-        ManualDocumentRenderer.new,
         manual,
         manual_document
       ).call

--- a/app/services/abstract_manual_document_service_registry.rb
+++ b/app/services/abstract_manual_document_service_registry.rb
@@ -126,7 +126,6 @@ private
       ).call
 
       SectionPublishingAPIExporter.new(
-        publishing_api_v2.method(:put_content),
         organisation(manual.attributes.fetch(:organisation_slug)),
         ManualDocumentRenderer.new,
         manual,

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -199,7 +199,7 @@ private
     manual.documents.each do |document|
       puts "Sending a draft of manual section #{document.id} (version: #{document.version_number})"
       SectionPublishingAPIExporter.new(
-        put_content, organisation, manual_document_renderer, manual, document
+        organisation, manual_document_renderer, manual, document
       ).call
     end
   end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -189,7 +189,6 @@ private
     put_content = publishing_api.method(:put_content)
     organisation = fetch_organisation(manual.organisation_slug)
     manual_renderer = ManualRenderer.new
-    manual_document_renderer = ManualDocumentRenderer.new
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(
@@ -199,7 +198,7 @@ private
     manual.documents.each do |document|
       puts "Sending a draft of manual section #{document.id} (version: #{document.version_number})"
       SectionPublishingAPIExporter.new(
-        organisation, manual_document_renderer, manual, document
+        organisation, manual, document
       ).call
     end
   end

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -13,7 +13,7 @@ describe SectionPublishingAPIExporter do
     )
   }
 
-  let(:export_recipient) { double(:export_recipient, call: nil) }
+  let(:publishing_api) { double(:publishing_api, put_content: nil) }
   let(:document_renderer) { ->(_) { double(:rendered_document, attributes: rendered_attributes) } }
 
   let(:organisation) {
@@ -80,7 +80,7 @@ describe SectionPublishingAPIExporter do
   }
 
   before {
-    allow(subject).to receive(:export_recipient).and_return(export_recipient)
+    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
     allow(subject).to receive(:document_renderer).and_return(document_renderer)
   }
 
@@ -126,7 +126,7 @@ describe SectionPublishingAPIExporter do
   it "exports the serialized document attributes" do
     subject.call
 
-    expect(export_recipient).to have_received(:call).with(
+    expect(publishing_api).to have_received(:put_content).with(
       document.id,
       all_of(
         hash_including(
@@ -159,7 +159,7 @@ describe SectionPublishingAPIExporter do
     it "adds it as the value for first_published_at in the serialized attributes" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         document.id,
         hash_including(
           first_published_at: previously_published_date.iso8601,
@@ -171,7 +171,7 @@ describe SectionPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(true)
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         document.id,
         hash_including(
           public_updated_at: previously_published_date.iso8601,
@@ -183,7 +183,7 @@ describe SectionPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(false)
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         document.id,
         hash_excluding(:public_updated_at)
       )
@@ -216,7 +216,7 @@ describe SectionPublishingAPIExporter do
         let(:explicit_update_type) { "republish" }
         it "exports with the update_type set to republish" do
           subject.call
-          expect(export_recipient).to have_received(:call).with(
+          expect(publishing_api).to have_received(:put_content).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
             hash_including(update_type: "republish")
           )
@@ -227,7 +227,7 @@ describe SectionPublishingAPIExporter do
         let(:explicit_update_type) { "minor" }
         it "exports with the update_type set to minor" do
           subject.call
-          expect(export_recipient).to have_received(:call).with(
+          expect(publishing_api).to have_received(:put_content).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
             hash_including(update_type: "minor")
           )
@@ -238,7 +238,7 @@ describe SectionPublishingAPIExporter do
         let(:explicit_update_type) { "major" }
         it "exports with the update_type set to major" do
           subject.call
-          expect(export_recipient).to have_received(:call).with(
+          expect(publishing_api).to have_received(:put_content).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
             hash_including(update_type: "major")
           )
@@ -258,7 +258,7 @@ describe SectionPublishingAPIExporter do
         allow(document).to receive(:has_ever_been_published?).and_return(false)
         subject.call
 
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "major")
         )
@@ -267,7 +267,7 @@ describe SectionPublishingAPIExporter do
       it "sets it to minor if the document has been published before" do
         subject.call
 
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "minor")
         )
@@ -288,7 +288,7 @@ describe SectionPublishingAPIExporter do
         update_type_attributes[:ever_been_published] = false
         subject.call
 
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "major")
         )
@@ -297,7 +297,7 @@ describe SectionPublishingAPIExporter do
       it "sets it to major if the document has been published before" do
         subject.call
 
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
           hash_including(update_type: "major")
         )
@@ -310,7 +310,7 @@ describe SectionPublishingAPIExporter do
   it "exports section metadata for the document" do
     subject.call
 
-    expect(export_recipient).to have_received(:call).with(
+    expect(publishing_api).to have_received(:put_content).with(
       document.id,
       hash_including(
         details: {

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -81,7 +81,7 @@ describe SectionPublishingAPIExporter do
 
   before {
     allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
-    allow(subject).to receive(:document_renderer).and_return(document_renderer)
+    allow(ManualDocumentRenderer).to receive(:new).and_return(document_renderer)
   }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -7,7 +7,6 @@ require "section_publishing_api_exporter"
 describe SectionPublishingAPIExporter do
   subject {
     described_class.new(
-      export_recipient,
       organisation,
       document_renderer,
       manual,
@@ -81,10 +80,13 @@ describe SectionPublishingAPIExporter do
     }
   }
 
+  before {
+    allow(subject).to receive(:export_recipient).and_return(export_recipient)
+  }
+
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
-        export_recipient,
         organisation,
         document_renderer,
         manual,
@@ -98,7 +100,6 @@ describe SectionPublishingAPIExporter do
     %w(major minor republish).each do |update_type|
       expect {
         described_class.new(
-          export_recipient,
           organisation,
           document_renderer,
           manual,
@@ -112,7 +113,6 @@ describe SectionPublishingAPIExporter do
   it "accepts explicitly setting nil as the option for update_type" do
     expect {
       described_class.new(
-        export_recipient,
         organisation,
         document_renderer,
         manual,
@@ -208,7 +208,6 @@ describe SectionPublishingAPIExporter do
     shared_examples_for "obeying the provided update_type" do
       subject {
         described_class.new(
-          export_recipient,
           organisation,
           document_renderer,
           manual,
@@ -260,7 +259,7 @@ describe SectionPublishingAPIExporter do
       end
 
       it "sets it to major if the document has never been published" do
-        update_type_attributes[:ever_been_published] = false
+        allow(document).to receive(:has_ever_been_published?).and_return(false)
         subject.call
 
         expect(export_recipient).to have_received(:call).with(

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -8,7 +8,6 @@ describe SectionPublishingAPIExporter do
   subject {
     described_class.new(
       organisation,
-      document_renderer,
       manual,
       document
     )
@@ -82,13 +81,13 @@ describe SectionPublishingAPIExporter do
 
   before {
     allow(subject).to receive(:export_recipient).and_return(export_recipient)
+    allow(subject).to receive(:document_renderer).and_return(document_renderer)
   }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
         organisation,
-        document_renderer,
         manual,
         document,
         update_type: "reticulate-splines"
@@ -101,7 +100,6 @@ describe SectionPublishingAPIExporter do
       expect {
         described_class.new(
           organisation,
-          document_renderer,
           manual,
           document,
           update_type: update_type
@@ -114,7 +112,6 @@ describe SectionPublishingAPIExporter do
     expect {
       described_class.new(
         organisation,
-        document_renderer,
         manual,
         document,
         update_type: nil
@@ -209,7 +206,6 @@ describe SectionPublishingAPIExporter do
       subject {
         described_class.new(
           organisation,
-          document_renderer,
           manual,
           document,
           update_type: explicit_update_type


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `SectionPublishingAPIExporter` with different `export_recipient`s or `document_renderer`s. Constructing them in the class makes this more explicit.
