### PR TITLE
Remove params from ManualPublishingAPIExporter

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -4,10 +4,10 @@ class ManualPublishingAPIExporter
   PUBLISHING_API_SCHEMA_NAME = "manual".freeze
   PUBLISHING_API_DOCUMENT_TYPE = "manual".freeze
 
-  def initialize(organisation, manual_renderer, publication_logs, manual, update_type: nil)
+  def initialize(organisation, publication_logs, manual, update_type: nil)
     @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
-    @manual_renderer = manual_renderer
+    @manual_renderer = ManualRenderer.new
     @publication_logs = publication_logs
     @manual = manual
     @update_type = update_type

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -4,8 +4,8 @@ class ManualPublishingAPIExporter
   PUBLISHING_API_SCHEMA_NAME = "manual".freeze
   PUBLISHING_API_DOCUMENT_TYPE = "manual".freeze
 
-  def initialize(export_recipient, organisation, manual_renderer, publication_logs, manual, update_type: nil)
-    @export_recipient = export_recipient
+  def initialize(organisation, manual_renderer, publication_logs, manual, update_type: nil)
+    @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
     @manual_renderer = manual_renderer
     @publication_logs = publication_logs

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -6,7 +6,6 @@ class ManualPublishingAPIExporter
 
   def initialize(organisation, manual, update_type: nil)
     @organisation = organisation
-    @publication_logs = PublicationLog
     @manual = manual
     @update_type = update_type
     check_update_type!(@update_type)
@@ -20,7 +19,6 @@ private
 
   attr_reader(
     :organisation,
-    :publication_logs,
     :manual,
   )
 
@@ -115,7 +113,7 @@ private
   end
 
   def serialised_change_notes
