### PR TITLE
Inline listeners in services

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -109,7 +109,6 @@ class ManualsController < ApplicationController
       manual_repository: repository,
       manual_id: manual_id,
       attributes: publication_date_manual_params,
-      listeners: ManualObserversRegistry.new.update_original_publication_date,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -52,7 +52,6 @@ class ManualsController < ApplicationController
     service = CreateManualService.new(
       manual_repository: repository,
       manual_builder: ManualBuilder.create,
-      listeners: ManualObserversRegistry.new.creation,
       attributes: create_manual_params,
     )
     manual = service.call

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -81,7 +81,6 @@ class ManualsController < ApplicationController
       manual_repository: repository,
       manual_id: manual_id,
       attributes: update_manual_params,
-      listeners: ManualObserversRegistry.new.update,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -154,10 +154,6 @@ class SectionsController < ApplicationController
     service = RemoveSectionService.new(
       manual_repository,
       self,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionDiscarder.new
-      ]
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -126,7 +126,6 @@ class SectionsController < ApplicationController
     service = ReorderSectionsService.new(
       manual_repository,
       self,
-      listeners: [PublishingApiDraftManualExporter.new]
     )
     manual, _sections = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -39,10 +39,6 @@ class SectionsController < ApplicationController
   def create
     service = CreateSectionService.new(
       manual_repository: manual_repository,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -70,10 +70,6 @@ class SectionsController < ApplicationController
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
       context: self,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
     )
     manual, section = service.call
 

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,5 +1,5 @@
 class PublishingApiDraftManualExporter
