### PR TITLE
Remove params from ManualPublishingAPILinksExporter

### DIFF
--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -1,17 +1,16 @@
 class ManualPublishingAPILinksExporter
   def initialize(organisation, manual)
-    @export_recipient = Services.publishing_api_v2.method(:patch_links)
     @organisation = organisation
     @manual = manual
   end
 
   def call
-    export_recipient.call(content_id, exportable_attributes)
+    Services.publishing_api_v2.patch_links(content_id, exportable_attributes)
   end
 
 private
 
-  attr_reader :export_recipient, :organisation, :manual
+  attr_reader :organisation, :manual
 
   def content_id
     manual.id

--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -1,6 +1,6 @@
 class ManualPublishingAPILinksExporter
-  def initialize(export_recipient, organisation, manual)
-    @export_recipient = export_recipient
+  def initialize(organisation, manual)
+    @export_recipient = Services.publishing_api_v2.method(:patch_links)
     @organisation = organisation
     @manual = manual
   end

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,7 +1,6 @@
 class PublishingApiDraftManualExporter
   def call(_, manual)
     ManualPublishingAPILinksExporter.new(
-      Services.publishing_api_v2.method(:patch_links),
       OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       manual
     ).call

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -167,7 +167,7 @@ private
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
 
       ManualPublishingAPILinksExporter.new(
-        patch_links, organisation, manual
+        organisation, manual
       ).call
 
       ManualPublishingAPIExporter.new(

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -6,7 +6,6 @@ require "manual_publishing_api_links_exporter"
 describe ManualPublishingAPILinksExporter do
   subject {
     ManualPublishingAPILinksExporter.new(
-      export_recipient,
       organisation,
       manual
     )
@@ -39,6 +38,10 @@ describe ManualPublishingAPILinksExporter do
       double(:document, id: "c19ffb7d-448c-4cc8-bece-022662ef9611"),
       double(:document, id: "f9c91a07-6a41-4b97-94a8-ecdc81997d49"),
     ]
+  }
+
+  before {
+    allow(subject).to receive(:export_recipient).and_return(export_recipient)
   }
 
   it "exports links for the manual" do

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -11,7 +11,7 @@ describe ManualPublishingAPILinksExporter do
     )
   }
 
-  let(:export_recipient) { double(:export_recipient, call: nil) }
+  let(:publishing_api) { double(:publishing_api, patch_links: nil) }
 
   let(:organisation) {
     {
@@ -41,13 +41,13 @@ describe ManualPublishingAPILinksExporter do
   }
 
   before {
-    allow(subject).to receive(:export_recipient).and_return(export_recipient)
+    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
   }
 
   it "exports links for the manual" do
     subject.call
 
-    expect(export_recipient).to have_received(:call).with(
+    expect(publishing_api).to have_received(:patch_links).with(
       manual.id,
       hash_including(
         links: {


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `ManualPublishingAPILinksExporter` with different `export_recipient`s. Constructing it in the class makes this more explicit.

This is similar to the changes in PR #880.
