### PR TITLE
Inline service registries into ManualsController

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -2,6 +2,8 @@ require "list_manuals_service"
 require "show_manual_service"
 require "create_manual_service"
 require "update_manual_service"
+require "queue_publish_manual_service"
+require "publish_manual_worker"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -121,7 +123,12 @@ class ManualsController < ApplicationController
   end
 
   def publish
-    manual = services.queue_publish(manual_id).call
+    service = QueuePublishManualService.new(
+      PublishManualWorker,
+      services.repository,
+      manual_id,
+    )
+    manual = service.call
 
     redirect_to(
       manual_path(manual),

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -141,7 +141,7 @@ class ManualsController < ApplicationController
     service = PreviewManualService.new(
       repository: services.repository,
       builder: services.manual_builder,
-      renderer: services.manual_renderer,
+      renderer: ManualRenderer.new,
       manual_id: params[:id],
       attributes: update_manual_params,
     )

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -1,8 +1,14 @@
+require "list_manuals_service"
+
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
 
   def index
-    all_manuals = services.list(self).call
+    service = ListManualsService.new(
+      manual_repository: services.associationless_repository,
+      context: self,
+    )
+    all_manuals = service.call
 
     render(:index, locals: { manuals: all_manuals })
   end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -1,4 +1,5 @@
 require "list_manuals_service"
+require "show_manual_service"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -14,7 +15,11 @@ class ManualsController < ApplicationController
   end
 
   def show
-    manual, metadata = services.show(manual_id).call
+    service = ShowManualService.new(
+      manual_repository: services.repository,
+      manual_id: manual_id,
+    )
+    manual, metadata = service.call
     slug_unique = metadata.fetch(:slug_unique)
     clashing_sections = metadata.fetch(:clashing_sections)
 
@@ -49,7 +54,11 @@ class ManualsController < ApplicationController
   end
 
   def edit
-    manual, _metadata = services.show(manual_id).call
+    service = ShowManualService.new(
+      manual_repository: services.repository,
+      manual_id: manual_id,
+    )
+    manual, _metadata = service.call
 
     render(:edit, locals: { manual: manual_form(manual) })
   end
@@ -68,7 +77,11 @@ class ManualsController < ApplicationController
   end
 
   def edit_original_publication_date
-    manual, _metadata = services.show(manual_id).call
+    service = ShowManualService.new(
+      manual_repository: services.repository,
+      manual_id: manual_id,
+    )
+    manual, _metadata = service.call
 
     render(:edit_original_publication_date, locals: { manual: manual_form(manual) })
   end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -262,7 +262,14 @@ private
   end
 
   def associationless_repository
-    services.associationless_repository
+    if current_user_is_gds_editor?
+      RepositoryRegistry.create
+        .associationless_manual_repository
+    else
+      associationless_manual_repository_factory = RepositoryRegistry.create
+        .associationless_organisation_scoped_manual_repository_factory
+      associationless_manual_repository_factory.call(current_organisation_slug)
+    end
   end
 
   def authorize_user_for_publishing

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -35,7 +35,8 @@ class ManualsController < ApplicationController
   end
 
   def new
-    manual = services.new(self).call
+    service = ->() { services.manual_builder.call(title: "") }
+    manual = service.call
 
     render(:new, locals: { manual: manual_form(manual) })
   end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -102,7 +102,13 @@ class ManualsController < ApplicationController
   end
 
   def update_original_publication_date
-    manual = services.update_original_publication_date(manual_id, publication_date_manual_params).call
+    service = UpdateManualOriginalPublicationDateService.new(
+      manual_repository: services.repository,
+      manual_id: manual_id,
+      attributes: publication_date_manual_params,
+      listeners: services.observers.update_original_publication_date,
+    )
+    manual = service.call
     manual = manual_form(manual)
 
     if manual.valid?

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -1,6 +1,7 @@
 require "list_manuals_service"
 require "show_manual_service"
 require "create_manual_service"
+require "update_manual_service"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -72,7 +73,13 @@ class ManualsController < ApplicationController
   end
 
   def update
-    manual = services.update(manual_id, update_manual_params).call
+    service = UpdateManualService.new(
+      manual_repository: services.repository,
+      manual_id: manual_id,
+      attributes: update_manual_params,
+      listeners: services.observers.update,
+    )
+    manual = service.call
     manual = manual_form(manual)
 
     if manual.valid?

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -6,6 +6,7 @@ require "queue_publish_manual_service"
 require "publish_manual_worker"
 require "preview_manual_service"
 require "builders/manual_builder"
+require "manual_observers_registry"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -51,7 +52,7 @@ class ManualsController < ApplicationController
     service = CreateManualService.new(
       manual_repository: services.repository,
       manual_builder: ManualBuilder.create,
-      listeners: services.observers.creation,
+      listeners: ManualObserversRegistry.new.creation,
       attributes: create_manual_params,
     )
     manual = service.call
@@ -81,7 +82,7 @@ class ManualsController < ApplicationController
       manual_repository: services.repository,
       manual_id: manual_id,
       attributes: update_manual_params,
-      listeners: services.observers.update,
+      listeners: ManualObserversRegistry.new.update,
     )
     manual = service.call
     manual = manual_form(manual)
