### PR TITLE
[WIP] Inline listeners in services

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -154,10 +154,6 @@ class SectionsController < ApplicationController
     service = RemoveSectionService.new(
       manual_repository,
       self,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionDiscarder.new
-      ]
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -126,7 +126,6 @@ class SectionsController < ApplicationController
     service = ReorderSectionsService.new(
       manual_repository,
       self,
-      listeners: [PublishingApiDraftManualExporter.new]
     )
     manual, _sections = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -39,10 +39,6 @@ class SectionsController < ApplicationController
   def create
     service = CreateSectionService.new(
       manual_repository: manual_repository,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -70,10 +70,6 @@ class SectionsController < ApplicationController
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
       context: self,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
     )
     manual, section = service.call
 

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,5 +1,5 @@
 class PublishingApiDraftManualExporter
-  def call(_, manual)
+  def call(manual)
     ManualPublishingAPILinksExporter.new(
       OrganisationFetcher.instance.call(manual.attributes.fetch(:organisation_slug)),
       manual

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -32,7 +32,7 @@ private
   end
 
   def call_publishing_api_draft_manual_exporter
-    PublishingApiDraftManualExporter.new.call(new_document, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 
   def document_params

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -1,10 +1,6 @@
 class CreateSectionService
   def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
-    @listeners = [
-      PublishingApiDraftManualExporter.new,
-      PublishingApiDraftSectionExporter.new
-    ]
     @context = context
   end
 
@@ -14,7 +10,8 @@ class CreateSectionService
     if new_document.valid?
       manual.draft
       manual_repository.store(manual)
-      notify_listeners
+      call_publishing_api_draft_manual_exporter
+      call_publishing_api_draft_section_exporter
     end
 
     [manual, new_document]
@@ -30,10 +27,12 @@ private
     @manual ||= manual_repository.fetch(context.params.fetch("manual_id"))
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(new_document, manual)
-    end
+  def call_publishing_api_draft_section_exporter
+    PublishingApiDraftSectionExporter.new.call(new_document, manual)
+  end
+
+  def call_publishing_api_draft_manual_exporter
+    PublishingApiDraftManualExporter.new.call(new_document, manual)
   end
 
   def document_params

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -1,7 +1,10 @@
 class CreateSectionService
-  def initialize(manual_repository:, listeners:, context:)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
-    @listeners = listeners
+    @listeners = [
+      PublishingApiDraftManualExporter.new,
+      PublishingApiDraftSectionExporter.new
+    ]
     @context = context
   end
 

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -1,8 +1,11 @@
 class RemoveSectionService
-  def initialize(manual_repository, context, listeners:)
+  def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = listeners
+    @listeners = [
+      PublishingApiDraftManualExporter.new,
+      PublishingApiDraftSectionDiscarder.new
+    ]
   end
 
   def call

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -65,7 +65,7 @@ private
   end
 
   def call_publishing_api_draft_manual_exporter
-    PublishingApiDraftManualExporter.new.call(document, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 
   class ManualNotFoundError < StandardError; end

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -2,10 +2,6 @@ class RemoveSectionService
   def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = [
-      PublishingApiDraftManualExporter.new,
-      PublishingApiDraftSectionDiscarder.new
-    ]
   end
 
   def call
@@ -19,7 +15,8 @@ class RemoveSectionService
 
       remove
       persist
-      notify_listeners
+      call_publishing_api_draft_manual_exporter
+      call_publishing_api_draft_section_discarder
     end
 
     [manual, document]
@@ -63,10 +60,12 @@ private
     }
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(document, manual)
-    end
+  def call_publishing_api_draft_section_discarder
+    PublishingApiDraftSectionDiscarder.new.call(document, manual)
+  end
+
+  def call_publishing_api_draft_manual_exporter
+    PublishingApiDraftManualExporter.new.call(document, manual)
   end
 
   class ManualNotFoundError < StandardError; end

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -42,6 +42,6 @@ private
   end
 
   def call_publishing_api_draft_manual_exporter
-    PublishingApiDraftManualExporter.new.call(nil, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 end

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -2,14 +2,13 @@ class ReorderSectionsService
   def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = [PublishingApiDraftManualExporter.new]
   end
 
   def call
     manual.draft
     update
     persist
-    notify_listeners
+    call_publishing_api_draft_manual_exporter
 
     [manual, documents]
   end
@@ -42,9 +41,7 @@ private
     context.params.fetch("section_order")
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(nil, manual)
-    end
+  def call_publishing_api_draft_manual_exporter
+    PublishingApiDraftManualExporter.new.call(nil, manual)
   end
 end

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -1,8 +1,8 @@
 class ReorderSectionsService
-  def initialize(manual_repository, context, listeners:)
+  def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = listeners
+    @listeners = [PublishingApiDraftManualExporter.new]
   end
 
   def call

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -1,8 +1,11 @@
 class UpdateSectionService
-  def initialize(manual_repository:, context:, listeners:)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
-    @listeners = listeners
+    @listeners = [
+      PublishingApiDraftManualExporter.new,
+      PublishingApiDraftSectionExporter.new
+    ]
   end
 
   def call

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -46,6 +46,6 @@ private
   end
 
   def call_publishing_api_draft_manual_exporter
-    PublishingApiDraftManualExporter.new.call(document, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 end

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -2,10 +2,6 @@ class UpdateSectionService
   def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
-    @listeners = [
-      PublishingApiDraftManualExporter.new,
-      PublishingApiDraftSectionExporter.new
-    ]
   end
 
   def call
@@ -14,7 +10,8 @@ class UpdateSectionService
     if document.valid?
       manual.draft
       manual_repository.store(manual)
-      notify_listeners
+      call_publishing_api_draft_manual_exporter
+      call_publishing_api_draft_section_exporter
     end
 
     [manual, document]
@@ -44,9 +41,11 @@ private
     context.params.fetch("section")
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(document, manual)
-    end
+  def call_publishing_api_draft_section_exporter
+    PublishingApiDraftSectionExporter.new.call(document, manual)
+  end
+
+  def call_publishing_api_draft_manual_exporter
+    PublishingApiDraftManualExporter.new.call(document, manual)
   end
 end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -54,10 +54,6 @@ module ManualHelpers
 
     service = CreateSectionService.new(
       manual_repository: organisational_manual_repository,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
       context: create_service_context,
     )
     _, document = service.call

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -111,10 +111,6 @@ module ManualHelpers
     service = UpdateSectionService.new(
       manual_repository: organisational_manual_repository,
       context: service_context,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
     )
     _, document = service.call
 

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -80,10 +80,6 @@ private
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
       context: context_for_section_edition_update,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
     )
     _manual, document = service.call
     document.latest_edition

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -31,15 +31,19 @@ RSpec.describe RemoveSectionService do
     )
   }
 
-  let(:listener) { spy(call: nil) }
-
   let(:service) {
     described_class.new(
       repository,
       service_context,
-      listeners: [listener],
     )
   }
+  let(:discarder) { spy(PublishingApiDraftSectionDiscarder) }
+  let(:exporter) { spy(PublishingApiDraftManualExporter) }
+
+  before do
+    allow(PublishingApiDraftManualExporter).to receive(:new).and_return(exporter)
+    allow(PublishingApiDraftSectionDiscarder).to receive(:new).and_return(discarder)
+  end
 
   context "with a document id that doesn't belong to the manual" do
     let(:document) {
@@ -70,9 +74,14 @@ RSpec.describe RemoveSectionService do
       expect(manual).not_to have_received(:draft)
     end
 
-    it "does not notifies its listeners" do
+    it "does not publish a manual" do
       begin; service.call; rescue; end
-      expect(listener).not_to have_received(:call)
+      expect(exporter).not_to have_received(:call)
+    end
+
+    it "does not discard a section" do
+      begin; service.call; rescue; end
+      expect(discarder).not_to have_received(:call)
     end
   end
 
@@ -112,8 +121,12 @@ RSpec.describe RemoveSectionService do
       expect(repository).not_to have_received(:store).with(manual)
     end
 
-    it "does not notify its listeners" do
-      expect(listener).not_to have_received(:call).with(document, manual)
+    it "does not publish a manual" do
+      expect(exporter).not_to have_received(:call)
+    end
+
+    it "does not discard a section" do
+      expect(discarder).not_to have_received(:call)
     end
   end
 
@@ -155,8 +168,12 @@ RSpec.describe RemoveSectionService do
         expect(repository).to have_received(:store).with(manual)
       end
 
-      it "notifies its listeners" do
-        expect(listener).to have_received(:call).with(document, manual)
+      it "publishes a manual" do
+        expect(exporter).to have_received(:call).with(document, manual)
+      end
+
+      it "discards a section" do
+        expect(discarder).to have_received(:call).with(document, manual)
       end
     end
 
@@ -191,8 +208,12 @@ RSpec.describe RemoveSectionService do
         expect(repository).to have_received(:store).with(manual)
       end
 
-      it "notifies its listeners" do
-        expect(listener).to have_received(:call).with(document, manual)
+      it "publishes a manual" do
+        expect(exporter).to have_received(:call).with(document, manual)
+      end
+
+      it "discards a section" do
+        expect(discarder).to have_received(:call).with(document, manual)
       end
     end
 

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "publishes a manual" do
-        expect(exporter).to have_received(:call).with(document, manual)
+        expect(exporter).to have_received(:call).with(manual)
       end
 
       it "discards a section" do
@@ -209,7 +209,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "publishes a manual" do
-        expect(exporter).to have_received(:call).with(document, manual)
+        expect(exporter).to have_received(:call).with(manual)
       end
 
       it "discards a section" do


### PR DESCRIPTION
I'm looking at inlining the `listeners` that are injected into the various `Service` classes used in the controller actions. In all cases I've looked at so far, the listeners that are injected are always the same so it feels like this change helps to remove some indirection. 

It does make the unit testing (where it exists) slightly more verbose as we cannot inject a stub listener and assert that methods are called on it. On the other hand, this at least makes it obvious that calling a service results in calls being made to the API. 

What do you think @chrisroos @floehopper ?