### PR TITLE
Remove manuals observers registry

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -6,7 +6,6 @@ require "queue_publish_manual_service"
 require "publish_manual_worker"
 require "preview_manual_service"
 require "builders/manual_builder"
-require "manual_observers_registry"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]

--- a/app/exporters/publishing_api_draft_manual_with_sections_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_with_sections_exporter.rb
@@ -1,0 +1,31 @@
+class PublishingApiDraftManualWithSectionsExporter
+  def call(manual, action = nil)
+    update_type = (action == :republish ? "republish" : nil)
+
+    organisation = organisation(manual.attributes.fetch(:organisation_slug))
+
+    ManualPublishingAPILinksExporter.new(
+      organisation, manual
+    ).call
+
+    ManualPublishingAPIExporter.new(
+      organisation, manual, update_type: update_type
+    ).call
+
+    manual.sections.each do |document|
+      next if !document.needs_exporting? && action != :republish
+
+      SectionPublishingAPILinksExporter.new(
+        organisation, manual, document
+      ).call
+
+      SectionPublishingAPIExporter.new(
+        organisation, manual, document, update_type: update_type
+      ).call
+    end
+  end
+
+  def organisation(slug)
+    OrganisationFetcher.fetch(slug)
+  end
+end

--- a/app/exporters/publishing_api_manual_with_sections_publisher.rb
+++ b/app/exporters/publishing_api_manual_with_sections_publisher.rb
@@ -1,0 +1,33 @@
+class PublishingApiManualWithSectionsPublisher
+  def call(manual, action = nil)
+    update_type = (action == :republish ? "republish" : nil)
+    PublishingAPIPublisher.new(
+      entity: manual,
+      update_type: update_type,
+    ).call
+
+    manual.sections.each do |document|
+      next if !document.needs_exporting? && action != :republish
+
+      PublishingAPIPublisher.new(
+        entity: document,
+        update_type: update_type,
+      ).call
+
+      document.mark_as_exported! if action != :republish
+    end
+
+    manual.removed_sections.each do |document|
+      next if document.withdrawn? && action != :republish
+      begin
+        publishing_api_v2.unpublish(document.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+      rescue GdsApi::HTTPNotFound # rubocop:disable Lint/HandleExceptions
+      end
+      document.withdraw_and_mark_as_exported! if action != :republish
+    end
+  end
+
+  def publishing_api_v2
+    Services.publishing_api_v2
+  end
+end

--- a/app/exporters/publishing_api_manual_with_sections_withdrawer.rb
+++ b/app/exporters/publishing_api_manual_with_sections_withdrawer.rb
@@ -1,0 +1,13 @@
+class PublishingApiManualWithSectionsWithdrawer
+  def call(manual, _ = nil)
+    PublishingAPIWithdrawer.new(
+      entity: manual,
+    ).call
+
+    manual.sections.each do |document|
+      PublishingAPIWithdrawer.new(
+        entity: document,
+      ).call
+    end
+  end
+end

--- a/app/exporters/rummager_manual_with_sections_exporter.rb
+++ b/app/exporters/rummager_manual_with_sections_exporter.rb
@@ -1,0 +1,26 @@
+require "rummager_indexer"
+
+class RummagerManualWithSectionsExporter
+  def call(manual, _ = nil)
+    indexer = RummagerIndexer.new
+
+    indexer.add(
+      ManualIndexableFormatter.new(manual)
+    )
+
+    manual.sections.each do |section|
+      indexer.add(
+        SectionIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(section),
+          manual,
+        )
+      )
+    end
+
+    manual.removed_sections.each do |section|
+      indexer.delete(
+        SectionIndexableFormatter.new(section, manual),
+      )
+    end
+  end
+end

--- a/app/exporters/rummager_manual_with_sections_withdrawer.rb
+++ b/app/exporters/rummager_manual_with_sections_withdrawer.rb
@@ -1,0 +1,18 @@
+class RummagerManualWithSectionsWithdrawer
+  def call(manual, _ = nil)
+    indexer = RummagerIndexer.new
+
+    indexer.delete(
+      ManualIndexableFormatter.new(manual)
+    )
+
+    manual.sections.each do |section|
+      indexer.delete(
+        SectionIndexableFormatter.new(
+          MarkdownAttachmentProcessor.new(section),
+          manual,
+        )
+      )
+    end
+  end
+end

