### PR TITLE
Extract SectionFactory

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -86,7 +86,7 @@ class SectionsController < ApplicationController
   def preview
     service = PreviewSectionService.new(
       manual_repository,
-      SectionBuilder.create,
+      SectionBuilder.new,
       SectionRenderer.new,
       self,
     )

--- a/app/lib/section_factory.rb
+++ b/app/lib/section_factory.rb
@@ -1,0 +1,19 @@
+class SectionFactory
+  def initialize(manual)
+    @manual = manual
+  end
+
+  def call(id, editions)
+    slug_generator = SlugGenerator.new(prefix: @manual.slug)
+
+    ChangeNoteValidator.new(
+      SectionValidator.new(
+        Section.new(
+          slug_generator,
+          id,
+          editions,
+        ),
+      )
+    )
+  end
+end

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -2,11 +2,11 @@ require "securerandom"
 
 class SectionBuilder
   def self.create
-    SectionBuilder.new(factory_factory: DocumentFactoryRegistry.new.section_factory_factory)
+    SectionBuilder.new
   end
 
-  def initialize(factory_factory:)
-    @factory_factory = factory_factory
+  def initialize
+    @factory_factory = DocumentFactoryRegistry.new.section_factory_factory
   end
 
   def call(manual, attrs)

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -3,9 +3,8 @@ require "securerandom"
 class SectionBuilder
   def call(manual, attrs)
     factory_factory = DocumentFactoryRegistry.new.section_factory_factory
-    document = factory_factory
-      .call(manual)
-      .call(SecureRandom.uuid, [])
+    section_factory = factory_factory.call(manual)
+    document = section_factory.call(SecureRandom.uuid, [])
 
     document.update(attrs.reverse_merge(defaults))
 

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -1,12 +1,9 @@
 require "securerandom"
 
 class SectionBuilder
-  def initialize
-    @factory_factory = DocumentFactoryRegistry.new.section_factory_factory
-  end
-
   def call(manual, attrs)
-    document = @factory_factory
+    factory_factory = DocumentFactoryRegistry.new.section_factory_factory
+    document = factory_factory
       .call(manual)
       .call(SecureRandom.uuid, [])
 

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -2,7 +2,7 @@ require "securerandom"
 
 class SectionBuilder
   def self.create
-    DocumentFactoryRegistry.new.section_builder
+    SectionBuilder.new(factory_factory: DocumentFactoryRegistry.new.section_factory_factory)
   end
 
   def initialize(factory_factory:)

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -1,10 +1,6 @@
 require "securerandom"
 
 class SectionBuilder
-  def self.create
-    SectionBuilder.new
-  end
-
   def initialize
     @factory_factory = DocumentFactoryRegistry.new.section_factory_factory
   end

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -2,8 +2,7 @@ require "securerandom"
 
 class SectionBuilder
   def call(manual, attrs)
-    factory_factory = DocumentFactoryRegistry.new.section_factory_factory
-    section_factory = factory_factory.call(manual)
+    section_factory = SectionFactory.new(manual)
     document = section_factory.call(SecureRandom.uuid, [])
 
     document.update(attrs.reverse_merge(defaults))

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -14,7 +14,7 @@ class DocumentFactoryRegistry
       ManualValidator.new(
         NullValidator.new(
           ManualWithDocuments.new(
-            SectionBuilder.create,
+            SectionBuilder.new,
             manual,
             attrs,
           )

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -24,7 +24,7 @@ class DocumentFactoryRegistry
   end
 
   def section_builder
-    SectionBuilder.new(factory_factory: section_factory_factory)
+    SectionBuilder.create
   end
 
   def section_factory_factory

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -14,17 +14,13 @@ class DocumentFactoryRegistry
       ManualValidator.new(
         NullValidator.new(
           ManualWithDocuments.new(
-            section_builder,
+            SectionBuilder.create,
             manual,
             attrs,
           )
         )
       )
     }
-  end
-
-  def section_builder
-    SectionBuilder.create
   end
 
   def section_factory_factory

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -22,10 +22,4 @@ class DocumentFactoryRegistry
       )
     }
   end
-
-  def section_factory_factory
-    ->(manual) {
-      SectionFactory.new(manual)
-    }
-  end
 end

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -25,19 +25,7 @@ class DocumentFactoryRegistry
 
   def section_factory_factory
     ->(manual) {
-      ->(id, editions) {
-        slug_generator = SlugGenerator.new(prefix: manual.slug)
-
-        ChangeNoteValidator.new(
-          SectionValidator.new(
-            Section.new(
-              slug_generator,
-              id,
-              editions,
-            ),
-          )
-        )
-      }
+      SectionFactory.new(manual)
     }
   end
 end

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -3,7 +3,7 @@ require "delegate"
 class ManualWithDocuments < SimpleDelegator
   def self.create(attrs)
     ManualWithDocuments.new(
-      SectionBuilder.create,
+      SectionBuilder.new,
       Manual.new(attrs),
       documents: [],
     )

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -46,7 +46,7 @@ class RepositoryRegistry
 
   def section_repository_factory
     ->(manual) {
-      section_factory = DocumentFactoryRegistry.new.section_factory_factory.call(manual)
+      section_factory = SectionFactory.new(manual)
 
       SectionRepository.new(
         section_factory: section_factory,


### PR DESCRIPTION
This allows me to remove the `DocumentFactoryRegistry#section_factory_factory` and, in my opinion, leaves the code in a more understandable state.
