### PR TITLE
Remove params from RepositoryRegistry

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -232,9 +232,9 @@ private
 
   def repository
     if current_user_is_gds_editor?
-      RepositoryRegistry.create.manual_repository
+      RepositoryRegistry.new.manual_repository
     else
-      manual_repository_factory = RepositoryRegistry.create
+      manual_repository_factory = RepositoryRegistry.new
         .organisation_scoped_manual_repository_factory
       manual_repository_factory.call(current_organisation_slug)
     end
@@ -242,10 +242,10 @@ private
 
   def associationless_repository
     if current_user_is_gds_editor?
-      RepositoryRegistry.create
+      RepositoryRegistry.new
         .associationless_manual_repository
     else
-      associationless_manual_repository_factory = RepositoryRegistry.create
+      associationless_manual_repository_factory = RepositoryRegistry.new
         .associationless_organisation_scoped_manual_repository_factory
       associationless_manual_repository_factory.call(current_organisation_slug)
     end

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -73,11 +73,11 @@ private
   end
 
   def gds_editor_repository
-    RepositoryRegistry.create.manual_repository
+    RepositoryRegistry.new.manual_repository
   end
 
   def organisational_repository
-    manual_repository_factory = RepositoryRegistry.create
+    manual_repository_factory = RepositoryRegistry.new
       .organisation_scoped_manual_repository_factory
     manual_repository_factory.call(current_organisation_slug)
   end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -176,9 +176,9 @@ private
 
   def manual_repository
     if current_user_is_gds_editor?
-      RepositoryRegistry.create.manual_repository
+      RepositoryRegistry.new.manual_repository
     else
-      manual_repository_factory = RepositoryRegistry.create.
+      manual_repository_factory = RepositoryRegistry.new.
         organisation_scoped_manual_repository_factory
       manual_repository_factory.call(current_organisation_slug)
     end

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -2,7 +2,7 @@ require "securerandom"
 
 class SectionBuilder
   def self.create
-    DocumentFactoryRegistry.validatable_document_factories.section_builder
+    DocumentFactoryRegistry.new.section_builder
   end
 
   def initialize(factory_factory:)

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -9,10 +9,6 @@ require "slug_generator"
 require "section"
 
 class DocumentFactoryRegistry