--- a/app/lib/publication_logger.rb
+++ b/app/lib/publication_logger.rb
@@ -1,0 +1,27 @@
+class PublicationLogger
+  def call(manual)
+    manual.sections.each do |doc|
+      next unless doc.needs_exporting?
+      next if doc.minor_update?
+
+      PublicationLog.create!(
+        title: doc.title,
+        slug: doc.slug,
+        version_number: doc.version_number,
+        change_note: doc.change_note,
+      )
+    end
+
+    manual.removed_sections.each do |doc|
+      next if doc.withdrawn?
+      next if doc.minor_update?
+
+      PublicationLog.create!(
+        title: doc.title,
+        slug: doc.slug,
+        version_number: doc.version_number,
+        change_note: doc.change_note,
+      )
+    end
+  end
+end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -6,21 +6,6 @@ require 'rummager_manual_with_sections_withdrawer'
 require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
-  def publication
-    # The order here is important. For example content exporting
-    # should happen before publishing to search.
-    #
-    # A draft export step follows publication logging as this ensures that
-    # change notes that relate to the current draft are pushed straight to the
-    # publishing API rather than on the subsequent draft-publish cycle.
-    [
-      PublicationLogger.new,
-      PublishingApiDraftManualWithSectionsExporter.new,
-      PublishingApiManualWithSectionsPublisher.new,
-      RummagerManualWithSectionsExporter.new,
-    ]
-  end
-
   def republication
     # Note that these should probably always be called with the :republish
     # action as 2nd argument, but we have to leave that up to the calling

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -6,12 +6,11 @@ require 'rummager_manual_with_sections_withdrawer'
 require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
-  def update
+  def update_original_publication_date
     [
       PublishingApiDraftManualWithSectionsExporter.new
     ]
   end