-    publication_logs.change_notes_for(manual.attributes.fetch(:slug)).map { |publication|
+    PublicationLog.change_notes_for(manual.attributes.fetch(:slug)).map { |publication|
       {
         base_path: "/#{publication.slug}",
         title: publication.title,

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -4,11 +4,11 @@ class ManualPublishingAPIExporter
   PUBLISHING_API_SCHEMA_NAME = "manual".freeze
   PUBLISHING_API_DOCUMENT_TYPE = "manual".freeze
 
-  def initialize(organisation, publication_logs, manual, update_type: nil)
+  def initialize(organisation, manual, update_type: nil)
     @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
     @manual_renderer = ManualRenderer.new
-    @publication_logs = publication_logs
+    @publication_logs = PublicationLog
     @manual = manual
     @update_type = update_type
     check_update_type!(@update_type)

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -6,7 +6,6 @@ class ManualPublishingAPIExporter
 
   def initialize(organisation, manual, update_type: nil)
     @organisation = organisation
-    @manual_renderer = ManualRenderer.new
     @publication_logs = PublicationLog
     @manual = manual
     @update_type = update_type
@@ -21,7 +20,6 @@ private
 
   attr_reader(
     :organisation,
-    :manual_renderer,
     :publication_logs,
     :manual,
   )
@@ -78,7 +76,7 @@ private
   end
 
   def rendered_manual_attributes
-    @rendered_manual_attributes ||= manual_renderer.call(manual).attributes
+    @rendered_manual_attributes ||= ManualRenderer.new.call(manual).attributes
   end
 
   def details_data

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -5,7 +5,6 @@ class ManualPublishingAPIExporter
   PUBLISHING_API_DOCUMENT_TYPE = "manual".freeze
 
   def initialize(organisation, manual, update_type: nil)
-    @export_recipient = Services.publishing_api_v2.method(:put_content)
     @organisation = organisation
     @manual_renderer = ManualRenderer.new
     @publication_logs = PublicationLog
@@ -15,13 +14,12 @@ class ManualPublishingAPIExporter
   end
 
   def call
-    export_recipient.call(content_id, exportable_attributes)
+    Services.publishing_api_v2.put_content(content_id, exportable_attributes)
   end
 
 private
 
   attr_reader(
-    :export_recipient,
     :organisation,
     :manual_renderer,
     :publication_logs,

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -7,7 +7,6 @@ class PublishingApiDraftManualExporter
     ).call
 
     ManualPublishingAPIExporter.new(
-      Services.publishing_api_v2.method(:put_content),
       OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       ManualRenderer.new,
       PublicationLog,

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -8,7 +8,6 @@ class PublishingApiDraftManualExporter
 
     ManualPublishingAPIExporter.new(
       OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
-      PublicationLog,
       manual
     ).call
   end

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -8,7 +8,6 @@ class PublishingApiDraftManualExporter
 
     ManualPublishingAPIExporter.new(
       OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
-      ManualRenderer.new,
       PublicationLog,
       manual
     ).call

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -171,7 +171,7 @@ private
       ).call
 
       ManualPublishingAPIExporter.new(
-        organisation, PublicationLog, manual, update_type: update_type
+        organisation, manual, update_type: update_type
       ).call
 
       manual.documents.each do |document|

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -164,7 +164,6 @@ private
       update_type = (action == :republish ? "republish" : nil)
 
       patch_links = publishing_api_v2.method(:patch_links)
-      put_content = publishing_api_v2.method(:put_content)
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
       manual_renderer = ManualRenderer.new
 
@@ -173,7 +172,7 @@ private
       ).call
 
       ManualPublishingAPIExporter.new(
-        put_content, organisation, manual_renderer, PublicationLog, manual, update_type: update_type
+        organisation, manual_renderer, PublicationLog, manual, update_type: update_type
       ).call
 
       manual.documents.each do |document|

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -165,14 +165,13 @@ private
 
       patch_links = publishing_api_v2.method(:patch_links)
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
-      manual_renderer = ManualRenderer.new
 
       ManualPublishingAPILinksExporter.new(
         patch_links, organisation, manual
       ).call
 
       ManualPublishingAPIExporter.new(
-        organisation, manual_renderer, PublicationLog, manual, update_type: update_type
+        organisation, PublicationLog, manual, update_type: update_type
       ).call
 
       manual.documents.each do |document|

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -190,7 +190,7 @@ private
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(
-      organisation, PublicationLog, manual
+      organisation, manual
     ).call
 
     manual.documents.each do |document|

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -187,11 +187,10 @@ private
 
   def send_draft(manual)
     organisation = fetch_organisation(manual.organisation_slug)
-    manual_renderer = ManualRenderer.new
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(
-      organisation, manual_renderer, PublicationLog, manual
+      organisation, PublicationLog, manual
     ).call
 
     manual.documents.each do |document|

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -186,13 +186,12 @@ private
   end
 
   def send_draft(manual)
-    put_content = publishing_api.method(:put_content)
     organisation = fetch_organisation(manual.organisation_slug)
     manual_renderer = ManualRenderer.new
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(
-      put_content, organisation, manual_renderer, PublicationLog, manual
+      organisation, manual_renderer, PublicationLog, manual
     ).call
 
     manual.documents.each do |document|

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -7,7 +7,6 @@ require "manual_publishing_api_exporter"
 describe ManualPublishingAPIExporter do
   subject {
     described_class.new(
-      export_recipient,
       organisation,
       manual_renderer,
       publication_logs_collection,
@@ -106,10 +105,13 @@ describe ManualPublishingAPIExporter do
     ]
   }
 
+  before {
+    allow(subject).to receive(:export_recipient).and_return(export_recipient)
+  }
+
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
-        export_recipient,
         organisation,
         manual_renderer,
         publication_logs_collection,
@@ -123,7 +125,6 @@ describe ManualPublishingAPIExporter do
     %w(major minor republish).each do |update_type|
       expect {
         described_class.new(
-          export_recipient,
           organisation,
           manual_renderer,
           publication_logs_collection,
@@ -137,7 +138,6 @@ describe ManualPublishingAPIExporter do
   it "accepts explicitly setting nil as the option for update_type" do
     expect {
       described_class.new(
-        export_recipient,
         organisation,
         manual_renderer,
         publication_logs_collection,
@@ -278,7 +278,7 @@ describe ManualPublishingAPIExporter do
 
   shared_examples_for "publishing a manual that has never been published" do
     before do
-      manual_attributes[:ever_been_published] = false
+      allow(manual).to receive(:has_ever_been_published?).and_return(false)
     end
 
     it "exports with the update_type set to major" do
@@ -294,7 +294,6 @@ describe ManualPublishingAPIExporter do
   shared_examples_for "obeying the provided update_type" do
     subject {
       described_class.new(
-        export_recipient,
         organisation,
         manual_renderer,
         publication_logs_collection,

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -80,10 +80,6 @@ describe ManualPublishingAPIExporter do
     }
   }
 
-  let(:publication_logs_collection) {
-    double(:publication_logs, change_notes_for: publication_logs)
-  }
-
   let(:publication_logs) {
     [
       double(
@@ -106,7 +102,7 @@ describe ManualPublishingAPIExporter do
   before {
     allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
     allow(ManualRenderer).to receive(:new).and_return(manual_renderer)
-    allow(subject).to receive(:publication_logs).and_return(publication_logs_collection)
+    allow(PublicationLog).to receive(:change_notes_for).and_return(publication_logs)
   }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -12,7 +12,7 @@ describe ManualPublishingAPIExporter do
     )
   }
 
-  let(:export_recipient) { double(:export_recipient, call: nil) }
+  let(:publishing_api) { double(:publishing_api, put_content: nil) }
   let(:manual_renderer) { ->(_) { double(:rendered_manual, attributes: rendered_manual_attributes) } }
 
   let(:manual) {
@@ -104,7 +104,7 @@ describe ManualPublishingAPIExporter do
   }
 
   before {
-    allow(subject).to receive(:export_recipient).and_return(export_recipient)
+    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
     allow(subject).to receive(:manual_renderer).and_return(manual_renderer)
     allow(subject).to receive(:publication_logs).and_return(publication_logs_collection)
   }
@@ -148,7 +148,7 @@ describe ManualPublishingAPIExporter do
   it "exports the serialized document attributes" do
     subject.call
 
-    expect(export_recipient).to have_received(:call).with(
+    expect(publishing_api).to have_received(:put_content).with(
       "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       all_of(
         hash_including(
@@ -186,7 +186,7 @@ describe ManualPublishingAPIExporter do
     it "adds it as the value for first_published_at in the serialized attributes" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(
           first_published_at: previously_published_date.iso8601,
@@ -198,7 +198,7 @@ describe ManualPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(true)
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(
           public_updated_at: previously_published_date.iso8601,
@@ -210,7 +210,7 @@ describe ManualPublishingAPIExporter do
       allow(manual).to receive(:use_originally_published_at_for_public_timestamp?).and_return(false)
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_excluding(:public_updated_at)
       )
@@ -220,7 +220,7 @@ describe ManualPublishingAPIExporter do
   it "exports section metadata for the manual" do
     subject.call
 
-    expect(export_recipient).to have_received(:call).with(
+    expect(publishing_api).to have_received(:put_content).with(
       "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       hash_including(
         details: {
@@ -278,7 +278,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -298,7 +298,7 @@ describe ManualPublishingAPIExporter do
       let(:explicit_update_type) { "republish" }
       it "exports with the update_type set to republish" do
         subject.call
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
           hash_including(update_type: "republish")
         )
@@ -309,7 +309,7 @@ describe ManualPublishingAPIExporter do
       let(:explicit_update_type) { "minor" }
       it "exports with the update_type set to minor" do
         subject.call
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
           hash_including(update_type: "minor")
         )
@@ -320,7 +320,7 @@ describe ManualPublishingAPIExporter do
       let(:explicit_update_type) { "major" }
       it "exports with the update_type set to major" do
         subject.call
-        expect(export_recipient).to have_received(:call).with(
+        expect(publishing_api).to have_received(:put_content).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
           hash_including(update_type: "major")
         )
@@ -353,7 +353,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to minor" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "minor")
       )
@@ -388,7 +388,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to minor" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "minor")
       )
@@ -423,7 +423,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -457,7 +457,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -492,7 +492,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to minor" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "minor")
       )
@@ -527,7 +527,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -560,7 +560,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )
@@ -595,7 +595,7 @@ describe ManualPublishingAPIExporter do
     it "exports with the update_type set to major" do
       subject.call
 
-      expect(export_recipient).to have_received(:call).with(
+      expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(update_type: "major")
       )

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -8,7 +8,6 @@ describe ManualPublishingAPIExporter do
   subject {
     described_class.new(
       organisation,
-      publication_logs_collection,
       manual
     )
   }
@@ -107,13 +106,13 @@ describe ManualPublishingAPIExporter do
   before {
     allow(subject).to receive(:export_recipient).and_return(export_recipient)
     allow(subject).to receive(:manual_renderer).and_return(manual_renderer)
+    allow(subject).to receive(:publication_logs).and_return(publication_logs_collection)
   }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
         organisation,
-        publication_logs_collection,
         manual,
         update_type: "reticulate-splines"
       )
@@ -125,7 +124,6 @@ describe ManualPublishingAPIExporter do
       expect {
         described_class.new(
           organisation,
-          publication_logs_collection,
           manual,
           update_type: update_type
         )
@@ -137,7 +135,6 @@ describe ManualPublishingAPIExporter do
     expect {
       described_class.new(
         organisation,
-        publication_logs_collection,
         manual,
         update_type: nil
       )
@@ -292,7 +289,6 @@ describe ManualPublishingAPIExporter do
     subject {
       described_class.new(
         organisation,
-        publication_logs_collection,
         manual,
         update_type: explicit_update_type
       )

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -8,7 +8,6 @@ describe ManualPublishingAPIExporter do
   subject {
     described_class.new(
       organisation,
-      manual_renderer,
       publication_logs_collection,
       manual
     )
@@ -107,13 +106,13 @@ describe ManualPublishingAPIExporter do
 
   before {
     allow(subject).to receive(:export_recipient).and_return(export_recipient)
+    allow(subject).to receive(:manual_renderer).and_return(manual_renderer)
   }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
         organisation,
-        manual_renderer,
         publication_logs_collection,
         manual,
         update_type: "reticulate-splines"
@@ -126,7 +125,6 @@ describe ManualPublishingAPIExporter do
       expect {
         described_class.new(
           organisation,
-          manual_renderer,
           publication_logs_collection,
           manual,
           update_type: update_type
@@ -139,7 +137,6 @@ describe ManualPublishingAPIExporter do
     expect {
       described_class.new(
         organisation,
-        manual_renderer,
         publication_logs_collection,
         manual,
         update_type: nil
@@ -295,7 +292,6 @@ describe ManualPublishingAPIExporter do
     subject {
       described_class.new(
         organisation,
-        manual_renderer,
         publication_logs_collection,
         manual,
         update_type: explicit_update_type

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -105,7 +105,7 @@ describe ManualPublishingAPIExporter do
 
   before {
     allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
-    allow(subject).to receive(:manual_renderer).and_return(manual_renderer)
+    allow(ManualRenderer).to receive(:new).and_return(manual_renderer)
     allow(subject).to receive(:publication_logs).and_return(publication_logs_collection)
   }
 


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `ManualPublishingAPIExporter` with different `export_recipient`s, `manual_renderer`s or `publication_log`s. Constructing them in the class makes this more explicit.

This is similar to the changes in PR #880.