@@ -110,7 +111,7 @@ class ManualsController < ApplicationController
       manual_repository: services.repository,
       manual_id: manual_id,
       attributes: publication_date_manual_params,
-      listeners: services.observers.update_original_publication_date,
+      listeners: ManualObserversRegistry.new.update_original_publication_date,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -233,24 +233,6 @@ private
     ManualViewAdapter.new(manual)
   end
 
-  def services
-    if current_user_is_gds_editor?
-      gds_editor_services
-    else
-      organisational_services
-    end
-  end
-
-  def gds_editor_services
-    ManualServiceRegistry.new
-  end
-
-  def organisational_services
-    OrganisationalManualServiceRegistry.new(
-      organisation_slug: current_organisation_slug,
-    )
-  end
-
   def repository
     if current_user_is_gds_editor?
       RepositoryRegistry.create.manual_repository

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -252,7 +252,13 @@ private
   end
 
   def repository
-    services.repository
+    if current_user_is_gds_editor?
+      RepositoryRegistry.create.manual_repository
+    else
+      manual_repository_factory = RepositoryRegistry.create
+        .organisation_scoped_manual_repository_factory
+      manual_repository_factory.call(current_organisation_slug)
+    end
   end
 
   def associationless_repository

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -1,5 +1,6 @@
 require "list_manuals_service"
 require "show_manual_service"
+require "create_manual_service"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -42,7 +43,13 @@ class ManualsController < ApplicationController
   end
 
   def create
-    manual = services.create(create_manual_params).call
+    service = CreateManualService.new(
+      manual_repository: services.repository,
+      manual_builder: services.manual_builder,
+      listeners: services.observers.creation,
+      attributes: create_manual_params,
+    )
+    manual = service.call
     manual = manual_form(manual)
 
     if manual.valid?

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -5,6 +5,7 @@ require "update_manual_service"
 require "queue_publish_manual_service"
 require "publish_manual_worker"
 require "preview_manual_service"
+require "builders/manual_builder"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -40,7 +41,7 @@ class ManualsController < ApplicationController
   end
 
   def new
-    service = ->() { services.manual_builder.call(title: "") }
+    service = ->() { ManualBuilder.create.call(title: "") }
     manual = service.call
 
     render(:new, locals: { manual: manual_form(manual) })
@@ -49,7 +50,7 @@ class ManualsController < ApplicationController
   def create
     service = CreateManualService.new(
       manual_repository: services.repository,
-      manual_builder: services.manual_builder,
+      manual_builder: ManualBuilder.create,
       listeners: services.observers.creation,
       attributes: create_manual_params,
     )
@@ -140,7 +141,7 @@ class ManualsController < ApplicationController
   def preview
     service = PreviewManualService.new(
       repository: services.repository,
-      builder: services.manual_builder,
+      builder: ManualBuilder.create,
       renderer: ManualRenderer.new,
       manual_id: params[:id],
       attributes: update_manual_params,

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -4,6 +4,7 @@ require "create_manual_service"
 require "update_manual_service"
 require "queue_publish_manual_service"
 require "publish_manual_worker"
+require "preview_manual_service"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]
@@ -137,7 +138,14 @@ class ManualsController < ApplicationController
   end
 
   def preview
