### PR TITLE
Rename ManualWithDocuments

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -103,7 +103,7 @@ private
   end
 
   def sections
-    manual.documents.map { |d|
+    manual.sections.map { |d|
       {
         title: d.attributes.fetch(:title),
         description: d.attributes.fetch(:summary),

--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -20,7 +20,7 @@ private
     {
       links: {
         organisations: [organisation["details"]["content_id"]],
-        sections: manual.documents.map(&:id),
+        sections: manual.sections.map(&:id),
       },
     }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,8 +18,8 @@ module ApplicationHelper
   end
 
   def show_preview?(item)
-    if item.respond_to?(:documents)
-      item.draft? || item.documents.any?(&:draft?)
+    if item.respond_to?(:sections)
+      item.draft? || item.sections.any?(&:draft?)
     else
       item.draft?
     end

--- a/app/lib/manual_update_type.rb
+++ b/app/lib/manual_update_type.rb
@@ -24,7 +24,7 @@ private
 
   def all_documents_are_minor?
     manual.
-      documents.
+      sections.
       select(&:needs_exporting?).
       all? { |d|
         d.minor_update? && d.has_ever_been_published?

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -7,7 +7,7 @@ class ManualBuilder
       factory: ->(attrs) {
         ManualValidator.new(
           NullValidator.new(
-            ManualWithDocuments.create(attrs),
+            ManualWithSections.create(attrs),
           ),
         )
       }

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -4,7 +4,7 @@ require "validators/manual_validator"
 require "validators/null_validator"
 
 require "builders/section_builder"
-require "manual_with_documents"
+require "manual_with_sections"
 require "slug_generator"
 require "section"
 
@@ -13,7 +13,7 @@ class DocumentFactoryRegistry
     ->(manual, attrs) {
       ManualValidator.new(
         NullValidator.new(
-          ManualWithDocuments.new(
+          ManualWithSections.new(
             SectionBuilder.new,
             manual,
             attrs,

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -9,7 +9,7 @@ require "slug_generator"
 require "section"
 
 class DocumentFactoryRegistry
-  def manual_with_documents
+  def manual_with_sections
     ->(manual, attrs) {
       ManualValidator.new(
         NullValidator.new(

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -17,7 +17,7 @@ class ManualWithDocuments < SimpleDelegator
     super(manual)
   end
 
-  def documents
+  def sections
     @sections.to_enum
   end
 
@@ -38,7 +38,7 @@ class ManualWithDocuments < SimpleDelegator
 
   def publish
     manual.publish do
-      documents.each(&:publish!)
+      sections.each(&:publish!)
     end
   end
 

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -31,7 +31,7 @@ class ManualWithDocuments < SimpleDelegator
       attributes
     )
 
-    add_document(document)
+    add_section(document)
 
     document
   end
@@ -69,7 +69,7 @@ private
 
   attr_reader :section_builder, :manual
 
-  def add_document(section)
+  def add_section(section)
     @sections << section
   end
 end

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -54,11 +54,11 @@ class ManualWithDocuments < SimpleDelegator
   end
 
   def remove_document(section_id)
-    found_document = @sections.find { |d| d.id == section_id }
+    found_section = @sections.find { |d| d.id == section_id }
 
-    return if found_document.nil?
+    return if found_section.nil?
 
-    removed = @sections.delete(found_document)
+    removed = @sections.delete(found_section)
 
     return if removed.nil?
 

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -42,15 +42,15 @@ class ManualWithDocuments < SimpleDelegator
     end
   end
 
-  def reorder_documents(document_order)
-    unless document_order.sort == @sections.map(&:id).sort
+  def reorder_documents(section_order)
+    unless section_order.sort == @sections.map(&:id).sort
       raise(
         ArgumentError,
-        "document_order must contain each document_id exactly once",
+        "section_order must contain each section_id exactly once",
       )
     end
 
-    @sections.sort_by! { |doc| document_order.index(doc.id) }
+    @sections.sort_by! { |doc| section_order.index(doc.id) }
   end
 
   def remove_document(document_id)

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -9,11 +9,11 @@ class ManualWithDocuments < SimpleDelegator
     )
   end
 
-  def initialize(document_builder, manual, documents:, removed_documents: [])
+  def initialize(section_builder, manual, documents:, removed_documents: [])
     @manual = manual
     @documents = documents
     @removed_documents = removed_documents
-    @document_builder = document_builder
+    @section_builder = section_builder
     super(manual)
   end
 
@@ -26,7 +26,7 @@ class ManualWithDocuments < SimpleDelegator
   end
 
   def build_document(attributes)
-    document = document_builder.call(
+    document = section_builder.call(
       self,
       attributes
     )
@@ -67,7 +67,7 @@ class ManualWithDocuments < SimpleDelegator
 
 private
 
-  attr_reader :document_builder, :manual
+  attr_reader :section_builder, :manual
 
   def add_document(document)
     @documents << document

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -9,10 +9,10 @@ class ManualWithDocuments < SimpleDelegator
     )
   end
 
-  def initialize(section_builder, manual, sections:, removed_documents: [])
+  def initialize(section_builder, manual, sections:, removed_sections: [])
     @manual = manual
     @documents = sections
-    @removed_documents = removed_documents
+    @removed_documents = removed_sections
     @section_builder = section_builder
     super(manual)
   end

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -53,8 +53,8 @@ class ManualWithDocuments < SimpleDelegator
     @sections.sort_by! { |doc| section_order.index(doc.id) }
   end
 
-  def remove_document(document_id)
-    found_document = @sections.find { |d| d.id == document_id }
+  def remove_document(section_id)
+    found_document = @sections.find { |d| d.id == section_id }
 
     return if found_document.nil?
 

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -69,7 +69,7 @@ private
 
   attr_reader :section_builder, :manual
 
-  def add_document(document)
-    @sections << document
+  def add_document(section)
+    @sections << section
   end
 end

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -42,7 +42,7 @@ class ManualWithDocuments < SimpleDelegator
     end
   end
 
-  def reorder_documents(section_order)
+  def reorder_sections(section_order)
     unless section_order.sort == @sections.map(&:id).sort
       raise(
         ArgumentError,

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -21,7 +21,7 @@ class ManualWithDocuments < SimpleDelegator
     @sections.to_enum
   end
 
-  def removed_documents
+  def removed_sections
     @removed_sections.to_enum
   end
 

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -25,7 +25,7 @@ class ManualWithDocuments < SimpleDelegator
     @removed_sections.to_enum
   end
 
-  def build_document(attributes)
+  def build_section(attributes)
     section = section_builder.call(
       self,
       attributes

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -5,13 +5,13 @@ class ManualWithDocuments < SimpleDelegator
     ManualWithDocuments.new(
       SectionBuilder.new,
       Manual.new(attrs),
-      documents: [],
+      sections: [],
     )
   end
 
-  def initialize(section_builder, manual, documents:, removed_documents: [])
+  def initialize(section_builder, manual, sections:, removed_documents: [])
     @manual = manual
-    @documents = documents
+    @documents = sections
     @removed_documents = removed_documents
     @section_builder = section_builder
     super(manual)

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -11,14 +11,14 @@ class ManualWithDocuments < SimpleDelegator
 
   def initialize(section_builder, manual, sections:, removed_sections: [])
     @manual = manual
-    @documents = sections
+    @sections = sections
     @removed_documents = removed_sections
     @section_builder = section_builder
     super(manual)
   end
 
   def documents
-    @documents.to_enum
+    @sections.to_enum
   end
 
   def removed_documents
@@ -43,22 +43,22 @@ class ManualWithDocuments < SimpleDelegator
   end
 
   def reorder_documents(document_order)
-    unless document_order.sort == @documents.map(&:id).sort
+    unless document_order.sort == @sections.map(&:id).sort
       raise(
         ArgumentError,
         "document_order must contain each document_id exactly once",
       )
     end
 
-    @documents.sort_by! { |doc| document_order.index(doc.id) }
+    @sections.sort_by! { |doc| document_order.index(doc.id) }
   end
 
   def remove_document(document_id)
-    found_document = @documents.find { |d| d.id == document_id }
+    found_document = @sections.find { |d| d.id == document_id }
 
     return if found_document.nil?
 
-    removed = @documents.delete(found_document)
+    removed = @sections.delete(found_document)
 
     return if removed.nil?
 
@@ -70,6 +70,6 @@ private
   attr_reader :section_builder, :manual
 
   def add_document(document)
-    @documents << document
+    @sections << document
   end
 end

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -12,7 +12,7 @@ class ManualWithDocuments < SimpleDelegator
   def initialize(section_builder, manual, sections:, removed_sections: [])
     @manual = manual
     @sections = sections
-    @removed_documents = removed_sections
+    @removed_sections = removed_sections
     @section_builder = section_builder
     super(manual)
   end
@@ -22,7 +22,7 @@ class ManualWithDocuments < SimpleDelegator
   end
 
   def removed_documents
-    @removed_documents.to_enum
+    @removed_sections.to_enum
   end
 
   def build_document(attributes)
@@ -62,7 +62,7 @@ class ManualWithDocuments < SimpleDelegator
 
     return if removed.nil?
 
-    @removed_documents << removed
+    @removed_sections << removed
   end
 
 private

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -26,14 +26,14 @@ class ManualWithDocuments < SimpleDelegator
   end
 
   def build_document(attributes)
-    document = section_builder.call(
+    section = section_builder.call(
       self,
       attributes
     )
 
-    add_section(document)
+    add_section(section)
 
-    document
+    section
   end
 
   def publish

--- a/app/models/manual_with_documents.rb
+++ b/app/models/manual_with_documents.rb
@@ -53,7 +53,7 @@ class ManualWithDocuments < SimpleDelegator
     @sections.sort_by! { |doc| section_order.index(doc.id) }
   end
 
-  def remove_document(section_id)
+  def remove_section(section_id)
     found_section = @sections.find { |d| d.id == section_id }
 
     return if found_section.nil?

--- a/app/models/manual_with_sections.rb
+++ b/app/models/manual_with_sections.rb
@@ -1,8 +1,8 @@
 require "delegate"
 
-class ManualWithDocuments < SimpleDelegator
+class ManualWithSections < SimpleDelegator
   def self.create(attrs)
-    ManualWithDocuments.new(
+    ManualWithSections.new(
       SectionBuilder.new,
       Manual.new(attrs),
       sections: [],

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -69,7 +69,7 @@ private
         )
       end
 
-      manual.removed_documents.each do |doc|
+      manual.removed_sections.each do |doc|
         next if doc.withdrawn?
         next if doc.minor_update?
 
@@ -100,7 +100,7 @@ private
         )
       end
 
-      manual.removed_documents.each do |section|
+      manual.removed_sections.each do |section|
         indexer.delete(
           SectionIndexableFormatter.new(section, manual),
         )
@@ -146,7 +146,7 @@ private
         document.mark_as_exported! if action != :republish
       end
 
-      manual.removed_documents.each do |document|
+      manual.removed_sections.each do |document|
         next if document.withdrawn? && action != :republish
         begin
           publishing_api_v2.unpublish(document.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -57,7 +57,7 @@ private
 
   def publication_logger
     ->(manual, _: nil) {
-      manual.documents.each do |doc|
+      manual.sections.each do |doc|
         next unless doc.needs_exporting?
         next if doc.minor_update?
 
@@ -91,7 +91,7 @@ private
         ManualIndexableFormatter.new(manual)
       )
 
-      manual.documents.each do |section|
+      manual.sections.each do |section|
         indexer.add(
           SectionIndexableFormatter.new(
             MarkdownAttachmentProcessor.new(section),
@@ -116,7 +116,7 @@ private
         ManualIndexableFormatter.new(manual)
       )
 
-      manual.documents.each do |section|
+      manual.sections.each do |section|
         indexer.delete(
           SectionIndexableFormatter.new(
             MarkdownAttachmentProcessor.new(section),
@@ -135,7 +135,7 @@ private
         update_type: update_type,
       ).call
 
-      manual.documents.each do |document|
+      manual.sections.each do |document|
         next if !document.needs_exporting? && action != :republish
 
         PublishingAPIPublisher.new(
@@ -171,7 +171,7 @@ private
         organisation, manual, update_type: update_type
       ).call
 
-      manual.documents.each do |document|
+      manual.sections.each do |document|
         next if !document.needs_exporting? && action != :republish
 
         SectionPublishingAPILinksExporter.new(
@@ -191,7 +191,7 @@ private
         entity: manual,
       ).call
 
-      manual.documents.each do |document|
+      manual.sections.each do |document|
         PublishingAPIWithdrawer.new(
           entity: document,
         ).call

--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -19,7 +19,7 @@ class DocumentAssociationMarshaller
       end
     }
 
-    decorator.call(manual, documents: docs, removed_documents: removed_docs)
+    decorator.call(manual, sections: docs, removed_documents: removed_docs)
   end
 
   def dump(manual, record)

--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -25,7 +25,7 @@ class DocumentAssociationMarshaller
   def dump(manual, record)
     document_repository = section_repository_factory.call(manual)
 
-    manual.documents.each do |document|
+    manual.sections.each do |document|
       document_repository.store(document)
     end
 
@@ -33,7 +33,7 @@ class DocumentAssociationMarshaller
       document_repository.store(document)
     end
 
-    record.document_ids = manual.documents.map(&:id)
+    record.document_ids = manual.sections.map(&:id)
     record.removed_document_ids = manual.removed_sections.map(&:id)
 
     nil

--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -19,7 +19,7 @@ class DocumentAssociationMarshaller
       end
     }
 
-    decorator.call(manual, sections: docs, removed_documents: removed_docs)
+    decorator.call(manual, sections: docs, removed_sections: removed_docs)
   end
 
   def dump(manual, record)

--- a/app/repositories/marshallers/document_association_marshaller.rb
+++ b/app/repositories/marshallers/document_association_marshaller.rb
@@ -29,12 +29,12 @@ class DocumentAssociationMarshaller
       document_repository.store(document)
     end
 
-    manual.removed_documents.each do |document|
+    manual.removed_sections.each do |document|
       document_repository.store(document)
     end
 
     record.document_ids = manual.documents.map(&:id)
-    record.removed_document_ids = manual.removed_documents.map(&:id)
+    record.removed_document_ids = manual.removed_sections.map(&:id)
 
     nil
   end

--- a/app/repositories/repository_registry.rb
+++ b/app/repositories/repository_registry.rb
@@ -27,7 +27,7 @@ class RepositoryRegistry
         DocumentAssociationMarshaller.new(
           section_repository_factory: section_repository_factory,
           decorator: ->(manual, attrs) {
-            DocumentFactoryRegistry.new.manual_with_documents.call(manual, attrs)
+            DocumentFactoryRegistry.new.manual_with_sections.call(manual, attrs)
           }
         ),
         ManualPublishTaskAssociationMarshaller.new(

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -24,7 +24,7 @@ private
 
     build_manual_for(manual_record, manual_record.latest_edition) do
       {
-        documents: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
+        sections: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
         removed_documents: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
       }
     end
@@ -36,7 +36,7 @@ private
     if manual_record.latest_edition.state == "published"
       build_manual_for(manual_record, manual_record.latest_edition) do
         {
-          documents: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
+          sections: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
           removed_documents: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
         }
       end
@@ -45,7 +45,7 @@ private
       if previous_edition.state == "published"
         build_manual_for(manual_record, previous_edition) do
           {
-            documents: get_published_version_of_documents(previous_edition.document_ids),
+            sections: get_published_version_of_documents(previous_edition.document_ids),
             removed_documents: get_latest_version_of_documents(previous_edition.removed_document_ids)
           }
         end

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -80,7 +80,7 @@ private
 
     document_attrs = yield
 
-    ManualWithDocuments.new(
+    ManualWithSections.new(
       ->(_manual, _attrs) { raise RuntimeError, "read only manaul" },
       base_manual,
       document_attrs

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -25,7 +25,7 @@ private
     build_manual_for(manual_record, manual_record.latest_edition) do
       {
         sections: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
-        removed_documents: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
+        removed_sections: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
       }
     end
   end
@@ -37,7 +37,7 @@ private
       build_manual_for(manual_record, manual_record.latest_edition) do
         {
           sections: get_latest_version_of_documents(manual_record.latest_edition.document_ids),
-          removed_documents: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
+          removed_sections: get_latest_version_of_documents(manual_record.latest_edition.removed_document_ids),
         }
       end
     elsif manual_record.latest_edition.state == "draft"
@@ -46,7 +46,7 @@ private
         build_manual_for(manual_record, previous_edition) do
           {
             sections: get_published_version_of_documents(previous_edition.document_ids),
-            removed_documents: get_latest_version_of_documents(previous_edition.removed_document_ids)
+            removed_sections: get_latest_version_of_documents(previous_edition.removed_document_ids)
           }
         end
       else

--- a/app/services/create_section_attachment_service.rb
+++ b/app/services/create_section_attachment_service.rb
@@ -17,7 +17,7 @@ private
   attr_reader :manual_repository, :context
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -5,7 +5,7 @@ class CreateSectionService
   end
 
   def call
-    @new_document = manual.build_document(document_params)
+    @new_document = manual.build_section(document_params)
 
     if new_document.valid?
       manual.draft

--- a/app/services/list_sections_service.rb
+++ b/app/services/list_sections_service.rb
@@ -13,7 +13,7 @@ private
   attr_reader :manual_repository, :context
 
   def documents
-    manual.documents
+    manual.sections
   end
 
   def manual

--- a/app/services/new_section_attachment_service.rb
+++ b/app/services/new_section_attachment_service.rb
@@ -18,7 +18,7 @@ private
   end
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/services/new_section_service.rb
+++ b/app/services/new_section_service.rb
@@ -5,7 +5,7 @@ class NewSectionService
   end
 
   def call
-    [manual, manual.build_document({})]
+    [manual, manual.build_section({})]
   end
 
 private

--- a/app/services/preview_section_service.rb
+++ b/app/services/preview_section_service.rb
@@ -34,7 +34,7 @@ private
   end
 
   def existing_document
-    @existing_document ||= manual.documents.find { |document|
+    @existing_document ||= manual.sections.find { |document|
       document.id == document_id
     }
   end

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -35,7 +35,7 @@ private
   end
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -27,7 +27,7 @@ private
   attr_reader :manual_repository, :context
 
   def remove
-    manual.remove_document(document_id)
+    manual.remove_section(document_id)
   end
 
   def persist

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -18,7 +18,7 @@ private
   attr_reader :manual_repository, :context
 
   def update
-    manual.reorder_documents(document_order)
+    manual.reorder_sections(document_order)
   end
 
   def persist

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -26,7 +26,7 @@ private
   end
 
   def documents
-    manual.documents
+    manual.sections
   end
 
   def manual

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -34,7 +34,7 @@ private
   end
 
   def clashing_sections
-    manual.documents
+    manual.sections
       .group_by(&:slug)
       .select { |_slug, docs| docs.size > 1 }
   end

--- a/app/services/show_section_attachment_service.rb
+++ b/app/services/show_section_attachment_service.rb
@@ -17,7 +17,7 @@ private
   end
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/services/show_section_service.rb
+++ b/app/services/show_section_service.rb
@@ -13,7 +13,7 @@ private
   attr_reader :manual_repository, :context
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -40,7 +40,7 @@ private
   end
 
   def update_documents
-    manual.documents.each do |document|
+    manual.sections.each do |document|
       # a no-op update will force a new draft if we need it
       document.update({})
     end

--- a/app/services/update_section_attachment_service.rb
+++ b/app/services/update_section_attachment_service.rb
@@ -21,7 +21,7 @@ private
   end
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -22,7 +22,7 @@ private
   attr_reader :manual_repository, :context, :listeners
 
   def document
-    @document ||= manual.documents.find { |d| d.id == document_id }
+    @document ||= manual.sections.find { |d| d.id == document_id }
   end
 
   def manual

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -67,9 +67,9 @@
       <%= link_to 'Reorder sections', reorder_manual_sections_path(manual), class: 'btn btn-default add-right-margin' %>
       <%= link_to 'Add section', new_manual_section_path(manual), class: 'btn btn-default' %>
     </div>
-    <% if manual.documents.any? %>
+    <% if manual.sections.any? %>
     <ul class="document-list">
-     <% manual.documents.each do |document| %>
+     <% manual.sections.each do |document| %>
         <li class="document">
           <%= link_to(document.title, manual_section_path(manual, document), class: 'document-title') %>
           <ul class="metadata">
@@ -92,7 +92,7 @@
       <div class="panel-heading"><h3>Publish manual</h3></div>
       <div class="panel-body">
         <%= publish_text(manual, slug_unique) %>
-        <% if manual.draft? && manual.documents.any? && current_user_can_publish? && slug_unique %>
+        <% if manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique %>
           <%= form_tag(publish_manual_path(manual), method: :post) do %>
             <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
           <% end -%>

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -62,7 +62,7 @@ Given(/^a draft manual exists with some sections$/) do
   )
 
   @manual = most_recently_created_manual
-  @documents = @manual.documents.to_a
+  @documents = @manual.sections.to_a
   @document = @documents.first
 
   WebMock::RequestRegistry.instance.reset!
@@ -117,7 +117,7 @@ When(/^I create a section for the manual$/) do
 
   create_section(@manual_fields.fetch(:title), @document_fields)
 
-  @document = most_recently_created_manual.documents.to_a.last
+  @document = most_recently_created_manual.sections.to_a.last
 end
 
 When(/^I create a section for the manual with a change note$/) do
@@ -134,7 +134,7 @@ When(/^I create a section for the manual with a change note$/) do
 
   create_section(@manual_fields.fetch(:title), @document_fields)
 
-  @document = most_recently_created_manual.documents.to_a.last
+  @document = most_recently_created_manual.sections.to_a.last
 end
 
 Then(/^I see the manual has the new section$/) do
@@ -203,7 +203,7 @@ Given(/^a draft section exists for the manual$/) do
 
   create_section(@manual_fields.fetch(:title), @document_fields)
 
-  @document = most_recently_created_manual.documents.to_a.last
+  @document = most_recently_created_manual.sections.to_a.last
 
   @documents ||= []
   @documents << @document
@@ -337,7 +337,7 @@ Given(/^a published manual exists$/) do
   )
 
   @manual = most_recently_created_manual
-  @documents = @manual.documents.to_a
+  @documents = @manual.sections.to_a
 
   publish_manual
 
@@ -566,7 +566,7 @@ When(/^I add another section to the manual$/) do
 
   create_section(@manual_title, fields)
 
-  @new_document = most_recently_created_manual.documents.to_a.last
+  @new_document = most_recently_created_manual.sections.to_a.last
 end
 
 Then(/^I see no visible change note in the section edit form$/) do

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -193,7 +193,7 @@ module ManualHelpers
   def check_section_exists(manual_id, section_id)
     manual = manual_repository.fetch(manual_id)
 
-    manual.documents.any? { |document| document.id == section_id }
+    manual.sections.any? { |document| document.id == section_id }
   end
 
   def check_section_was_removed(manual_id, section_id)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -199,7 +199,7 @@ module ManualHelpers
   def check_section_was_removed(manual_id, section_id)
     manual = manual_repository.fetch(manual_id)
 
-    manual.removed_documents.any? { |document| document.id == section_id }
+    manual.removed_sections.any? { |document| document.id == section_id }
   end
 
   def go_to_edit_page_for_manual(manual_title)

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -176,7 +176,7 @@ private
 
       puts "Publishing published edition of manual: #{manual_to_publish.id}"
       publishing_api.publish(manual_to_publish.id, "republish")
-      manual_to_publish.documents.each do |document|
+      manual_to_publish.sections.each do |document|
         puts "Publishing published edition of manual section: #{document.id}"
         publishing_api.publish(document.id, "republish")
       end
@@ -193,7 +193,7 @@ private
       organisation, manual
     ).call
 
-    manual.documents.each do |document|
+    manual.sections.each do |document|
       puts "Sending a draft of manual section #{document.id} (version: #{document.version_number})"
       SectionPublishingAPIExporter.new(
         organisation, manual, document

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -20,7 +20,7 @@ describe ManualPublishingAPIExporter do
       :manual,
       id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       attributes: manual_attributes,
-      documents: documents,
+      sections: documents,
       has_ever_been_published?: manual_attributes[:ever_been_published],
       originally_published_at: nil,
       use_originally_published_at_for_public_timestamp?: false,

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -29,7 +29,7 @@ describe ManualPublishingAPILinksExporter do
         slug: "guidance/my-first-manual",
         organisation_slug: "cabinet-office",
       },
-      documents: documents,
+      sections: documents,
     )
   }
 

--- a/spec/lib/manual_update_type_spec.rb
+++ b/spec/lib/manual_update_type_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ManualUpdateType do
     before { allow(manual).to receive(:has_ever_been_published?).and_return true }
 
     context "and has no documents" do
-      before { allow(manual).to receive(:documents).and_return [] }
+      before { allow(manual).to receive(:sections).and_return [] }
 
       it "is 'minor'" do
         expect(subject).to eql "minor"
@@ -27,7 +27,7 @@ RSpec.describe ManualUpdateType do
       let(:section_1) { double(:section) }
       let(:section_2) { double(:section) }
       let(:section_3) { double(:section) }
-      before { allow(manual).to receive(:documents).and_return [section_1, section_2, section_3] }
+      before { allow(manual).to receive(:sections).and_return [section_1, section_2, section_3] }
 
       context "none of which need exporting" do
         before do

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -136,10 +136,10 @@ describe ManualWithDocuments do
       expect(manual_with_documents.documents.to_a).to eq([document_b])
     end
 
-    it "adds the document to #removed_documents" do
+    it "adds the document to #removed_sections" do
       manual_with_documents.remove_section(document_a.id)
 
-      expect(manual_with_documents.removed_documents.to_a).to eq(
+      expect(manual_with_documents.removed_sections.to_a).to eq(
         [
           document_c,
           document_a,

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -108,7 +108,7 @@ describe ManualWithDocuments do
     end
   end
 
-  describe "#remove_document" do
+  describe "#remove_section" do
     subject(:manual_with_documents) {
       ManualWithDocuments.new(
         document_builder,
@@ -131,13 +131,13 @@ describe ManualWithDocuments do
     let(:document_c) { double(:document, id: "c") }
 
     it "removes the document from #documents" do
-      manual_with_documents.remove_document(document_a.id)
+      manual_with_documents.remove_section(document_a.id)
 
       expect(manual_with_documents.documents.to_a).to eq([document_b])
     end
 
     it "adds the document to #removed_documents" do
-      manual_with_documents.remove_document(document_a.id)
+      manual_with_documents.remove_section(document_a.id)
 
       expect(manual_with_documents.removed_documents.to_a).to eq(
         [

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -47,7 +47,7 @@ describe ManualWithDocuments do
     end
   end
 
-  describe "#reorder_documents" do
+  describe "#reorder_sections" do
     let(:documents) {
       [
         alpha_document,
@@ -63,7 +63,7 @@ describe ManualWithDocuments do
     let(:document_order) { %w(gamma alpha beta) }
 
     it "reorders the documents to match the given order" do
-      manual_with_documents.reorder_documents(%w(
+      manual_with_documents.reorder_sections(%w(
         gamma
         alpha
         beta
@@ -78,7 +78,7 @@ describe ManualWithDocuments do
 
     it "raises an error if document_order doesn't contain all IDs" do
       expect {
-        manual_with_documents.reorder_documents(%w(
+        manual_with_documents.reorder_sections(%w(
           alpha
           beta
         ))
@@ -87,7 +87,7 @@ describe ManualWithDocuments do
 
     it "raises an error if document_order contains non-existent IDs" do
       expect {
-        manual_with_documents.reorder_documents(%w(
+        manual_with_documents.reorder_sections(%w(
           alpha
           beta
           gamma
@@ -98,7 +98,7 @@ describe ManualWithDocuments do
 
     it "raises an error if document_order contains duplicate IDs" do
       expect {
-        manual_with_documents.reorder_documents(%w(
+        manual_with_documents.reorder_sections(%w(
           alpha
           beta
           gamma

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -4,7 +4,7 @@ require "manual_with_documents"
 
 describe ManualWithDocuments do
   subject(:manual_with_documents) {
-    ManualWithDocuments.new(document_builder, manual, documents: documents)
+    ManualWithDocuments.new(document_builder, manual, sections: documents)
   }
 
   let(:manual) { double(:manual, publish: nil) }
@@ -113,7 +113,7 @@ describe ManualWithDocuments do
       ManualWithDocuments.new(
         document_builder,
         manual,
-        documents: documents,
+        sections: documents,
         removed_documents: removed_documents,
       )
     }

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -114,7 +114,7 @@ describe ManualWithDocuments do
         document_builder,
         manual,
         sections: documents,
-        removed_documents: removed_documents,
+        removed_sections: removed_documents,
       )
     }
 

--- a/spec/models/manual_with_documents_spec.rb
+++ b/spec/models/manual_with_documents_spec.rb
@@ -69,7 +69,7 @@ describe ManualWithDocuments do
         beta
       ))
 
-      expect(manual_with_documents.documents.to_a).to eq([
+      expect(manual_with_documents.sections.to_a).to eq([
         gamma_document,
         alpha_document,
         beta_document,
@@ -133,7 +133,7 @@ describe ManualWithDocuments do
     it "removes the document from #documents" do
       manual_with_documents.remove_section(document_a.id)
 
-      expect(manual_with_documents.documents.to_a).to eq([document_b])
+      expect(manual_with_documents.sections.to_a).to eq([document_b])
     end
 
     it "adds the document to #removed_sections" do

--- a/spec/models/manual_with_sections_spec.rb
+++ b/spec/models/manual_with_sections_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 require "manual_with_sections"
 
 describe ManualWithSections do
-  subject(:manual_with_documents) {
+  subject(:manual_with_sections) {
     ManualWithSections.new(document_builder, manual, sections: documents)
   }
 
@@ -21,7 +21,7 @@ describe ManualWithSections do
 
   describe "#publish" do
     it "notifies the underlying manual" do
-      manual_with_documents.publish
+      manual_with_sections.publish
 
       expect(manual).to have_received(:publish)
     end
@@ -32,7 +32,7 @@ describe ManualWithSections do
       end
 
       it "passes a block which publishes" do
-        manual_with_documents.publish
+        manual_with_sections.publish
 
         expect(document).to have_received(:publish!)
       end
@@ -40,7 +40,7 @@ describe ManualWithSections do
 
     context "when the manual publish does not succeed" do
       it "does not publish the documents" do
-        manual_with_documents.publish
+        manual_with_sections.publish
 
         expect(document).not_to have_received(:publish!)
       end
@@ -63,13 +63,13 @@ describe ManualWithSections do
     let(:document_order) { %w(gamma alpha beta) }
 
     it "reorders the documents to match the given order" do
-      manual_with_documents.reorder_sections(%w(
+      manual_with_sections.reorder_sections(%w(
         gamma
         alpha
         beta
       ))
 
-      expect(manual_with_documents.sections.to_a).to eq([
+      expect(manual_with_sections.sections.to_a).to eq([
         gamma_document,
         alpha_document,
         beta_document,
@@ -78,7 +78,7 @@ describe ManualWithSections do
 
     it "raises an error if document_order doesn't contain all IDs" do
       expect {
-        manual_with_documents.reorder_sections(%w(
+        manual_with_sections.reorder_sections(%w(
           alpha
           beta
         ))
@@ -87,7 +87,7 @@ describe ManualWithSections do
 
     it "raises an error if document_order contains non-existent IDs" do
       expect {
-        manual_with_documents.reorder_sections(%w(
+        manual_with_sections.reorder_sections(%w(
           alpha
           beta
           gamma
@@ -98,7 +98,7 @@ describe ManualWithSections do
 
     it "raises an error if document_order contains duplicate IDs" do
       expect {
-        manual_with_documents.reorder_sections(%w(
+        manual_with_sections.reorder_sections(%w(
           alpha
           beta
           gamma
@@ -109,7 +109,7 @@ describe ManualWithSections do
   end
 
   describe "#remove_section" do
-    subject(:manual_with_documents) {
+    subject(:manual_with_sections) {
       ManualWithSections.new(
         document_builder,
         manual,
@@ -131,15 +131,15 @@ describe ManualWithSections do
     let(:document_c) { double(:document, id: "c") }
 
     it "removes the document from #documents" do
-      manual_with_documents.remove_section(document_a.id)
+      manual_with_sections.remove_section(document_a.id)
 
-      expect(manual_with_documents.sections.to_a).to eq([document_b])
+      expect(manual_with_sections.sections.to_a).to eq([document_b])
     end
 
     it "adds the document to #removed_sections" do
-      manual_with_documents.remove_section(document_a.id)
+      manual_with_sections.remove_section(document_a.id)
 
-      expect(manual_with_documents.removed_sections.to_a).to eq(
+      expect(manual_with_sections.removed_sections.to_a).to eq(
         [
           document_c,
           document_a,

--- a/spec/models/manual_with_sections_spec.rb
+++ b/spec/models/manual_with_sections_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
-require "manual_with_documents"
+require "manual_with_sections"
 
-describe ManualWithDocuments do
+describe ManualWithSections do
   subject(:manual_with_documents) {
-    ManualWithDocuments.new(document_builder, manual, sections: documents)
+    ManualWithSections.new(document_builder, manual, sections: documents)
   }
 
   let(:manual) { double(:manual, publish: nil) }
@@ -110,7 +110,7 @@ describe ManualWithDocuments do
 
   describe "#remove_section" do
     subject(:manual_with_documents) {
-      ManualWithDocuments.new(
+      ManualWithSections.new(
         document_builder,
         manual,
         sections: documents,

--- a/spec/repositories/marshallers/document_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/document_association_marshaller_spec.rb
@@ -70,7 +70,7 @@ describe DocumentAssociationMarshaller do
       marshaller.load(entity, record)
 
       expect(decorator).to have_received(:call).
-        with(entity, sections: documents, removed_documents: removed_documents)
+        with(entity, sections: documents, removed_sections: removed_documents)
     end
 
     it "returns the decorated entity" do

--- a/spec/repositories/marshallers/document_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/document_association_marshaller_spec.rb
@@ -83,7 +83,7 @@ describe DocumentAssociationMarshaller do
   describe "#dump" do
     before do
       allow(entity).to receive(:documents).and_return(documents)
-      allow(entity).to receive(:removed_documents).and_return(removed_documents)
+      allow(entity).to receive(:removed_sections).and_return(removed_documents)
     end
 
     it "saves associated documents and removed documents" do

--- a/spec/repositories/marshallers/document_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/document_association_marshaller_spec.rb
@@ -82,7 +82,7 @@ describe DocumentAssociationMarshaller do
 
   describe "#dump" do
     before do
-      allow(entity).to receive(:documents).and_return(documents)
+      allow(entity).to receive(:sections).and_return(documents)
       allow(entity).to receive(:removed_sections).and_return(removed_documents)
     end
 

--- a/spec/repositories/marshallers/document_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/document_association_marshaller_spec.rb
@@ -70,7 +70,7 @@ describe DocumentAssociationMarshaller do
       marshaller.load(entity, record)
 
       expect(decorator).to have_received(:call).
-        with(entity, documents: documents, removed_documents: removed_documents)
+        with(entity, sections: documents, removed_documents: removed_documents)
     end
 
     it "returns the decorated entity" do

--- a/spec/repositories/versioned_manual_repository_spec.rb
+++ b/spec/repositories/versioned_manual_repository_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe VersionedManualRepository do
     context "the draft version returned" do
       subject { repository.get_manual(manual_id)[:draft] }
 
-      it "is the first draft as a ManualWithDocuments instance" do
-        expect(subject).to be_a ::ManualWithDocuments
+      it "is the first draft as a ManualWithSections instance" do
+        expect(subject).to be_a ::ManualWithSections
         expect(subject.id).to eq manual_id
         expect(subject.state).to eq "draft"
         expect(subject.version_number).to eq 1
@@ -72,8 +72,8 @@ RSpec.describe VersionedManualRepository do
     context "the published version returned" do
       subject { repository.get_manual(manual_id)[:published] }
 
-      it "is the published version as a ManualWithDocuments instance" do
-        expect(subject).to be_a ::ManualWithDocuments
+      it "is the published version as a ManualWithSections instance" do
+        expect(subject).to be_a ::ManualWithSections
         expect(subject.id).to eq manual_id
         expect(subject.state).to eq "published"
         expect(subject.version_number).to eq 1
@@ -155,8 +155,8 @@ RSpec.describe VersionedManualRepository do
       context "the published version returned" do
         subject { repository.get_manual(manual_id)[:published] }
 
-        it "is the published version as a ManualWithDocuments instance" do
-          expect(subject).to be_a ::ManualWithDocuments
+        it "is the published version as a ManualWithSections instance" do
+          expect(subject).to be_a ::ManualWithSections
           expect(subject.id).to eq manual_id
           expect(subject.state).to eq "published"
           expect(subject.version_number).to eq 1
@@ -186,8 +186,8 @@ RSpec.describe VersionedManualRepository do
       context "the draft version returned" do
         subject { repository.get_manual(manual_id)[:draft] }
 
-        it "is the new draft as a ManualWithDocuments instance" do
-          expect(subject).to be_a ::ManualWithDocuments
+        it "is the new draft as a ManualWithSections instance" do
+          expect(subject).to be_a ::ManualWithSections
           expect(subject.id).to eq manual_id
           expect(subject.state).to eq "draft"
           expect(subject.version_number).to eq 2
@@ -222,8 +222,8 @@ RSpec.describe VersionedManualRepository do
       context "the published version returned" do
         subject { repository.get_manual(manual_id)[:published] }
 
-        it "is the published version as a ManualWithDocuments instance" do
-          expect(subject).to be_a ::ManualWithDocuments
+        it "is the published version as a ManualWithSections instance" do
+          expect(subject).to be_a ::ManualWithSections
           expect(subject.id).to eq manual_id
           expect(subject.state).to eq "published"
           expect(subject.version_number).to eq 1
@@ -253,8 +253,8 @@ RSpec.describe VersionedManualRepository do
       context "the draft version returned" do
         subject { repository.get_manual(manual_id)[:draft] }
 
-        it "is the new draft as a ManualWithDocuments instance" do
-          expect(subject).to be_a ::ManualWithDocuments
+        it "is the new draft as a ManualWithSections instance" do
+          expect(subject).to be_a ::ManualWithSections
           expect(subject.id).to eq manual_id
           expect(subject.state).to eq "draft"
           expect(subject.version_number).to eq 2
@@ -290,8 +290,8 @@ RSpec.describe VersionedManualRepository do
       context "the published version returned" do
         subject { repository.get_manual(manual_id)[:published] }
 
-        it "is the published version as a ManualWithDocuments instance" do
-          expect(subject).to be_a ::ManualWithDocuments
+        it "is the published version as a ManualWithSections instance" do
+          expect(subject).to be_a ::ManualWithSections
           expect(subject.id).to eq manual_id
           expect(subject.state).to eq "published"
           expect(subject.version_number).to eq 1
@@ -321,8 +321,8 @@ RSpec.describe VersionedManualRepository do
       context "the draft version returned" do
         subject { repository.get_manual(manual_id)[:draft] }
 
-        it "is the new draft as a ManualWithDocuments instance" do
-          expect(subject).to be_a ::ManualWithDocuments
+        it "is the new draft as a ManualWithSections instance" do
+          expect(subject).to be_a ::ManualWithSections
           expect(subject.id).to eq manual_id
           expect(subject.state).to eq "draft"
           expect(subject.version_number).to eq 2

--- a/spec/repositories/versioned_manual_repository_spec.rb
+++ b/spec/repositories/versioned_manual_repository_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe VersionedManualRepository do
       end
 
       it "has the first draft of the section editions as Section instances attached" do
-        documents = subject.documents.to_a
+        documents = subject.sections.to_a
         expect(documents.size).to eq 2
 
         document_1 = documents[0]
@@ -81,7 +81,7 @@ RSpec.describe VersionedManualRepository do
       end
 
       it "has the published version of the section editions as Section instances attached" do
-        documents = subject.documents.to_a
+        documents = subject.sections.to_a
         expect(documents.size).to eq 2
 
         document_1 = documents[0]
@@ -164,7 +164,7 @@ RSpec.describe VersionedManualRepository do
         end
 
         it "has the published versions of the section editions as Section instances attached" do
-          documents = subject.documents.to_a
+          documents = subject.sections.to_a
           expect(documents.size).to eq 2
 
           document_1 = documents[0]
@@ -195,7 +195,7 @@ RSpec.describe VersionedManualRepository do
         end
 
         it "has the new drafts of the section editions as Section instances attached" do
-          documents = subject.documents.to_a
+          documents = subject.sections.to_a
           expect(documents.size).to eq 2
 
           document_1 = documents[0]
@@ -231,7 +231,7 @@ RSpec.describe VersionedManualRepository do
         end
 
         it "has the published versions of the section editions as Section instances attached" do
-          documents = subject.documents.to_a
+          documents = subject.sections.to_a
           expect(documents.size).to eq 2
 
           document_1 = documents[0]
@@ -262,7 +262,7 @@ RSpec.describe VersionedManualRepository do
         end
 
         it "has the published versions of the section editions as Section instances attached" do
-          documents = subject.documents.to_a
+          documents = subject.sections.to_a
           expect(documents.size).to eq 2
 
           document_1 = documents[0]
@@ -299,7 +299,7 @@ RSpec.describe VersionedManualRepository do
         end
 
         it "has the published versions of the section editions as Section instances attached" do
-          documents = subject.documents.to_a
+          documents = subject.sections.to_a
           expect(documents.size).to eq 2
 
           document_1 = documents[0]
@@ -330,7 +330,7 @@ RSpec.describe VersionedManualRepository do
         end
 
         it "has correct draft or published version of the section editions as Section instances attached" do
-          documents = subject.documents.to_a
+          documents = subject.sections.to_a
           expect(documents.size).to eq 2
 
           document_1 = documents[0]

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RemoveSectionService do
   let(:manual) {
     double(
       draft: nil,
-      documents: [
+      sections: [
         document,
       ],
       remove_section: nil,
@@ -52,7 +52,7 @@ RSpec.describe RemoveSectionService do
     let(:manual) {
       double(
         draft: nil,
-        documents: [],
+        sections: [],
         remove_section: nil,
       )
     }

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RemoveSectionService do
       documents: [
         document,
       ],
-      remove_document: nil,
+      remove_section: nil,
     )
   }
 
@@ -53,7 +53,7 @@ RSpec.describe RemoveSectionService do
       double(
         draft: nil,
         documents: [],
-        remove_document: nil,
+        remove_section: nil,
       )
     }
     let(:change_note_params) do
@@ -110,7 +110,7 @@ RSpec.describe RemoveSectionService do
     end
 
     it "does not removes the section" do
-      expect(manual).not_to have_received(:remove_document).with(document.id)
+      expect(manual).not_to have_received(:remove_section).with(document.id)
     end
 
     it "does not mark the manual as a draft" do
@@ -157,7 +157,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "removes the section" do
-        expect(manual).to have_received(:remove_document).with(document.id)
+        expect(manual).to have_received(:remove_section).with(document.id)
       end
 
       it "marks the manual as a draft" do
@@ -196,7 +196,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "removes the section" do
-        expect(manual).to have_received(:remove_document).with(document_id)
+        expect(manual).to have_received(:remove_section).with(document_id)
       end
 
       it "marks the manual as a draft" do

--- a/spec/services/update_manual_original_publication_date_service_spec.rb
+++ b/spec/services/update_manual_original_publication_date_service_spec.rb
@@ -4,7 +4,7 @@ require "update_manual_original_publication_date_service"
 RSpec.describe UpdateManualOriginalPublicationDateService do
   let(:manual_id) { double(:manual_id) }
   let(:manual_repository) { double(:manual_repository) }
-  let(:manual) { double(:manual, id: manual_id, documents: documents) }
+  let(:manual) { double(:manual, id: manual_id, sections: documents) }
   let(:document_1) { double(:document, update: nil) }
   let(:document_2) { double(:document, update: nil) }
   let(:documents) { [document_1, document_2] }


### PR DESCRIPTION
This branch renames `ManualWithDocuments` and its methods to reflect the language of the domain.

Note that there are still lots of variables (in code and test) that refer to 'documents' instead of 'sections'. I'm intentionally not changing them in this branch as it's a big enough change as it is.
