### PR TITLE
Add missing require statements

### DIFF
--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -1,4 +1,6 @@
 require "securerandom"
+require "validators/manual_validator"
+require "validators/null_validator"
 
 class ManualBuilder
   def self.create

--- a/app/models/manual_with_sections.rb
+++ b/app/models/manual_with_sections.rb
@@ -1,4 +1,5 @@
 require "delegate"
+require "builders/section_builder"
 
 class ManualWithSections < SimpleDelegator
   def self.create(attrs)

--- a/app/models/validators/manual_validator.rb
+++ b/app/models/validators/manual_validator.rb
@@ -1,4 +1,5 @@
 require "delegate"
+require "validators/safe_html_validator"
 
 class ManualValidator < SimpleDelegator
   include ActiveModel::Validations


### PR DESCRIPTION
I needed to add these in order to be able to navigate to /manuals/new in
development.

They've been needed since 30a72a16dadde70c86a669ae23f715f20554b7fd.
Prior to that commit, constructing a `RepositoryRegistry` (which happens
indirectly in `ManualsController#index`) would result in a
`DocumentFactoryRegistry` being created which in turn would result in
the necessary builders and validators being required.

As of this commit I appear to be able to do everything through the user
interface as expected.

A longer term fix might be to autoload/require the builders and
validators as suggested in issue #907.