-    manual = services.preview(params[:id], update_manual_params).call
+    service = PreviewManualService.new(
+      repository: services.repository,
+      builder: services.manual_builder,
+      renderer: services.manual_renderer,
+      manual_id: params[:id],
+      attributes: update_manual_params,
+    )
+    manual = service.call
 
     manual.valid? # Force validation check or errors will be empty
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -23,7 +23,7 @@ class ManualsController < ApplicationController
 
   def show
     service = ShowManualService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       manual_id: manual_id,
     )
     manual, metadata = service.call
@@ -50,7 +50,7 @@ class ManualsController < ApplicationController
 
   def create
     service = CreateManualService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       manual_builder: ManualBuilder.create,
       listeners: ManualObserversRegistry.new.creation,
       attributes: create_manual_params,
@@ -69,7 +69,7 @@ class ManualsController < ApplicationController
 
   def edit
     service = ShowManualService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       manual_id: manual_id,
     )
     manual, _metadata = service.call
@@ -79,7 +79,7 @@ class ManualsController < ApplicationController
 
   def update
     service = UpdateManualService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       manual_id: manual_id,
       attributes: update_manual_params,
       listeners: ManualObserversRegistry.new.update,
@@ -98,7 +98,7 @@ class ManualsController < ApplicationController
 
   def edit_original_publication_date
     service = ShowManualService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       manual_id: manual_id,
     )
     manual, _metadata = service.call
@@ -108,7 +108,7 @@ class ManualsController < ApplicationController
 
   def update_original_publication_date
     service = UpdateManualOriginalPublicationDateService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       manual_id: manual_id,
       attributes: publication_date_manual_params,
       listeners: ManualObserversRegistry.new.update_original_publication_date,
@@ -128,7 +128,7 @@ class ManualsController < ApplicationController
   def publish
     service = QueuePublishManualService.new(
       PublishManualWorker,
-      services.repository,
+      repository,
       manual_id,
     )
     manual = service.call