-  def self.validatable_document_factories
-    new
-  end
-
   def manual_with_documents
     ->(manual, attrs) {
       ManualValidator.new(

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -10,7 +10,7 @@ require "manual_record"
 
 class RepositoryRegistry
   def initialize
-    @entity_factories = DocumentFactoryRegistry.validatable_document_factories
+    @entity_factories = DocumentFactoryRegistry.new
   end
 
   def organisation_scoped_manual_repository_factory

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -8,16 +8,13 @@ require "manual_with_publish_tasks"
 require "manual"
 require "manual_record"
 
-
 class RepositoryRegistry
   def self.create
-    RepositoryRegistry.new(
-      entity_factories: DocumentFactoryRegistry.validatable_document_factories,
-    )
+    RepositoryRegistry.new
   end
 
-  def initialize(entity_factories:)
-    @entity_factories = entity_factories
+  def initialize
+    @entity_factories = DocumentFactoryRegistry.validatable_document_factories
   end
 
   def organisation_scoped_manual_repository_factory

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -9,10 +9,6 @@ require "manual"
 require "manual_record"
 
 class RepositoryRegistry
-  def self.create
-    RepositoryRegistry.new
-  end
-
   def initialize
     @entity_factories = DocumentFactoryRegistry.validatable_document_factories
   end

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -9,10 +9,6 @@ require "manual"
 require "manual_record"
 
 class RepositoryRegistry
-  def initialize
-    @entity_factories = DocumentFactoryRegistry.new
-  end
-
   def organisation_scoped_manual_repository_factory
     ->(organisation_slug) {
       scoped_manual_repository(
@@ -31,7 +27,7 @@ class RepositoryRegistry
         DocumentAssociationMarshaller.new(
           section_repository_factory: section_repository_factory,
           decorator: ->(manual, attrs) {
-            entity_factories.manual_with_documents.call(manual, attrs)
+            DocumentFactoryRegistry.new.manual_with_documents.call(manual, attrs)
           }
         ),
         ManualPublishTaskAssociationMarshaller.new(
@@ -50,7 +46,7 @@ class RepositoryRegistry
 
   def section_repository_factory
     ->(manual) {
-      section_factory = entity_factories.section_factory_factory.call(manual)
+      section_factory = DocumentFactoryRegistry.new.section_factory_factory.call(manual)
 
       SectionRepository.new(
         section_factory: section_factory,
@@ -75,8 +71,4 @@ class RepositoryRegistry
       )
     }
   end
-
-private
-
-  attr_reader :entity_factories
 end

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -34,7 +34,7 @@ class PublishManualWorker
 private
 
   def repository
-    RepositoryRegistry.create.manual_repository
+    RepositoryRegistry.new.manual_repository
   end
 
   def requeue_task(manual_id, error)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -5,7 +5,7 @@ require "manual_withdrawer"
 
 module ManualHelpers
   def manual_repository
-    RepositoryRegistry.create.manual_repository
+    RepositoryRegistry.new.manual_repository
   end
 
   def create_manual(fields, save: true)
@@ -19,7 +19,7 @@ module ManualHelpers
 
   def create_manual_without_ui(fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
-    manual_repository_factory = RepositoryRegistry.create
+    manual_repository_factory = RepositoryRegistry.new
       .organisation_scoped_manual_repository_factory
     repository = manual_repository_factory.call(organisation_slug)
 
@@ -45,7 +45,7 @@ module ManualHelpers
   end
 
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
-    manual_repository_factory = RepositoryRegistry.create.
+    manual_repository_factory = RepositoryRegistry.new.
       organisation_scoped_manual_repository_factory
     organisational_manual_repository = manual_repository_factory.call(organisation_slug)
 
@@ -76,7 +76,7 @@ module ManualHelpers
 
   def edit_manual_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
-    manual_repository_factory = RepositoryRegistry.create
+    manual_repository_factory = RepositoryRegistry.new
       .organisation_scoped_manual_repository_factory
     repository = manual_repository_factory.call(organisation_slug)
 
@@ -102,7 +102,7 @@ module ManualHelpers
   end
 
   def edit_section_without_ui(manual, document, fields, organisation_slug: "ministry-of-tea")
-    manual_repository_factory = RepositoryRegistry.create.
+    manual_repository_factory = RepositoryRegistry.new.
       organisation_scoped_manual_repository_factory
     organisational_manual_repository = manual_repository_factory.call(organisation_slug)
 
@@ -164,7 +164,7 @@ module ManualHelpers
     stub_manual_publication_observers(organisation_slug)
 
     service = PublishManualService.new(
-      manual_repository: RepositoryRegistry.create.manual_repository,
+      manual_repository: RepositoryRegistry.new.manual_repository,
       manual_id: manual.id,
       version_number: manual.version_number,
     )
@@ -256,7 +256,7 @@ module ManualHelpers
   end
 
   def section_repository(manual)
-    RepositoryRegistry.create.section_repository_factory.call(manual)
+    RepositoryRegistry.new.section_repository_factory.call(manual)
   end
 
   def check_section_is_archived_in_db(manual, document_id)
@@ -540,7 +540,7 @@ module ManualHelpers
   end
 
   def most_recently_created_manual
-    RepositoryRegistry.create.manual_repository.all.first
+    RepositoryRegistry.new.manual_repository.all.first
   end
 
   def document_fields(document)

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -8,7 +8,7 @@ class ManualWithdrawer
   def execute(manual_id)
     observers = ManualObserversRegistry.new
     service = WithdrawManualService.new(
-      manual_repository: RepositoryRegistry.create.manual_repository,
+      manual_repository: RepositoryRegistry.new.manual_repository,
       listeners: observers.withdrawal,
       manual_id: manual_id,
     )

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -76,7 +76,7 @@ private
   end
 
   def new_edition_for_slug_change
-    manual_repository = RepositoryRegistry.create.manual_repository
+    manual_repository = RepositoryRegistry.new.manual_repository
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
       context: context_for_section_edition_update,
@@ -109,7 +109,7 @@ private
   def publish_manual
     observers = ManualObserversRegistry.new
     service = PublishManualService.new(
-      manual_repository: RepositoryRegistry.create.manual_repository,
+      manual_repository: RepositoryRegistry.new.manual_repository,
       listeners: observers.publication,
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,
@@ -126,7 +126,7 @@ private
   end
 
   def manual_repository
-    RepositoryRegistry.create.manual_repository
+    RepositoryRegistry.new.manual_repository
   end
 
   def current_section_edition

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishing manuals", type: :feature do
   let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
 
   def manual_repository
-    RepositoryRegistry.create.manual_repository
+    RepositoryRegistry.new.manual_repository
   end
 
   describe "publishing a manual with major and minor updates" do

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Republishing manuals", type: :feature do
   end
 
   def manual_repository
-    RepositoryRegistry.create.manual_repository
+    RepositoryRegistry.new.manual_repository
   end
 
   describe "republishing a published manual with sections" do


### PR DESCRIPTION
We weren't using the flexibility of being able to construct a `RepositoryRegistry` with different `entity_factories`s. Constructing it in the class makes this more explicit.

This is similar to the changes in PR #880.
