### PR TITLE
Rename SectionEdition's database collection from specialist_document_editions to manual_section_editions

### DIFF
--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -4,7 +4,7 @@ class SectionEdition
   include Mongoid::Document
   include Mongoid::Timestamps
 
-  store_in "specialist_document_editions"
+  store_in "manual_section_editions"
 
   field :document_id,          type: String
   field :version_number,       type: Integer, default: 1

--- a/db/migrate/20170320160403_rename_specialist_document_editions_collection_to_section_editions.rb
+++ b/db/migrate/20170320160403_rename_specialist_document_editions_collection_to_section_editions.rb
@@ -1,0 +1,21 @@
+class RenameSpecialistDocumentEditionsCollectionToSectionEditions < Mongoid::Migration
+  def self.up
+    rename_collection('specialist_document_editions', 'manual_section_editions')
+  end
+
+  def self.down
+    rename_collection('manual_section_editions', 'specialist_document_editions')
+  end
+
+  def self.rename_collection(source, target)
+    db = Mongoid.database
+    if db.collection_names.include?(target)
+      if db.collection(target).count == 0
+        db.drop_collection(target)
+      else
+        raise "Unexpected non-empty collection: #{target}"
+      end
+    end
+    db.rename_collection(source, target)
+  end
+end

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SectionEdition do
   subject { SectionEdition.new }
 
-  it 'stores data in the specialist_document_editions collection' do
-    expect(subject.collection.name).to eq('specialist_document_editions')
+  it 'stores data in the manual_section_editions collection' do
+    expect(subject.collection.name).to eq('manual_section_editions')
   end
 end


### PR DESCRIPTION
* The new name more closely matches the model class name and removes one of the last vestiges of specialist documents in the app.

* I've prefixed the new collection name with "manual" rather than just using "section_editions", because it turns out that this app is sharing a database with a number of other apps, e.g. Publisher, and I felt as if "section_editions" was too generic and might lead to confusion.

* I've used methods on `Mongoid::DB` rather than `ActiveRecord::ConnectionAdapters::SchemaStatements#rename_table`, because of an incompatibility (see #896) between `mongoid_rails_migrations` and the version of `mongoid` we are using which results in the following exception:

```
NoMethodError: undefined method `default_session' for Mongoid:Module
```

* I've had to include code to drop the target collection if it exists and is empty before doing the rename, because it appears that something (presumably Mongoid) is creating the collection on application startup based on the existence of the `SectionEdition` class and its call to `store_in` with the new collection name. This means that an empty `manual_section_editions` collection is created before the migration is run and if we didn't drop the collection, the rename would fail. I'm only doing this if the collection is empty, on the off-chance that the collection really exists and contains some important data.

Closes #848.