### PR TITLE
Use 'rummager' to find Rummager service

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -36,6 +36,6 @@ module Services
   end
 
   def self.rummager
-    @rummager_api ||= GdsApi::Rummager.new(Plek.find("search"))
+    @rummager_api ||= GdsApi::Rummager.new(Plek.find("rummager"))
   end
 end


### PR DESCRIPTION
As per the commit note for
https://github.com/alphagov/gds-api-adapters/commit/ddae94d1656f59f7778ca794a0cce356fc75e7e2.

This change was released in version 32.0.0[1] of gds-api-adapters and we're
currently using 39.2.0.

This allows me to use the GdsApi::TestHelpers::Rummager methods (e.g.
`stub_any_rummager_post`) in our tests.

[1]:
https://github.com/alphagov/gds-api-adapters/blob/master/CHANGELOG.md#3200