@@ -141,7 +141,7 @@ class ManualsController < ApplicationController
 
   def preview
     service = PreviewManualService.new(
-      repository: services.repository,
+      repository: repository,
       builder: ManualBuilder.create,
       renderer: ManualRenderer.new,
       manual_id: params[:id],
@@ -249,6 +249,10 @@ private
     OrganisationalManualServiceRegistry.new(
       organisation_slug: current_organisation_slug,
     )
+  end
+
+  def repository
+    services.repository
   end
 
   def authorize_user_for_publishing

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -13,7 +13,7 @@ class ManualsController < ApplicationController
 
   def index
     service = ListManualsService.new(
-      manual_repository: services.associationless_repository,
+      manual_repository: associationless_repository,
       context: self,
     )
     all_manuals = service.call
@@ -253,6 +253,10 @@ private
 
   def repository
     services.repository
+  end
+
+  def associationless_repository
+    services.associationless_repository
   end
 
   def authorize_user_for_publishing

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,2 +1,0 @@
-class AbstractManualServiceRegistry
-end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -10,10 +10,6 @@ require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def new(_context)
-    ->() { manual_builder.call(title: "") }
-  end
-
   def create(attributes)
     CreateManualService.new(
       manual_repository: repository,

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,4 +1,3 @@
-require "list_manuals_service"
 require "create_manual_service"
 require "update_manual_service"
 require "show_manual_service"
@@ -12,13 +11,6 @@ require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def list(context)
-    ListManualsService.new(
-      manual_repository: associationless_repository,
-      context: context,
-    )
-  end
-
   def new(_context)
     ->() { manual_builder.call(title: "") }
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,19 +1,9 @@
-require "publish_manual_service"
 require "republish_manual_service"
 require "withdraw_manual_service"
 require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def publish(manual_id, version_number)
-    PublishManualService.new(
-      manual_repository: repository,
-      listeners: observers.publication,
-      manual_id: manual_id,
-      version_number: version_number,
-    )
-  end
-
   def republish(manual_id)
     RepublishManualService.new(
       draft_listeners: observers.update,

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,21 +1,11 @@
-require "queue_publish_manual_service"
 require "preview_manual_service"
 require "publish_manual_service"
 require "republish_manual_service"
 require "withdraw_manual_service"
-require "publish_manual_worker"
 require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def queue_publish(manual_id)
-    QueuePublishManualService.new(
-      PublishManualWorker,
-      repository,
-      manual_id,
-    )
-  end
-
   def preview(manual_id, attributes)
     PreviewManualService.new(
       repository: repository,

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,4 +1,3 @@
-require "create_manual_service"
 require "update_manual_service"
 require "queue_publish_manual_service"
 require "preview_manual_service"
@@ -10,15 +9,6 @@ require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def create(attributes)
-    CreateManualService.new(
-      manual_repository: repository,
-      manual_builder: manual_builder,
-      listeners: observers.creation,
-      attributes: attributes,
-    )
-  end
-
   def update(manual_id, attributes)
     UpdateManualService.new(
       manual_repository: repository,

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,8 +1,4 @@
 class AbstractManualServiceRegistry
-  def repository
-    raise NotImplementedError
-  end
-
   def associationless_repository
     raise NotImplementedError
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,11 +1,6 @@
 require "manual_observers_registry"
-require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def manual_builder
-    ManualBuilder.create
-  end
-
   def repository
     raise NotImplementedError
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,16 +1,7 @@
-require "withdraw_manual_service"
 require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def withdraw(manual_id)
-    WithdrawManualService.new(
-      manual_repository: repository,
-      listeners: observers.withdrawal,
-      manual_id: manual_id,
-    )
-  end
-
   def manual_renderer
     ManualRenderer.new
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,5 +1,3 @@
-require "manual_observers_registry"
-
 class AbstractManualServiceRegistry
   def repository
     raise NotImplementedError
@@ -7,9 +5,5 @@ class AbstractManualServiceRegistry
 
   def associationless_repository
     raise NotImplementedError
-  end
-
-  def observers
-    @observers ||= ManualObserversRegistry.new
   end
 end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -2,10 +2,6 @@ require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def manual_renderer
-    ManualRenderer.new
-  end
-
   def manual_builder
     ManualBuilder.create
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -100,8 +100,6 @@ class AbstractManualServiceRegistry
     )
   end
 
-private
-
   def manual_renderer
     ManualRenderer.new
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,4 +1,3 @@
-require "preview_manual_service"
 require "publish_manual_service"
 require "republish_manual_service"
 require "withdraw_manual_service"
@@ -6,16 +5,6 @@ require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def preview(manual_id, attributes)
-    PreviewManualService.new(
-      repository: repository,
-      builder: manual_builder,
-      renderer: manual_renderer,
-      manual_id: manual_id,
-      attributes: attributes,
-    )
-  end
-
   def publish(manual_id, version_number)
     PublishManualService.new(
       manual_repository: repository,

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,6 +1,5 @@
 require "create_manual_service"
 require "update_manual_service"
-require "show_manual_service"
 require "queue_publish_manual_service"
 require "preview_manual_service"
 require "publish_manual_service"
@@ -30,13 +29,6 @@ class AbstractManualServiceRegistry
       manual_id: manual_id,
       attributes: attributes,
       listeners: observers.update,
-    )
-  end
-
-  def show(manual_id)
-    ShowManualService.new(
-      manual_repository: repository,
-      manual_id: manual_id,
     )
   end
 

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,17 +1,8 @@
-require "republish_manual_service"
 require "withdraw_manual_service"
 require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def republish(manual_id)
-    RepublishManualService.new(
-      draft_listeners: observers.update,
-      published_listeners: observers.republication,
-      manual_id: manual_id,
-    )
-  end
-
   def withdraw(manual_id)
     WithdrawManualService.new(
       manual_repository: repository,

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -51,15 +51,6 @@ class AbstractManualServiceRegistry
     )
   end
 
-  def update_original_publication_date(manual_id, attributes)
-    UpdateManualOriginalPublicationDateService.new(
-      manual_repository: repository,
-      manual_id: manual_id,
-      attributes: attributes,
-      listeners: observers.update_original_publication_date,
-    )
-  end
-
   def manual_renderer
     ManualRenderer.new
   end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,5 +1,2 @@
 class AbstractManualServiceRegistry
-  def associationless_repository
-    raise NotImplementedError
-  end
 end

--- a/app/services/abstract_manual_service_registry.rb
+++ b/app/services/abstract_manual_service_registry.rb
@@ -1,4 +1,3 @@
-require "update_manual_service"
 require "queue_publish_manual_service"
 require "preview_manual_service"
 require "publish_manual_service"
@@ -9,15 +8,6 @@ require "manual_observers_registry"
 require "builders/manual_builder"
 
 class AbstractManualServiceRegistry
-  def update(manual_id, attributes)
-    UpdateManualService.new(
-      manual_repository: repository,
-      manual_id: manual_id,
-      attributes: attributes,
-      listeners: observers.update,
-    )
-  end
-
   def queue_publish(manual_id)
     QueuePublishManualService.new(
       PublishManualWorker,

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -1,6 +1,4 @@
 class ManualServiceRegistry < AbstractManualServiceRegistry
-private
-
   def associationless_repository
     RepositoryRegistry.create
       .associationless_manual_repository

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -3,8 +3,4 @@ class ManualServiceRegistry < AbstractManualServiceRegistry
     RepositoryRegistry.create
       .associationless_manual_repository
   end
-
-  def repository
-    RepositoryRegistry.create.manual_repository
-  end
 end

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -1,6 +1,2 @@
 class ManualServiceRegistry < AbstractManualServiceRegistry
-  def associationless_repository
-    RepositoryRegistry.create
-      .associationless_manual_repository
-  end
 end

--- a/app/services/manual_service_registry.rb
+++ b/app/services/manual_service_registry.rb
@@ -1,2 +1,0 @@
-class ManualServiceRegistry < AbstractManualServiceRegistry
-end

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -3,8 +3,6 @@ class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
     @organisation_slug = organisation_slug
   end
 
-private
-
   attr_reader :organisation_slug
 
   def repository

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -1,7 +1,0 @@
-class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
-  def initialize(organisation_slug:)
-    @organisation_slug = organisation_slug
-  end
-
-  attr_reader :organisation_slug
-end

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -5,12 +5,6 @@ class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
 
   attr_reader :organisation_slug
 
-  def repository
-    manual_repository_factory = RepositoryRegistry.create
-      .organisation_scoped_manual_repository_factory
-    manual_repository_factory.call(organisation_slug)
-  end
-
   def associationless_repository
     associationless_manual_repository_factory = RepositoryRegistry.create
       .associationless_organisation_scoped_manual_repository_factory

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -6,16 +6,13 @@ class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
   attr_reader :organisation_slug
 
   def repository
+    manual_repository_factory = RepositoryRegistry.create
+      .organisation_scoped_manual_repository_factory
     manual_repository_factory.call(organisation_slug)
   end
 
   def associationless_repository
     associationless_manual_repository_factory.call(organisation_slug)
-  end
-
-  def manual_repository_factory
-    RepositoryRegistry.create
-      .organisation_scoped_manual_repository_factory
   end
 
   def associationless_manual_repository_factory

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -4,10 +4,4 @@ class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
   end
 
   attr_reader :organisation_slug
-
-  def associationless_repository
-    associationless_manual_repository_factory = RepositoryRegistry.create
-      .associationless_organisation_scoped_manual_repository_factory
-    associationless_manual_repository_factory.call(organisation_slug)
-  end
 end

--- a/app/services/organisational_manual_service_registry.rb
+++ b/app/services/organisational_manual_service_registry.rb
@@ -12,11 +12,8 @@ class OrganisationalManualServiceRegistry < AbstractManualServiceRegistry
   end
 
   def associationless_repository
-    associationless_manual_repository_factory.call(organisation_slug)
-  end
-
-  def associationless_manual_repository_factory
-    RepositoryRegistry.create
+    associationless_manual_repository_factory = RepositoryRegistry.create
       .associationless_organisation_scoped_manual_repository_factory
+    associationless_manual_repository_factory.call(organisation_slug)
   end
 end

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -14,9 +14,10 @@ class PublishManualWorker
     task = ManualPublishTask.find(task_id)
     task.start!
 
+    observers = ManualObserversRegistry.new
     service = PublishManualService.new(
       manual_repository: services.repository,
-      listeners: services.observers.publication,
+      listeners: observers.publication,
       manual_id: task.manual_id,
       version_number: task.version_number,
     )

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -36,11 +36,7 @@ class PublishManualWorker
 private
 
   def repository
-    services.repository
-  end
-
-  def services
-    ManualServiceRegistry.new
+    RepositoryRegistry.create.manual_repository
   end
 
   def requeue_task(manual_id, error)

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -14,7 +14,13 @@ class PublishManualWorker
     task = ManualPublishTask.find(task_id)
     task.start!
 
-    services.publish(task.manual_id, task.version_number).call
+    service = PublishManualService.new(
+      manual_repository: services.repository,
+      listeners: services.observers.publication,
+      manual_id: task.manual_id,
+      version_number: task.version_number,
+    )
+    service.call
 
     task.finish!
   rescue GdsApi::HTTPServerError => error

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -16,7 +16,7 @@ class PublishManualWorker
 
     observers = ManualObserversRegistry.new
     service = PublishManualService.new(
-      manual_repository: services.repository,
+      manual_repository: repository,
       listeners: observers.publication,
       manual_id: task.manual_id,
       version_number: task.version_number,
@@ -34,6 +34,10 @@ class PublishManualWorker
   end
 
 private
+
+  def repository
+    services.repository
+  end
 
   def services
     ManualServiceRegistry.new

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -19,13 +19,13 @@ module ManualHelpers
 
   def create_manual_without_ui(fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
-    manual_services = OrganisationalManualServiceRegistry.new(
-      organisation_slug: organisation_slug,
-    )
+    manual_repository_factory = RepositoryRegistry.create
+      .organisation_scoped_manual_repository_factory
+    repository = manual_repository_factory.call(organisation_slug)
 
     observers = ManualObserversRegistry.new
     service = CreateManualService.new(
-      manual_repository: manual_services.repository,
+      manual_repository: repository,
       manual_builder: ManualBuilder.create,
       listeners: observers.creation,
       attributes: fields.merge(organisation_slug: organisation_slug),
@@ -82,13 +82,13 @@ module ManualHelpers
 
   def edit_manual_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
-    manual_services = OrganisationalManualServiceRegistry.new(
-      organisation_slug: organisation_slug,
-    )
+    manual_repository_factory = RepositoryRegistry.create
+      .organisation_scoped_manual_repository_factory
+    repository = manual_repository_factory.call(organisation_slug)
 
     observers = ManualObserversRegistry.new
     service = UpdateManualService.new(
-      manual_repository: manual_services.repository,
+      manual_repository: repository,
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
       listeners: observers.update,
@@ -175,10 +175,9 @@ module ManualHelpers
   def publish_manual_without_ui(manual, organisation_slug: "ministry-of-tea")
     stub_manual_publication_observers(organisation_slug)
 
-    manual_services = ManualServiceRegistry.new
     observers = ManualObserversRegistry.new
     service = PublishManualService.new(
-      manual_repository: manual_services.repository,
+      manual_repository: RepositoryRegistry.create.manual_repository,
       listeners: observers.publication,
       manual_id: manual.id,
       version_number: manual.version_number,

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -25,7 +25,7 @@ module ManualHelpers
 
     service = CreateManualService.new(
       manual_repository: manual_services.repository,
-      manual_builder: manual_services.manual_builder,
+      manual_builder: ManualBuilder.create,
       listeners: manual_services.observers.creation,
       attributes: fields.merge(organisation_slug: organisation_slug),
     )

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -22,9 +22,14 @@ module ManualHelpers
     manual_services = OrganisationalManualServiceRegistry.new(
       organisation_slug: organisation_slug,
     )
-    manual = manual_services.create(
-      fields.merge(organisation_slug: organisation_slug),
-    ).call
+
+    service = CreateManualService.new(
+      manual_repository: manual_services.repository,
+      manual_builder: manual_services.manual_builder,
+      listeners: manual_services.observers.creation,
+      attributes: fields.merge(organisation_slug: organisation_slug),
+    )
+    manual = service.call
 
     manual_repository.fetch(manual.id)
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -174,7 +174,13 @@ module ManualHelpers
     stub_manual_publication_observers(organisation_slug)
 
     manual_services = ManualServiceRegistry.new
-    manual_services.publish(manual.id, manual.version_number).call
+    service = PublishManualService.new(
+      manual_repository: manual_services.repository,
+      listeners: manual_services.observers.publication,
+      manual_id: manual.id,
+      version_number: manual.version_number,
+    )
+    service.call
   end
 
   def check_manual_exists_with(attributes)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -23,10 +23,11 @@ module ManualHelpers
       organisation_slug: organisation_slug,
     )
 
+    observers = ManualObserversRegistry.new
     service = CreateManualService.new(
       manual_repository: manual_services.repository,
       manual_builder: ManualBuilder.create,
-      listeners: manual_services.observers.creation,
+      listeners: observers.creation,
       attributes: fields.merge(organisation_slug: organisation_slug),
     )
     manual = service.call
@@ -85,11 +86,12 @@ module ManualHelpers
       organisation_slug: organisation_slug,
     )
 
+    observers = ManualObserversRegistry.new
     service = UpdateManualService.new(
       manual_repository: manual_services.repository,
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
-      listeners: manual_services.observers.update,
+      listeners: observers.update,
     )
     manual = service.call
 
@@ -174,9 +176,10 @@ module ManualHelpers
     stub_manual_publication_observers(organisation_slug)
 
     manual_services = ManualServiceRegistry.new
+    observers = ManualObserversRegistry.new
     service = PublishManualService.new(
       manual_repository: manual_services.repository,
-      listeners: manual_services.observers.publication,
+      listeners: observers.publication,
       manual_id: manual.id,
       version_number: manual.version_number,
     )

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -85,10 +85,13 @@ module ManualHelpers
       organisation_slug: organisation_slug,
     )
 
-    manual = manual_services.update(
-      manual.id,
-      fields.merge(organisation_slug: organisation_slug),
-    ).call
+    service = UpdateManualService.new(
+      manual_repository: manual_services.repository,
+      manual_id: manual.id,
+      attributes: fields.merge(organisation_slug: organisation_slug),
+      listeners: manual_services.observers.update,
+    )
+    manual = service.call
 
     manual
   end

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -8,7 +8,13 @@ class ManualWithdrawer
   end
 
   def execute(manual_id)
-    manual = ManualServiceRegistry.new.withdraw(manual_id).call
+    services = ManualServiceRegistry.new
+    service = WithdrawManualService.new(
+      manual_repository: services.repository,
+      listeners: services.observers.withdrawal,
+      manual_id: manual_id,
+    )
+    manual = service.call
 
     if manual.withdrawn?
       logger.info "SUCCESS: Manual `#{manual.slug}` withdrawn"

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -9,9 +9,10 @@ class ManualWithdrawer
 
   def execute(manual_id)
     services = ManualServiceRegistry.new
+    observers = ManualObserversRegistry.new
     service = WithdrawManualService.new(
       manual_repository: services.repository,
-      listeners: services.observers.withdrawal,
+      listeners: observers.withdrawal,
       manual_id: manual_id,
     )
     manual = service.call

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -1,5 +1,3 @@
-require "manual_service_registry"
-
 class ManualWithdrawer
   attr_reader :logger
 
@@ -8,10 +6,9 @@ class ManualWithdrawer
   end
 
   def execute(manual_id)
-    services = ManualServiceRegistry.new
     observers = ManualObserversRegistry.new
     service = WithdrawManualService.new(
-      manual_repository: services.repository,
+      manual_repository: RepositoryRegistry.create.manual_repository,
       listeners: observers.withdrawal,
       manual_id: manual_id,
     )

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -1,4 +1,3 @@
-require "manual_service_registry"
 require "marshallers/document_association_marshaller"
 
 class ManualsRepublisher

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -17,10 +17,10 @@ class ManualsRepublisher
     manual_records.to_a.each.with_index do |manual_record, i|
       begin
         logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
-        services = ManualServiceRegistry.new
+        observers = ManualObserversRegistry.new
         service = RepublishManualService.new(
-          draft_listeners: services.observers.update,
-          published_listeners: services.observers.republication,
+          draft_listeners: observers.update,
+          published_listeners: observers.republication,
           manual_id: manual_record.manual_id,
         )
         service.call

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -17,7 +17,13 @@ class ManualsRepublisher
     manual_records.to_a.each.with_index do |manual_record, i|
       begin
         logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
-        ManualServiceRegistry.new.republish(manual_record.manual_id).call
+        services = ManualServiceRegistry.new
+        service = RepublishManualService.new(
+          draft_listeners: services.observers.update,
+          published_listeners: services.observers.republication,
+          manual_id: manual_record.manual_id,
+        )
+        service.call
       rescue DocumentAssociationMarshaller::RemovedDocumentIdNotFoundError => e
         logger.error("Did not publish manual with id=#{manual_record.manual_id} slug=#{manual_record.slug}. It has at least one removed document which was not found: #{e.message}")
         next

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -111,10 +111,9 @@ private
   end
 
   def publish_manual
-    services = ManualServiceRegistry.new
     observers = ManualObserversRegistry.new
     service = PublishManualService.new(
-      manual_repository: services.repository,
+      manual_repository: RepositoryRegistry.create.manual_repository,
       listeners: observers.publication,
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -112,9 +112,10 @@ private
 
   def publish_manual
     services = ManualServiceRegistry.new
+    observers = ManualObserversRegistry.new
     service = PublishManualService.new(
       manual_repository: services.repository,
-      listeners: services.observers.publication,
+      listeners: observers.publication,
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,
     )

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -111,7 +111,14 @@ private
   end
 
   def publish_manual
-    ManualServiceRegistry.new.publish(manual_record.manual_id, manual_version_number).call
+    services = ManualServiceRegistry.new
+    service = PublishManualService.new(
+      manual_repository: services.repository,
+      listeners: services.observers.publication,
+      manual_id: manual_record.manual_id,
+      version_number: manual_version_number,
+    )
+    service.call
   end
 
   def manual_record

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -4,11 +4,11 @@ describe ManualsController, type: :controller do
   describe "#publish" do
     context "when the user lacks permission to publish" do
       let(:manual_id) { "manual-1" }
-      let(:services) { spy(AbstractManualServiceRegistry) }
+      let(:service) { spy(PublishManualService) }
       before do
         login_as_stub_user
         allow_any_instance_of(PermissionChecker).to receive(:can_publish?).and_return(false)
-        allow(controller).to receive(:services).and_return services
+        allow(PublishManualService).to receive(:new).and_return(service)
         post :publish, id: manual_id
       end
 
@@ -25,7 +25,7 @@ describe ManualsController, type: :controller do
       end
 
       it "does not publish the manual" do
-        expect(services).not_to have_received(:publish)
+        expect(service).not_to have_received(:call)
       end
 
       it "sets the authenticated user header" do


### PR DESCRIPTION
This is similar to #865 & #872, but for the `ManualsController` instead of the `SectionAttachmentsController` or `SectionsController`. The overall aim is to reduce the levels of indirection in the code to make it easier to follow. In some cases, this means temporarily introducing duplication, but we're confident that in the long run this will make it easier to identify better abstractions to remove that duplication.

The net effect is to inline most of the methods from `AbstractManualServiceRegistry` and its two sub-classes, `ManualServiceRegistry` & `OrganisationalManualServiceRegistry` into `ManualsController`.

I've tried hard to break the overall refactoring down into small steps to give as much confidence as possible that I haven't broken anything; the tests all pass after every commit.

Note that I improved the test coverage of a couple of scripts in #877 in order to give me more confidence I hadn't broken them in this PR. Although I've also applied the refactorings to `SectionReslugger`, this class is not tested. However, since the script which uses this class is already broken (see #851), I think this is OK.