-  alias_method :update_original_publication_date, :update
 
   def creation
     [

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -1,9 +1,3 @@
-require "manual_publishing_api_exporter"
-require "section_publishing_api_exporter"
-require "publishing_api_withdrawer"
-require "formatters/manual_indexable_formatter"
-require "formatters/section_indexable_formatter"
-require "services"
 require 'publication_logger'
 require 'publishing_api_draft_manual_with_sections_exporter'
 require 'publishing_api_manual_with_sections_publisher'

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -6,10 +6,4 @@ require 'rummager_manual_with_sections_withdrawer'
 require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
-  def withdrawal
-    [
-      PublishingApiManualWithSectionsWithdrawer.new,
-      RummagerManualWithSectionsWithdrawer.new,
-    ]
-  end
 end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -9,6 +9,7 @@ require 'publishing_api_draft_manual_with_sections_exporter'
 require 'publishing_api_manual_with_sections_publisher'
 require 'rummager_manual_with_sections_exporter'
 require 'rummager_manual_with_sections_withdrawer'
+require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
   def publication
@@ -52,28 +53,8 @@ class ManualObserversRegistry
 
   def withdrawal
     [
-      publishing_api_withdrawer,
+      PublishingApiManualWithSectionsWithdrawer.new,
       RummagerManualWithSectionsWithdrawer.new,
     ]
-  end
-
-private
-
-  def publishing_api_withdrawer
-    ->(manual, _ = nil) {
-      PublishingAPIWithdrawer.new(
-        entity: manual,
-      ).call
-
-      manual.sections.each do |document|
-        PublishingAPIWithdrawer.new(
-          entity: document,
-        ).call
-      end
-    }
-  end
-
-  def publishing_api_v2
-    Services.publishing_api_v2
   end
 end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -6,17 +6,6 @@ require 'rummager_manual_with_sections_withdrawer'
 require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
-  def republication
-    # Note that these should probably always be called with the :republish
-    # action as 2nd argument, but we have to leave that up to the calling
-    # service, rather than being able to encode it explicitly here.
-    [
-      PublishingApiDraftManualWithSectionsExporter.new,
-      PublishingApiManualWithSectionsPublisher.new,
-      RummagerManualWithSectionsExporter.new,
-    ]
-  end
-
   def update
     [
       PublishingApiDraftManualWithSectionsExporter.new

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -8,6 +8,7 @@ require 'publication_logger'
 require 'publishing_api_draft_manual_with_sections_exporter'
 require 'publishing_api_manual_with_sections_publisher'
 require 'rummager_manual_with_sections_exporter'
+require 'rummager_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
   def publication
@@ -52,30 +53,11 @@ class ManualObserversRegistry
   def withdrawal
     [
       publishing_api_withdrawer,
-      rummager_withdrawer,
+      RummagerManualWithSectionsWithdrawer.new,
     ]
   end
 
 private
-
-  def rummager_withdrawer
-    ->(manual, _ = nil) {
-      indexer = RummagerIndexer.new
-
-      indexer.delete(
-        ManualIndexableFormatter.new(manual)
-      )
-
-      manual.sections.each do |section|
-        indexer.delete(
-          SectionIndexableFormatter.new(
-            MarkdownAttachmentProcessor.new(section),
-            manual,
-          )
-        )
-      end
-    }
-  end
 
   def publishing_api_withdrawer
     ->(manual, _ = nil) {

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -6,12 +6,6 @@ require 'rummager_manual_with_sections_withdrawer'
 require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
-  def creation
-    [
-      PublishingApiDraftManualWithSectionsExporter.new
-    ]
-  end
-
   def withdrawal
     [
       PublishingApiManualWithSectionsWithdrawer.new,

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -6,12 +6,6 @@ require 'rummager_manual_with_sections_withdrawer'
 require 'publishing_api_manual_with_sections_withdrawer'
 
 class ManualObserversRegistry
-  def update_original_publication_date
-    [
-      PublishingApiDraftManualWithSectionsExporter.new
-    ]
-  end
-
   def creation
     [
       PublishingApiDraftManualWithSectionsExporter.new

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -1,9 +1,0 @@
-require 'publication_logger'
-require 'publishing_api_draft_manual_with_sections_exporter'
-require 'publishing_api_manual_with_sections_publisher'
-require 'rummager_manual_with_sections_exporter'
-require 'rummager_manual_with_sections_withdrawer'
-require 'publishing_api_manual_with_sections_withdrawer'
-
-class ManualObserversRegistry
-end

--- a/app/observers/manual_observers_registry.rb
+++ b/app/observers/manual_observers_registry.rb
@@ -1,13 +1,13 @@
 require "manual_publishing_api_exporter"
 require "section_publishing_api_exporter"
 require "publishing_api_withdrawer"
-require "rummager_indexer"
 require "formatters/manual_indexable_formatter"
 require "formatters/section_indexable_formatter"
 require "services"
 require 'publication_logger'
 require 'publishing_api_draft_manual_with_sections_exporter'
 require 'publishing_api_manual_with_sections_publisher'
+require 'rummager_manual_with_sections_exporter'
 
 class ManualObserversRegistry
   def publication
@@ -21,7 +21,7 @@ class ManualObserversRegistry
       PublicationLogger.new,
       PublishingApiDraftManualWithSectionsExporter.new,
       PublishingApiManualWithSectionsPublisher.new,
-      rummager_exporter,
+      RummagerManualWithSectionsExporter.new,
     ]
   end
 
@@ -32,7 +32,7 @@ class ManualObserversRegistry
     [
       PublishingApiDraftManualWithSectionsExporter.new,
       PublishingApiManualWithSectionsPublisher.new,
-      rummager_exporter,
+      RummagerManualWithSectionsExporter.new,
     ]
   end
 
@@ -57,31 +57,6 @@ class ManualObserversRegistry
   end
 
 private
-
-  def rummager_exporter
-    ->(manual, _ = nil) {
-      indexer = RummagerIndexer.new
-
-      indexer.add(
-        ManualIndexableFormatter.new(manual)
-      )
-
-      manual.sections.each do |section|
-        indexer.add(
-          SectionIndexableFormatter.new(
-            MarkdownAttachmentProcessor.new(section),
-            manual,
-          )
-        )
-      end
-
-      manual.removed_sections.each do |section|
-        indexer.delete(
-          SectionIndexableFormatter.new(section, manual),
-        )
-      end
-    }
-  end
 
   def rummager_withdrawer
     ->(manual, _ = nil) {

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -2,14 +2,13 @@ class CreateManualService
   def initialize(manual_repository:, manual_builder:, attributes:)
     @manual_repository = manual_repository
     @manual_builder = manual_builder
-    @listeners = [PublishingApiDraftManualWithSectionsExporter.new]
     @attributes = attributes
   end
 
   def call
     if manual.valid?
       persist
-      notify_listeners
+      export_draft_to_publishing_api
     end
 
     manual
@@ -20,7 +19,6 @@ private
   attr_reader(
     :manual_repository,
     :manual_builder,
-    :listeners,
     :attributes,
   )
 
@@ -32,10 +30,8 @@ private
     manual_repository.store(manual)
   end
 
-  def notify_listeners
+  def export_draft_to_publishing_api
     reloaded_manual = manual_repository[manual.id]
-    listeners.each do |listener|
-      listener.call(reloaded_manual)
-    end
+    PublishingApiDraftManualWithSectionsExporter.new.call(reloaded_manual)
   end
 end

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -2,7 +2,7 @@ class CreateManualService
   def initialize(manual_repository:, manual_builder:, attributes:)
     @manual_repository = manual_repository
     @manual_builder = manual_builder
-    @listeners = ManualObserversRegistry.new.creation
+    @listeners = [PublishingApiDraftManualWithSectionsExporter.new]
     @attributes = attributes
   end
 

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -2,7 +2,12 @@ class PublishManualService
   def initialize(manual_id:, manual_repository:, version_number:)
     @manual_id = manual_id
     @manual_repository = manual_repository
-    @listeners = ManualObserversRegistry.new.publication
+    @listeners = [
+      PublicationLogger.new,
+      PublishingApiDraftManualWithSectionsExporter.new,
+      PublishingApiManualWithSectionsPublisher.new,
+      RummagerManualWithSectionsExporter.new,
+    ]
     @version_number = version_number
   end
 

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -1,7 +1,11 @@
 class RepublishManualService
   def initialize(manual_id:)
+    @published_listeners = [
+      PublishingApiDraftManualWithSectionsExporter.new,
+      PublishingApiManualWithSectionsPublisher.new,
+      RummagerManualWithSectionsExporter.new,
+    ]
     registry = ManualObserversRegistry.new
-    @published_listeners = registry.republication
     @draft_listeners = registry.update
     @manual_id = manual_id
   end

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -5,8 +5,7 @@ class RepublishManualService
       PublishingApiManualWithSectionsPublisher.new,
       RummagerManualWithSectionsExporter.new,
     ]
-    registry = ManualObserversRegistry.new
-    @draft_listeners = registry.update
+    @draft_listeners = [PublishingApiDraftManualWithSectionsExporter.new]
     @manual_id = manual_id
   end
 

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -1,35 +1,52 @@
 class RepublishManualService
   def initialize(manual_id:)
-    @published_listeners = [
-      PublishingApiDraftManualWithSectionsExporter.new,
-      PublishingApiManualWithSectionsPublisher.new,
-      RummagerManualWithSectionsExporter.new,
-    ]
-    @draft_listeners = [PublishingApiDraftManualWithSectionsExporter.new]
     @manual_id = manual_id
   end
 
   def call
-    notify_published_listeners if manual_versions[:published].present?
-    notify_draft_listeners if manual_versions[:draft].present?
+    if published_manual_version.present?
+      export_published_manual_via_publishing_api
+      republish_published_manual_to_publishing_api
+      republish_published_manual_to_rummager
+    end
+
+    if draft_manual_version.present?
+      export_draft_manual_via_publishing_api
+    end
 
     manual_versions
   end
 
 private
 
-  attr_reader :published_listeners, :draft_listeners, :manual_id
+  attr_reader :manual_id
+
+  def published_manual_version
+    manual_versions[:published]
+  end
+
+  def draft_manual_version
+    manual_versions[:draft]
+  end
 
   def manual_repository
     VersionedManualRepository
   end
 
-  def notify_published_listeners
-    published_listeners.each { |l| l.call(manual_versions[:published], :republish) }
+  def export_published_manual_via_publishing_api
+    PublishingApiDraftManualWithSectionsExporter.new.call(published_manual_version, :republish)
   end
 
-  def notify_draft_listeners
-    draft_listeners.each { |l| l.call(manual_versions[:draft], :republish) }
+  def republish_published_manual_to_publishing_api
+    PublishingApiManualWithSectionsPublisher.new.call(published_manual_version, :republish)
+  end
+
+  def republish_published_manual_to_rummager
+    RummagerManualWithSectionsExporter.new.call(published_manual_version, :republish)
+  end
+
+  def export_draft_manual_via_publishing_api
+    PublishingApiDraftManualWithSectionsExporter.new.call(draft_manual_version, :republish)
   end
 
   def manual_versions

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -3,7 +3,7 @@ class UpdateManualOriginalPublicationDateService
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
-    @listeners = ManualObserversRegistry.new.update_original_publication_date
+    @listeners = [PublishingApiDraftManualWithSectionsExporter.new]
   end
 
   def call

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -3,7 +3,6 @@ class UpdateManualOriginalPublicationDateService
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
-    @listeners = [PublishingApiDraftManualWithSectionsExporter.new]
   end
 
   def call
@@ -12,7 +11,7 @@ class UpdateManualOriginalPublicationDateService
     update_documents
     persist
 
-    notify_listeners
+    export_draft_to_publishing_api
 
     manual
   end
@@ -23,7 +22,6 @@ private
     :manual_id,
     :manual_repository,
     :attributes,
-    :listeners,
   )
 
   def update
@@ -46,10 +44,8 @@ private
     end
   end
 
-  def notify_listeners
-    listeners.each do |listener|
-      listener.call(manual)
-    end
+  def export_draft_to_publishing_api
+    PublishingApiDraftManualWithSectionsExporter.new.call(manual)
   end
 
   def fetch_manual

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -3,14 +3,13 @@ class UpdateManualService
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes
-    @listeners = [PublishingApiDraftManualWithSectionsExporter.new]
   end
 
   def call
     manual.draft
     update
     persist
-    notify_listeners
+    export_draft_to_publishing_api
 
     manual
   end
@@ -21,7 +20,6 @@ private
     :manual_id,
     :manual_repository,
     :attributes,
-    :listeners,
   )
 
   def update
@@ -36,10 +34,8 @@ private
     @manual ||= manual_repository.fetch(manual_id)
   end
 
-  def notify_listeners
+  def export_draft_to_publishing_api
     reloaded_manual = manual_repository[manual.id]
-    listeners.each do |listener|
-      listener.call(reloaded_manual)
-    end
+    PublishingApiDraftManualWithSectionsExporter.new.call(reloaded_manual)
   end
 end

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -3,7 +3,7 @@ class UpdateManualService
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes
-    @listeners = ManualObserversRegistry.new.update
+    @listeners = [PublishingApiDraftManualWithSectionsExporter.new]
   end
 
   def call

--- a/app/services/withdraw_manual_service.rb
+++ b/app/services/withdraw_manual_service.rb
@@ -1,7 +1,10 @@
 class WithdrawManualService
-  def initialize(manual_repository:, listeners: [], manual_id:)
+  def initialize(manual_repository:, manual_id:)
     @manual_repository = manual_repository
-    @listeners = listeners
+    @listeners = [
+      PublishingApiManualWithSectionsWithdrawer.new,
+      RummagerManualWithSectionsWithdrawer.new,
+    ]
     @manual_id = manual_id
   end
 

--- a/app/services/withdraw_manual_service.rb
+++ b/app/services/withdraw_manual_service.rb
@@ -1,10 +1,6 @@
 class WithdrawManualService
   def initialize(manual_repository:, manual_id:)
     @manual_repository = manual_repository
-    @listeners = [
-      PublishingApiManualWithSectionsWithdrawer.new,
-      RummagerManualWithSectionsWithdrawer.new,
-    ]
     @manual_id = manual_id
   end
 
@@ -13,7 +9,8 @@ class WithdrawManualService
 
     if manual.withdrawn?
       persist
-      notify_listeners
+      withdraw_via_publishing_api
+      withdraw_from_rummager
     end
 
     manual
@@ -21,7 +18,7 @@ class WithdrawManualService
 
 private
 
-  attr_reader :manual_repository, :listeners, :manual_id
+  attr_reader :manual_repository, :manual_id
 
   def withdraw
     manual.withdraw
@@ -31,8 +28,12 @@ private
     manual_repository.store(manual)
   end
 
-  def notify_listeners
-    listeners.each { |l| l.call(manual) }
+  def withdraw_via_publishing_api
+    PublishingApiManualWithSectionsWithdrawer.new.call(manual)
+  end
+
+  def withdraw_from_rummager
+    RummagerManualWithSectionsWithdrawer.new.call(manual)
   end
 
   def manual

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -6,10 +6,8 @@ class ManualWithdrawer
   end
 
   def execute(manual_id)
-    observers = ManualObserversRegistry.new
     service = WithdrawManualService.new(
       manual_repository: RepositoryRegistry.new.manual_repository,
-      listeners: observers.withdrawal,
       manual_id: manual_id,
     )
     manual = service.call

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe PublishManualService do
   let(:manual_id) { double(:manual_id) }
   let(:manual_repository) { double(:manual_repository) }
   let(:manual) { double(:manual, id: manual_id, version_number: 3) }
-  let(:registry) { double(:registry, publication: []) }
+  let(:publication_logger) { double(:publication_logger) }
+  let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
+  let(:new_publishing_api_publisher) { double(:new_publishing_api_publisher) }
+  let(:rummager_exporter) { double(:rummager_exporter) }
 
   subject {
     PublishManualService.new(
@@ -22,7 +25,14 @@ RSpec.describe PublishManualService do
     allow(manual).to receive(:publish)
     allow(manual).to receive(:update)
     allow(manual).to receive(:documents)
-    allow(ManualObserversRegistry).to receive(:new).and_return(registry)
+    allow(PublicationLogger).to receive(:new) { publication_logger }
+    allow(PublishingApiDraftManualWithSectionsExporter).to receive(:new) { publishing_api_draft_exporter }
+    allow(PublishingApiManualWithSectionsPublisher).to receive(:new) { new_publishing_api_publisher }
+    allow(RummagerManualWithSectionsExporter).to receive(:new) { rummager_exporter }
+    allow(publication_logger).to receive(:call)
+    allow(publishing_api_draft_exporter).to receive(:call)
+    allow(new_publishing_api_publisher).to receive(:call)
+    allow(rummager_exporter).to receive(:call)
   end
 
   context "when the version number is up to date" do
@@ -31,6 +41,35 @@ RSpec.describe PublishManualService do
     it "publishes the manual" do
       subject.call
       expect(manual).to have_received(:publish)
+    end
+
+    it "calls the publication logger" do
+      subject.call
+      expect(publication_logger).to have_received(:call).with(manual)
+    end
+
+    it "calls the publishing api draft exporter" do
+      subject.call
+      expect(publishing_api_draft_exporter).to have_received(:call).with(manual)
+    end
+
+    it "calls the new publishing api publisher" do
+      subject.call
+      expect(new_publishing_api_publisher).to have_received(:call).with(manual)
+    end
+
+    it "calls the rummager exporter" do
+      subject.call
+      expect(rummager_exporter).to have_received(:call).with(manual)
+    end
+
+    it "makes the calls to the collaborators in the correct order" do
+      subject.call
+
+      expect(publication_logger).to have_received(:call).ordered
+      expect(publishing_api_draft_exporter).to have_received(:call).ordered
+      expect(new_publishing_api_publisher).to have_received(:call).ordered
+      expect(rummager_exporter).to have_received(:call).ordered
     end
   end
 

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -4,13 +4,14 @@ require "versioned_manual_repository"
 
 RSpec.describe RepublishManualService do
   let(:manual_id) { double(:manual_id) }
-  let(:published_listener) { double(:listener) }
-  let(:published_listeners) { [published_listener] }
   let(:draft_listener) { double(:listener) }
   let(:draft_listeners) { [draft_listener] }
-  let(:registry) { double(:registry, update: draft_listeners, republication: published_listeners) }
+  let(:registry) { double(:registry, update: draft_listeners) }
   let(:published_manual_version) { double(:manual) }
   let(:draft_manual_version) { double(:manual) }
+  let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
+  let(:publishing_api_publisher) { double(:publishing_api_publisher) }
+  let(:rummager_exporter) { double(:rummager_exporter) }
 
   subject {
     described_class.new(
@@ -20,8 +21,13 @@ RSpec.describe RepublishManualService do
 
   before do
     allow(draft_listener).to receive(:call)
-    allow(published_listener).to receive(:call)
     allow(ManualObserversRegistry).to receive(:new).and_return(registry)
+    allow(PublishingApiDraftManualWithSectionsExporter).to receive(:new) { publishing_api_draft_exporter }
+    allow(PublishingApiManualWithSectionsPublisher).to receive(:new) { publishing_api_publisher }
+    allow(RummagerManualWithSectionsExporter).to receive(:new) { rummager_exporter }
+    allow(publishing_api_draft_exporter).to receive(:call)
+    allow(publishing_api_publisher).to receive(:call)
+    allow(rummager_exporter).to receive(:call)
   end
 
   context "(for a published manual)" do
@@ -34,9 +40,19 @@ RSpec.describe RepublishManualService do
         )
     end
 
-    it "tells the published listeners to republish the published version of the manual" do
+    it "calls the publishing api draft exporter" do
       subject.call
-      expect(published_listener).to have_received(:call).with(published_manual_version, :republish)
+      expect(publishing_api_draft_exporter).to have_received(:call).with(published_manual_version, :republish)
+    end
+
+    it "calls the new publishing api publisher" do
+      subject.call
+      expect(publishing_api_publisher).to have_received(:call).with(published_manual_version, :republish)
+    end
+
+    it "calls the rummager exporter" do
+      subject.call
+      expect(rummager_exporter).to have_received(:call).with(published_manual_version, :republish)
     end
 
     it "tells the draft listeners nothing" do
@@ -57,7 +73,9 @@ RSpec.describe RepublishManualService do
 
     it "tells the published listeners nothing" do
       subject.call
-      expect(published_listener).not_to have_received(:call)
+      expect(publishing_api_draft_exporter).not_to have_received(:call)
+      expect(publishing_api_publisher).not_to have_received(:call)
+      expect(rummager_exporter).not_to have_received(:call)
     end
 
     it "tells the draft listeners to republish the draft version of the manual" do
@@ -76,9 +94,19 @@ RSpec.describe RepublishManualService do
         )
     end
 
-    it "tells the published listeners to republish the published version of the manual" do
+    it "calls the publishing api draft exporter" do
       subject.call
-      expect(published_listener).to have_received(:call).with(published_manual_version, :republish)
+      expect(publishing_api_draft_exporter).to have_received(:call).with(published_manual_version, :republish)
+    end
+
+    it "calls the new publishing api publisher" do
+      subject.call
+      expect(publishing_api_publisher).to have_received(:call).with(published_manual_version, :republish)
+    end
+
+    it "calls the rummager exporter" do
+      subject.call
+      expect(rummager_exporter).to have_received(:call).with(published_manual_version, :republish)
     end
 
     it "tells the draft listeners to republish the draft version of the manual" do
@@ -102,7 +130,9 @@ RSpec.describe RepublishManualService do
 
     it "tells none of the listeners to do anything" do
       begin; subject.call; rescue(RepublishManualService::ManualNotFoundError); end
-      expect(published_listener).not_to have_received(:call)
+      expect(publishing_api_draft_exporter).not_to have_received(:call)
+      expect(publishing_api_publisher).not_to have_received(:call)
+      expect(rummager_exporter).not_to have_received(:call)
       expect(draft_listener).not_to have_received(:call)
     end
   end
@@ -119,7 +149,9 @@ RSpec.describe RepublishManualService do
 
     it "tells none of the listeners to do anything" do
       subject.call
-      expect(published_listener).not_to have_received(:call)
+      expect(publishing_api_draft_exporter).not_to have_received(:call)
+      expect(publishing_api_publisher).not_to have_received(:call)
+      expect(rummager_exporter).not_to have_received(:call)
       expect(draft_listener).not_to have_received(:call)
     end
   end

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -4,9 +4,6 @@ require "versioned_manual_repository"
 
 RSpec.describe RepublishManualService do
   let(:manual_id) { double(:manual_id) }
-  let(:draft_listener) { double(:listener) }
-  let(:draft_listeners) { [draft_listener] }
-  let(:registry) { double(:registry, update: draft_listeners) }
   let(:published_manual_version) { double(:manual) }
   let(:draft_manual_version) { double(:manual) }
   let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
@@ -20,8 +17,6 @@ RSpec.describe RepublishManualService do
   }
 
   before do
-    allow(draft_listener).to receive(:call)
-    allow(ManualObserversRegistry).to receive(:new).and_return(registry)
     allow(PublishingApiDraftManualWithSectionsExporter).to receive(:new) { publishing_api_draft_exporter }
     allow(PublishingApiManualWithSectionsPublisher).to receive(:new) { publishing_api_publisher }
     allow(RummagerManualWithSectionsExporter).to receive(:new) { rummager_exporter }
@@ -57,7 +52,7 @@ RSpec.describe RepublishManualService do
 
     it "tells the draft listeners nothing" do
       subject.call
-      expect(draft_listener).not_to have_received(:call)
+      expect(publishing_api_draft_exporter).not_to have_received(:call).with(draft_manual_version, :republish)
     end
   end
 
@@ -73,14 +68,14 @@ RSpec.describe RepublishManualService do
 
     it "tells the published listeners nothing" do
       subject.call
-      expect(publishing_api_draft_exporter).not_to have_received(:call)
       expect(publishing_api_publisher).not_to have_received(:call)
+      expect(publishing_api_draft_exporter).not_to have_received(:call).with(published_manual_version, :republish)
       expect(rummager_exporter).not_to have_received(:call)
     end
 
     it "tells the draft listeners to republish the draft version of the manual" do
       subject.call
-      expect(draft_listener).to have_received(:call).with(draft_manual_version, :republish)
+      expect(publishing_api_draft_exporter).to have_received(:call).with(draft_manual_version, :republish)
     end
   end
 
@@ -111,7 +106,7 @@ RSpec.describe RepublishManualService do
 
     it "tells the draft listeners to republish the draft version of the manual" do
       subject.call
-      expect(draft_listener).to have_received(:call).with(draft_manual_version, :republish)
+      expect(publishing_api_draft_exporter).to have_received(:call).with(draft_manual_version, :republish)
     end
   end
 
@@ -133,7 +128,6 @@ RSpec.describe RepublishManualService do
       expect(publishing_api_draft_exporter).not_to have_received(:call)
       expect(publishing_api_publisher).not_to have_received(:call)
       expect(rummager_exporter).not_to have_received(:call)
-      expect(draft_listener).not_to have_received(:call)
     end
   end
 
@@ -152,7 +146,6 @@ RSpec.describe RepublishManualService do
       expect(publishing_api_draft_exporter).not_to have_received(:call)
       expect(publishing_api_publisher).not_to have_received(:call)
       expect(rummager_exporter).not_to have_received(:call)
-      expect(draft_listener).not_to have_received(:call)
     end
   end
 end

--- a/spec/services/update_manual_original_publication_date_service_spec.rb
+++ b/spec/services/update_manual_original_publication_date_service_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
   let(:document_2) { double(:document, update: nil) }
   let(:documents) { [document_1, document_2] }
   let(:originally_published_at) { 10.years.ago }
-  let(:registry) { double(:registry, update_original_publication_date: [listener]) }
-  let(:listener) { double(:listener) }
+  let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
 
   subject {
     described_class.new(
@@ -29,8 +28,8 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
     allow(manual_repository).to receive(:store)
     allow(manual).to receive(:draft)
     allow(manual).to receive(:update)
-    allow(ManualObserversRegistry).to receive(:new).and_return(registry)
-    allow(listener).to receive(:call)
+    allow(PublishingApiDraftManualWithSectionsExporter).to receive(:new) { publishing_api_draft_exporter }
+    allow(publishing_api_draft_exporter).to receive(:call)
   end
 
   it "updates the manual with only the originally_published_at and use_originally_published_at_for_public_timestamp attribtues" do
@@ -60,6 +59,6 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
     subject.call
 
     expect(manual_repository).to have_received(:store).with(manual).ordered
-    expect(listener).to have_received(:call).with(manual).ordered
+    expect(publishing_api_draft_exporter).to have_received(:call).with(manual).ordered
   end
 end


### PR DESCRIPTION
This PR removes the `ManualObserversRegistry` and inlines the functionality into the Service classes. This allows us to remove all of the references to "listeners" and instead use more imperative method names in the Service classes. 

I've struggled a little bit to come up with names for some of these methods and classes that I have extracted and I think this points to the fact that their functionality is duplicated in part elsewhere in the application. In particular: 

- NewPublishingApiPublisher <-> PublishingAPIPublisher
- NewPublishingApiWithdrawer <-> PublishingAPIWithdrawer
- PublishingApiDraftExporter <-> PublishingApiDraftManualExporter <-> PublishingApiDraftSectionExporter

If we're happy with these changes, I might raise issues to capture those three areas as places where we might be able to simplify the code. 
