### PR TITLE
Stub Services.rummager instead of GdsApi::Rummager.new

### DIFF
--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -16,7 +16,7 @@ module RummagerHelpers
     allow(fake_rummager).to receive(:add_document).and_call_original
     allow(fake_rummager).to receive(:delete_document).and_call_original
 
-    allow(GdsApi::Rummager).to receive(:new)
+    allow(Services).to receive(:rummager)
       .and_return(fake_rummager)
   end
 


### PR DESCRIPTION
Stubbing `GdsApi::Rummager.new` has no effect if `Services.rummager` has
already been called because `Services.rummager` memoizes the result of
`GdsApi::Rummager.new`.

This fixes some intermittent test failures I saw after adding a new test
that uses the GdsApi::TestHelpers::Rummager methods to stub calls to
Rummager.

The tests that failed were the RSpec features:
republishing_manuals_spec.rb and publishing_manuals_spec.rb.

I could replicate the problem by adding a spec named aaaa_spec.rb
containing a single test that calls `Services.rummager`.  Running
`bundle exec rspec --order=defined` with this spec in place means that
`Services.rummager` calls and memoises the result of
`GdsApi::Rummager.new` before it's then stubbed by calls to
`stub_rummager` from the `before(:each)` in the RSpec config in
spec_helper.rb.