### PR TITLE
Fix reslug_section script

### DIFF
--- a/app/exporters/publishing_api_redirecter.rb
+++ b/app/exporters/publishing_api_redirecter.rb
@@ -8,7 +8,7 @@ class PublishingAPIRedirecter
   end
 
   def call
-    raise 'GdsApi::PublishingApi#put_content_item was removed in gds-api-adapters v38.0.0'
+    publishing_api.put_content(content_id, exportable_attributes)
   end
 
 private
@@ -25,9 +25,9 @@ private
 
   def exportable_attributes
     {
-      format: "redirect",
+      document_type: 'redirect',
+      schema_name: 'redirect',
       publishing_app: "manuals-publisher",
-      update_type: "major",
       base_path: base_path,
       redirects: [
         {
@@ -36,7 +36,6 @@ private
           destination: redirect_to_location
         }
       ],
-      content_id: content_id,
     }
   end
 

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -44,7 +44,7 @@ private
 
   def validate_current_section_in_content_store
     raise Error.new("Manual Section does not exist in content store") if current_section_in_content_store.nil?
-    raise Error.new("Manual Section already withdrawn") if current_section_in_content_store.format == "gone"
+    raise Error.new("Manual Section already withdrawn") if current_section_in_content_store['format'] == "gone"
   end
 
   def validate_new_section

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -1,5 +1,4 @@
 require "gds_api/content_store"
-require "manual_service_registry"
 require "services"
 require "update_section_service"
 

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -65,7 +65,7 @@ private
 
   def redirect_section
     PublishingAPIRedirecter.new(
-      publishing_api: Services.publishing_api,
+      publishing_api: Services.publishing_api_v2,
       entity: current_section_edition,
       redirect_to_location: "/#{full_new_section_slug}"
     ).call

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -107,10 +107,8 @@ private
   end
 
   def publish_manual
-    observers = ManualObserversRegistry.new
     service = PublishManualService.new(
       manual_repository: RepositoryRegistry.new.manual_repository,
-      listeners: observers.publication,
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,
     )

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -60,6 +60,7 @@ private
   def validate_new_section_in_content_store
     section = section_in_content_store(full_new_section_slug)
     raise Error.new("Manual Section already exists in content store") if section
+  rescue GdsApi::ContentStore::ItemNotFound # rubocop:disable Lint/HandleExceptions
   end
 
   def redirect_section

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -90,7 +90,7 @@ private
   def context_for_section_edition_update
     params_hash = {
       "id" => current_section_edition.document_id,
-      "document" => {
+      "section" => {
         title: current_section_edition.title,
         summary: current_section_edition.summary,
         body: current_section_edition.body,

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require "gds_api/asset_manager"
+require "gds_api/content_store"
 require "gds_api/organisations"
 require "gds_api/publishing_api"
 require "gds_api/publishing_api_v2"

--- a/spec/exporters/publishing_api_redirecter_spec.rb
+++ b/spec/exporters/publishing_api_redirecter_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "support/all_of_matcher"
+require "support/govuk_content_schema_helpers"
+
+describe PublishingAPIRedirecter do
+  subject {
+    described_class.new(
+      publishing_api: publishing_api,
+      entity: entity,
+      redirect_to_location: '/new/slug/for/entity'
+    )
+  }
+
+  let(:publishing_api) { double(:publishing_api, put_content: nil) }
+  let(:entity) { double(:entity, slug: 'original/slug/for/entity') }
+
+  it "exports a redirect valid against the schema" do
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema("redirect")
+  end
+
+  it "exports the attributes required for the redirect" do
+    allow(subject).to receive(:content_id).and_return('content-id')
+
+    subject.call
+
+    expect(publishing_api).to have_received(:put_content).with(
+      'content-id',
+      all_of(
+        hash_including(
+          document_type: 'redirect',
+          schema_name: 'redirect',
+          publishing_app: 'manuals-publisher',
+          base_path: '/original/slug/for/entity',
+          redirects: [
+            {
+              path: '/original/slug/for/entity',
+              type: 'exact',
+              destination: '/new/slug/for/entity'
+            }
+          ]
+        )
+      )
+    )
+  end
+end

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require 'section_reslugger'
+require "gds_api/test_helpers/content_store"
+require "gds_api/test_helpers/rummager"
+
+describe SectionReslugger do
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::Organisations
+  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::Rummager
+
+  subject {
+    described_class.new(
+      'manual-slug',
+      'current-section-slug',
+      'new-section-slug'
+    )
+  }
+
+  before {
+    manual_record = ManualRecord.create!(
+      manual_id: 'manual-id',
+      slug: 'manual-slug',
+      organisation_slug: 'organisation-slug'
+    )
+    SectionEdition.create!(
+      document_id: 'document-id',
+      slug: 'manual-slug/current-section-slug',
+      title: 'section-edition-title',
+      summary: 'section-edition-summary',
+      body: 'section-edition-body'
+    )
+    manual_record.editions.create!(
+      document_ids: [
+        'document-id'
+      ]
+    )
+
+    content_store_has_item('/manual-slug/current-section-slug')
+    content_store_does_not_have_item('/manual-slug/new-section-slug')
+
+    organisations_api_has_organisation('organisation-slug')
+
+    stub_any_publishing_api_patch_links
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+
+    stub_any_rummager_post
+    stub_any_rummager_delete
+  }
+
+  it "doesn't raise any exceptions" do
+    subject.call
+  end
+end


### PR DESCRIPTION
This branch aims to fix the `bin/reslug_section` script that had been neglected. It was prompted by issue #851.

I've run the script locally and observed that it now updates manual section slugs. I haven't looked too closely at the actual behaviour but am hoping that someone familiar with the script will be able to use it to determine whether it's still doing the right thing.

This branch includes:

* Fixes for a number of small problems in `SectionReslugger`.
* Updates to `PublishingAPIRedirector` to use v2 of the Publishing API and added a spec to help us avoid breaking it again in future.
* A test for `SectionReslugger` to help us avoid breaking it again in future.
