### PR TITLE
Add missing require to section_factory.rb

### DIFF
--- a/app/lib/section_factory.rb
+++ b/app/lib/section_factory.rb
@@ -1,3 +1,6 @@
+require 'validators/change_note_validator'
+require 'validators/section_validator'
+
 class SectionFactory
   def initialize(manual)
     @manual = manual


### PR DESCRIPTION
This avoids the following error when trying to view a Manual in
development:

    uninitialized constant SectionFactory::ChangeNoteValidator

This is similar to the problem we saw in
01e4ab5af2fdb2a3811a4ea02fff9a2ceb1b93e7. As noted in that commit it
doesn't seem to be possible to write a test to protect us from these
sort of problems.