### PR TITLE
Remove params from SectionPublishingAPILinksExporter

### DIFF
--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -1,7 +1,6 @@
 class PublishingApiDraftSectionExporter
   def call(section, manual)
     SectionPublishingAPILinksExporter.new(
-      Services.publishing_api_v2.method(:patch_links),
       OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       manual,
       section

--- a/app/exporters/section_publishing_api_links_exporter.rb
+++ b/app/exporters/section_publishing_api_links_exporter.rb
@@ -1,6 +1,6 @@
 class SectionPublishingAPILinksExporter
-  def initialize(export_recipient, organisation, manual, document)
-    @export_recipient = export_recipient
+  def initialize(organisation, manual, document)
+    @export_recipient = Services.publishing_api_v2.method(:patch_links)
     @organisation = organisation
     @manual = manual
     @document = document

--- a/app/exporters/section_publishing_api_links_exporter.rb
+++ b/app/exporters/section_publishing_api_links_exporter.rb
@@ -1,18 +1,17 @@
 class SectionPublishingAPILinksExporter
   def initialize(organisation, manual, document)
-    @export_recipient = Services.publishing_api_v2.method(:patch_links)
     @organisation = organisation
     @manual = manual
     @document = document
   end
 
   def call
-    export_recipient.call(content_id, exportable_attributes)
+    Services.publishing_api_v2.patch_links(content_id, exportable_attributes)
   end
 
 private
 
-  attr_reader :export_recipient, :organisation, :manual, :document
+  attr_reader :organisation, :manual, :document
 
   def content_id
     document.id

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -161,7 +161,6 @@ private
     ->(manual, action = nil) {
       update_type = (action == :republish ? "republish" : nil)
 
-      patch_links = publishing_api_v2.method(:patch_links)
       organisation = organisation(manual.attributes.fetch(:organisation_slug))
 
       ManualPublishingAPILinksExporter.new(
@@ -176,7 +175,7 @@ private
         next if !document.needs_exporting? && action != :republish
 
         SectionPublishingAPILinksExporter.new(
-          patch_links, organisation, manual, document
+          organisation, manual, document
         ).call
 
         SectionPublishingAPIExporter.new(

--- a/spec/exporters/section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_links_exporter_spec.rb
@@ -12,7 +12,7 @@ describe SectionPublishingAPILinksExporter do
     )
   }
 
-  let(:export_recipient) { double(:export_recipient, call: nil) }
+  let(:publishing_api) { double(:publishing_api, patch_links: nil) }
 
   let(:organisation) {
     {
@@ -44,13 +44,13 @@ describe SectionPublishingAPILinksExporter do
   }
 
   before {
-    allow(subject).to receive(:export_recipient).and_return(export_recipient)
+    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
   }
 
   it "exports links for the document" do
     subject.call
 
-    expect(export_recipient).to have_received(:call).with(
+    expect(publishing_api).to have_received(:patch_links).with(
       document.id,
       hash_including(
         links: {

--- a/spec/exporters/section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_links_exporter_spec.rb
@@ -6,7 +6,6 @@ require "section_publishing_api_links_exporter"
 describe SectionPublishingAPILinksExporter do
   subject {
     SectionPublishingAPILinksExporter.new(
-      export_recipient,
       organisation,
       manual,
       document
@@ -42,6 +41,10 @@ describe SectionPublishingAPILinksExporter do
       attributes: { body: "##Some heading\nmanual section body" },
       attachments: []
     )
+  }
+
+  before {
+    allow(subject).to receive(:export_recipient).and_return(export_recipient)
   }
 
   it "exports links for the document" do


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `SectionPublishingAPILinksExporter` with different `export_recipient`s. Constructing it in the class makes this more explicit.

This is similar to the changes in PR #880.