-  def call(_, manual)
+  def call(manual)
     ManualPublishingAPILinksExporter.new(
       OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
       manual

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -1,8 +1,8 @@
 class CreateManualService
-  def initialize(manual_repository:, manual_builder:, listeners:, attributes:)
+  def initialize(manual_repository:, manual_builder:, attributes:)
     @manual_repository = manual_repository
     @manual_builder = manual_builder
-    @listeners = listeners
+    @listeners = ManualObserversRegistry.new.creation
     @attributes = attributes
   end
 

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -1,10 +1,6 @@
 class CreateSectionService
   def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
-    @listeners = [
-      PublishingApiDraftManualExporter.new,
-      PublishingApiDraftSectionExporter.new
-    ]
     @context = context
   end
 
@@ -14,7 +10,8 @@ class CreateSectionService
     if new_document.valid?
       manual.draft
       manual_repository.store(manual)
-      notify_listeners
+      export_draft_manual_to_publishing_api
+      export_draft_section_to_publishing_api
     end
 
     [manual, new_document]
@@ -22,7 +19,7 @@ class CreateSectionService
 
 private
 
-  attr_reader :manual_repository, :listeners, :context
+  attr_reader :manual_repository, :context
 
   attr_reader :new_document
 
@@ -30,10 +27,12 @@ private
     @manual ||= manual_repository.fetch(context.params.fetch("manual_id"))
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(new_document, manual)
-    end
+  def export_draft_manual_to_publishing_api
+    PublishingApiDraftManualExporter.new.call(new_document, manual)
+  end
+
+  def export_draft_section_to_publishing_api
+    PublishingApiDraftSectionExporter.new.call(new_document, manual)
   end
 
   def document_params

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -1,7 +1,10 @@
 class CreateSectionService
-  def initialize(manual_repository:, listeners:, context:)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
-    @listeners = listeners
+    @listeners = [
+      PublishingApiDraftManualExporter.new,
+      PublishingApiDraftSectionExporter.new
+    ]
     @context = context
   end
 

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -28,7 +28,7 @@ private
   end
 
   def export_draft_manual_to_publishing_api
-    PublishingApiDraftManualExporter.new.call(new_document, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 
   def export_draft_section_to_publishing_api

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -1,8 +1,8 @@
 class PublishManualService
-  def initialize(manual_id:, manual_repository:, listeners:, version_number:)
+  def initialize(manual_id:, manual_repository:, version_number:)
     @manual_id = manual_id
     @manual_repository = manual_repository
-    @listeners = listeners
+    @listeners = ManualObserversRegistry.new.publication
     @version_number = version_number
   end
 

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -65,7 +65,7 @@ private
   end
 
   def export_draft_manual_to_publishing_api
-    PublishingApiDraftManualExporter.new.call(document, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 
   class ManualNotFoundError < StandardError; end

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -1,8 +1,11 @@
 class RemoveSectionService
-  def initialize(manual_repository, context, listeners:)
+  def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = listeners
+    @listeners = [
+      PublishingApiDraftManualExporter.new,
+      PublishingApiDraftSectionDiscarder.new
+    ]
   end
 
   def call

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -2,21 +2,20 @@ class ReorderSectionsService
   def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = [PublishingApiDraftManualExporter.new]
   end
 
   def call
     manual.draft
     update
     persist
-    notify_listeners
+    export_draft_manual_to_publishing_api
 
     [manual, documents]
   end
 
 private
 
-  attr_reader :manual_repository, :context, :listeners
+  attr_reader :manual_repository, :context
 
   def update
     manual.reorder_documents(document_order)
@@ -42,9 +41,7 @@ private
     context.params.fetch("section_order")
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(nil, manual)
-    end
+  def export_draft_manual_to_publishing_api
+    PublishingApiDraftManualExporter.new.call(nil, manual)
   end
 end

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -42,6 +42,6 @@ private
   end
 
   def export_draft_manual_to_publishing_api
-    PublishingApiDraftManualExporter.new.call(nil, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 end

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -1,8 +1,8 @@
 class ReorderSectionsService
-  def initialize(manual_repository, context, listeners:)
+  def initialize(manual_repository, context)
     @manual_repository = manual_repository
     @context = context
-    @listeners = listeners
+    @listeners = [PublishingApiDraftManualExporter.new]
   end
 
   def call

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -1,7 +1,8 @@
 class RepublishManualService
-  def initialize(published_listeners: [], draft_listeners: [], manual_id:)
-    @published_listeners = published_listeners
-    @draft_listeners = draft_listeners
+  def initialize(manual_id:)
+    registry = ManualObserversRegistry.new
+    @published_listeners = registry.republication
+    @draft_listeners = registry.update
     @manual_id = manual_id
   end
 

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -1,9 +1,9 @@
 class UpdateManualOriginalPublicationDateService
-  def initialize(manual_repository:, manual_id:, attributes:, listeners:)
+  def initialize(manual_repository:, manual_id:, attributes:)
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
-    @listeners = listeners
+    @listeners = ManualObserversRegistry.new.update_original_publication_date
   end
 
   def call

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -1,9 +1,9 @@
 class UpdateManualService
-  def initialize(manual_repository:, manual_id:, attributes:, listeners:)
+  def initialize(manual_repository:, manual_id:, attributes:)
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes
-    @listeners = listeners
+    @listeners = ManualObserversRegistry.new.update
   end
 
   def call

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -1,8 +1,11 @@
 class UpdateSectionService
-  def initialize(manual_repository:, context:, listeners:)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
-    @listeners = listeners
+    @listeners = [
+      PublishingApiDraftManualExporter.new,
+      PublishingApiDraftSectionExporter.new
+    ]
   end
 
   def call

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -2,10 +2,6 @@ class UpdateSectionService
   def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
-    @listeners = [
-      PublishingApiDraftManualExporter.new,
-      PublishingApiDraftSectionExporter.new
-    ]
   end
 
   def call
@@ -14,7 +10,8 @@ class UpdateSectionService
     if document.valid?
       manual.draft
       manual_repository.store(manual)
-      notify_listeners
+      export_draft_manual_to_publishing_api
+      export_draft_section_to_publishing_api
     end
 
     [manual, document]
@@ -44,9 +41,11 @@ private
     context.params.fetch("section")
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(document, manual)
-    end
+  def export_draft_manual_to_publishing_api
+    PublishingApiDraftManualExporter.new.call(document, manual)
+  end
+
+  def export_draft_section_to_publishing_api
+    PublishingApiDraftSectionExporter.new.call(document, manual)
   end
 end

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -42,7 +42,7 @@ private
   end
 
   def export_draft_manual_to_publishing_api
-    PublishingApiDraftManualExporter.new.call(document, manual)
+    PublishingApiDraftManualExporter.new.call(manual)
   end
 
   def export_draft_section_to_publishing_api

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -14,10 +14,8 @@ class PublishManualWorker
     task = ManualPublishTask.find(task_id)
     task.start!
 
-    observers = ManualObserversRegistry.new
     service = PublishManualService.new(
       manual_repository: repository,
-      listeners: observers.publication,
       manual_id: task.manual_id,
       version_number: task.version_number,
     )

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -80,12 +80,10 @@ module ManualHelpers
       .organisation_scoped_manual_repository_factory
     repository = manual_repository_factory.call(organisation_slug)
 
-    observers = ManualObserversRegistry.new
     service = UpdateManualService.new(
       manual_repository: repository,
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
-      listeners: observers.update,
     )
     manual = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -163,10 +163,8 @@ module ManualHelpers
   def publish_manual_without_ui(manual, organisation_slug: "ministry-of-tea")
     stub_manual_publication_observers(organisation_slug)
 
-    observers = ManualObserversRegistry.new
     service = PublishManualService.new(
       manual_repository: RepositoryRegistry.create.manual_repository,
-      listeners: observers.publication,
       manual_id: manual.id,
       version_number: manual.version_number,
     )

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -23,11 +23,9 @@ module ManualHelpers
       .organisation_scoped_manual_repository_factory
     repository = manual_repository_factory.call(organisation_slug)
 
-    observers = ManualObserversRegistry.new
     service = CreateManualService.new(
       manual_repository: repository,
       manual_builder: ManualBuilder.create,
-      listeners: observers.creation,
       attributes: fields.merge(organisation_slug: organisation_slug),
     )
     manual = service.call

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -121,10 +121,6 @@ module ManualHelpers
     service = UpdateSectionService.new(
       manual_repository: organisational_manual_repository,
       context: service_context,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
     )
     _, document = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -60,10 +60,6 @@ module ManualHelpers
 
     service = CreateSectionService.new(
       manual_repository: organisational_manual_repository,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
       context: create_service_context,
     )
     _, document = service.call

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -16,10 +16,7 @@ class ManualsRepublisher
     manual_records.to_a.each.with_index do |manual_record, i|
       begin
         logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
-        observers = ManualObserversRegistry.new
         service = RepublishManualService.new(
-          draft_listeners: observers.update,
-          published_listeners: observers.republication,
           manual_id: manual_record.manual_id,
         )
         service.call

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -80,10 +80,6 @@ private
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
       context: context_for_section_edition_update,
-      listeners: [
-        PublishingApiDraftManualExporter.new,
-        PublishingApiDraftSectionExporter.new
-      ],
     )
     _manual, document = service.call
     document.latest_edition

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -5,14 +5,13 @@ require "ostruct"
 RSpec.describe PublishManualService do
   let(:manual_id) { double(:manual_id) }
   let(:manual_repository) { double(:manual_repository) }
-  let(:listeners) { [] }
   let(:manual) { double(:manual, id: manual_id, version_number: 3) }
+  let(:registry) { double(:registry, publication: []) }
 
   subject {
     PublishManualService.new(
       manual_id: manual_id,
       manual_repository: manual_repository,
-      listeners: listeners,
       version_number: version_number,
     )
   }
@@ -22,6 +21,8 @@ RSpec.describe PublishManualService do
     allow(manual_repository).to receive(:store)
     allow(manual).to receive(:publish)
     allow(manual).to receive(:update)
+    allow(manual).to receive(:documents)
+    allow(ManualObserversRegistry).to receive(:new).and_return(registry)
   end
 
   context "when the version number is up to date" do

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "exports a manual" do
-        expect(exporter).to have_received(:call).with(document, manual)
+        expect(exporter).to have_received(:call).with(manual)
       end
 
       it "discards a section" do
@@ -209,7 +209,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "exports a manual" do
-        expect(exporter).to have_received(:call).with(document, manual)
+        expect(exporter).to have_received(:call).with(manual)
       end
 
       it "discards a section" do

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -8,21 +8,20 @@ RSpec.describe RepublishManualService do
   let(:published_listeners) { [published_listener] }
   let(:draft_listener) { double(:listener) }
   let(:draft_listeners) { [draft_listener] }
-
+  let(:registry) { double(:registry, update: draft_listeners, republication: published_listeners) }
   let(:published_manual_version) { double(:manual) }
   let(:draft_manual_version) { double(:manual) }
 
   subject {
     described_class.new(
       manual_id: manual_id,
-      published_listeners: published_listeners,
-      draft_listeners: draft_listeners,
     )
   }
 
   before do
     allow(draft_listener).to receive(:call)
     allow(published_listener).to receive(:call)
+    allow(ManualObserversRegistry).to receive(:new).and_return(registry)
   end
 
   context "(for a published manual)" do

--- a/spec/services/update_manual_original_publication_date_service_spec.rb
+++ b/spec/services/update_manual_original_publication_date_service_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
   let(:document_2) { double(:document, update: nil) }
   let(:documents) { [document_1, document_2] }
   let(:originally_published_at) { 10.years.ago }
-  let(:listener_1) { double(:listener, call: nil) }
-  let(:listener_2) { double(:listener, call: nil) }
-  let(:listeners) { [listener_1, listener_2] }
+  let(:registry) { double(:registry, update_original_publication_date: [listener]) }
+  let(:listener) { double(:listener) }
 
   subject {
     described_class.new(
@@ -21,8 +20,7 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
         originally_published_at: originally_published_at,
         use_originally_published_at_for_public_timestamp: "1",
         title: "hats",
-      },
-      listeners: listeners
+      }
     )
   }
 
@@ -31,6 +29,8 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
     allow(manual_repository).to receive(:store)
     allow(manual).to receive(:draft)
     allow(manual).to receive(:update)
+    allow(ManualObserversRegistry).to receive(:new).and_return(registry)
+    allow(listener).to receive(:call)
   end
 
   it "updates the manual with only the originally_published_at and use_originally_published_at_for_public_timestamp attribtues" do
@@ -60,7 +60,6 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
     subject.call
 
     expect(manual_repository).to have_received(:store).with(manual).ordered
-    expect(listener_1).to have_received(:call).with(manual).ordered
-    expect(listener_2).to have_received(:call).with(manual).ordered
+    expect(listener).to have_received(:call).with(manual).ordered
   end
 end


### PR DESCRIPTION
In all the places I could find, when a Service was called from a Controller with a "listener" argument the value passed in did not vary from call site to call site. I've inlined these listener arguments into the constructor of each Service. 

In a couple of cases I've given the `notify_listeners` method a more meaningful name. In some others, where the listeners were fetched from the `ManualObserversRegistry` I haven't. I think instead I'd like to try and remove the `ManualObserversRegistry` and either inline the methods it calls into the Services themselves, or give it a better name. 
