### PR TITLE
Remove params from PublishingAPIPublisher

### DIFF
--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -1,8 +1,8 @@
 class PublishingAPIPublisher
   include PublishingAPIUpdateTypes
 
-  def initialize(publishing_api:, entity:, update_type: nil)
-    @publishing_api = publishing_api
+  def initialize(entity:, update_type: nil)
+    @publishing_api = Services.publishing_api_v2
     @entity = entity
     @update_type = update_type
     check_update_type!(@update_type)

--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -2,20 +2,18 @@ class PublishingAPIPublisher
   include PublishingAPIUpdateTypes
 
   def initialize(entity:, update_type: nil)
-    @publishing_api = Services.publishing_api_v2
     @entity = entity
     @update_type = update_type
     check_update_type!(@update_type)
   end
 
   def call
-    publishing_api.publish(entity.id, update_type)
+    Services.publishing_api_v2.publish(entity.id, update_type)
   end
 
 private
 
   attr_reader(
-    :publishing_api,
     :entity,
     :update_type,
   )

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -131,7 +131,6 @@ private
     ->(manual, action = nil) {
       update_type = (action == :republish ? "republish" : nil)
       PublishingAPIPublisher.new(
-        publishing_api: publishing_api_v2,
         entity: manual,
         update_type: update_type,
       ).call
@@ -140,7 +139,6 @@ private
         next if !document.needs_exporting? && action != :republish
 
         PublishingAPIPublisher.new(
-          publishing_api: publishing_api_v2,
           entity: document,
           update_type: update_type,
         ).call

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -38,7 +38,7 @@ describe PublishingAPIPublisher do
 
   describe "#call" do
     before {
-      allow(subject).to receive(:publishing_api).and_return(publishing_api)
+      allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
     }
 
     context "when no explicit update_type is given" do

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -10,7 +10,6 @@ describe PublishingAPIPublisher do
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
-        publishing_api: publishing_api,
         entity: document,
         update_type: "reticulate-splines"
       )
@@ -21,7 +20,6 @@ describe PublishingAPIPublisher do
     %w(major minor republish).each do |update_type|
       expect {
         described_class.new(
-          publishing_api: publishing_api,
           entity: document,
           update_type: update_type
         )
@@ -32,7 +30,6 @@ describe PublishingAPIPublisher do
   it "accepts explicitly setting nil as the option for update_type" do
     expect {
       described_class.new(
-        publishing_api: publishing_api,
         entity: document,
         update_type: nil
       )
@@ -40,10 +37,13 @@ describe PublishingAPIPublisher do
   end
 
   describe "#call" do
+    before {
+      allow(subject).to receive(:publishing_api).and_return(publishing_api)
+    }
+
     context "when no explicit update_type is given" do
       subject do
         described_class.new(
-          publishing_api: publishing_api,
           entity: document
         )
       end
@@ -58,7 +58,6 @@ describe PublishingAPIPublisher do
     context "when an explicit update_type is given" do
       subject do
         described_class.new(
-          publishing_api: publishing_api,
           entity: document,
           update_type: "republish"
         )


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `PublishingAPIPublisher` with different `publishing_api`s. Constructing it in the class makes this more explicit.

This is similar to the changes in PR #880.
