### PR TITLE
Remove params from PublishingAPIWithdrawer

### DIFF
--- a/app/exporters/publishing_api_withdrawer.rb
+++ b/app/exporters/publishing_api_withdrawer.rb
@@ -1,17 +1,15 @@
 class PublishingAPIWithdrawer
   def initialize(entity:)
-    @publishing_api = Services.publishing_api_v2
     @entity = entity
   end
 
   def call
-    publishing_api.unpublish(content_id, exportable_attributes)
+    Services.publishing_api_v2.unpublish(content_id, exportable_attributes)
   end
 
 private
 
   attr_reader(
-    :publishing_api,
     :entity,
   )
 

--- a/app/exporters/publishing_api_withdrawer.rb
+++ b/app/exporters/publishing_api_withdrawer.rb
@@ -1,6 +1,6 @@
 class PublishingAPIWithdrawer
-  def initialize(publishing_api:, entity:)
-    @publishing_api = publishing_api
+  def initialize(entity:)
+    @publishing_api = Services.publishing_api_v2
     @entity = entity
   end
 

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -188,13 +188,11 @@ private
   def publishing_api_withdrawer
     ->(manual, _ = nil) {
       PublishingAPIWithdrawer.new(
-        publishing_api: publishing_api_v2,
         entity: manual,
       ).call
 
       manual.documents.each do |document|
         PublishingAPIWithdrawer.new(
-          publishing_api: publishing_api_v2,
           entity: document,
         ).call
       end

--- a/spec/exporters/publishing_api_withdrawer_spec.rb
+++ b/spec/exporters/publishing_api_withdrawer_spec.rb
@@ -4,7 +4,8 @@ describe PublishingAPIWithdrawer do
   it 'unpublishes the entity' do
     publishing_api = double(:publishing_api, unpublish: nil)
     entity = double(:entity, id: 'content-id')
-    withdrawer = PublishingAPIWithdrawer.new(publishing_api: publishing_api, entity: entity)
+    withdrawer = PublishingAPIWithdrawer.new(entity: entity)
+    allow(withdrawer).to receive(:publishing_api).and_return(publishing_api)
 
     withdrawer.call
 

--- a/spec/exporters/publishing_api_withdrawer_spec.rb
+++ b/spec/exporters/publishing_api_withdrawer_spec.rb
@@ -5,7 +5,7 @@ describe PublishingAPIWithdrawer do
     publishing_api = double(:publishing_api, unpublish: nil)
     entity = double(:entity, id: 'content-id')
     withdrawer = PublishingAPIWithdrawer.new(entity: entity)
-    allow(withdrawer).to receive(:publishing_api).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
 
     withdrawer.call
 

--- a/spec/exporters/publishing_api_withdrawer_spec.rb
+++ b/spec/exporters/publishing_api_withdrawer_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe PublishingAPIWithdrawer do
+  it 'unpublishes the entity' do
+    publishing_api = double(:publishing_api, unpublish: nil)
+    entity = double(:entity, id: 'content-id')
+    withdrawer = PublishingAPIWithdrawer.new(publishing_api: publishing_api, entity: entity)
+
+    withdrawer.call
+
+    expect(publishing_api).to have_received(:unpublish).with('content-id', type: 'gone')
+  end
+end


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `PublishingAPIWithdrawer` with different `publishing_api`s. Constructing it in the class makes this more explicit.

This is similar to the changes in PR #880.
