### PR TITLE
Simplify OrganisationFetcher

### DIFF
--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,12 +1,12 @@
 class PublishingApiDraftManualExporter
   def call(_, manual)
     ManualPublishingAPILinksExporter.new(
-      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
       manual
     ).call
 
     ManualPublishingAPIExporter.new(
-      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
       manual
     ).call
   end

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -1,13 +1,13 @@
 class PublishingApiDraftSectionExporter
   def call(section, manual)
     SectionPublishingAPILinksExporter.new(
-      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
       manual,
       section
     ).call
 
     SectionPublishingAPIExporter.new(
-      OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
+      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
       manual,
       section
     ).call

--- a/app/lib/organisation_fetcher.rb
+++ b/app/lib/organisation_fetcher.rb
@@ -1,10 +1,8 @@
 require "services"
 
 class OrganisationFetcher
-  def self.instance
+  def self.fetch(organisation_slug)
     @organisations ||= {}
-    ->(organisation_slug) {
-      @organisations[organisation_slug] ||= Services.organisations.organisation(organisation_slug)
-    }
+    @organisations[organisation_slug] ||= Services.organisations.organisation(organisation_slug)
   end
 end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -206,6 +206,6 @@ private
   end
 
   def organisation(slug)
-    OrganisationFetcher.instance.call(slug)
+    OrganisationFetcher.fetch(slug)
   end
 end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -230,6 +230,6 @@ private
   end
 
   def fetch_organisation(slug)
-    OrganisationFetcher.instance.call(slug)
+    OrganisationFetcher.fetch(slug)
   end
 end


### PR DESCRIPTION
I think this is easier to understand. Previously the `instance` class
method returned an anonymous function that had to be `call`ed with an
organisation slug.