### PR TITLE
Add paths to autoload

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -5,7 +5,6 @@ require "update_manual_service"
 require "queue_publish_manual_service"
 require "publish_manual_worker"
 require "preview_manual_service"
-require "builders/manual_builder"
 
 class ManualsController < ApplicationController
   before_filter :authorize_user_for_publishing, only: [:publish]

--- a/app/lib/section_factory.rb
+++ b/app/lib/section_factory.rb
@@ -1,6 +1,3 @@
-require 'validators/change_note_validator'
-require 'validators/section_validator'
-
 class SectionFactory
   def initialize(manual)
     @manual = manual

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -1,6 +1,4 @@
 require "securerandom"
-require "validators/manual_validator"
-require "validators/null_validator"
 
 class ManualBuilder
   def self.create

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -3,7 +3,6 @@ require "validators/section_validator"
 require "validators/manual_validator"
 require "validators/null_validator"
 
-require "builders/section_builder"
 require "manual_with_sections"
 require "slug_generator"
 require "section"

--- a/app/models/document_factory_registry.rb
+++ b/app/models/document_factory_registry.rb
@@ -1,8 +1,3 @@
-require "validators/change_note_validator"
-require "validators/section_validator"
-require "validators/manual_validator"
-require "validators/null_validator"
-
 require "manual_with_sections"
 require "slug_generator"
 require "section"

--- a/app/models/manual_with_sections.rb
+++ b/app/models/manual_with_sections.rb
@@ -1,5 +1,4 @@
 require "delegate"
-require "builders/section_builder"
 
 class ManualWithSections < SimpleDelegator
   def self.create(attrs)

--- a/app/models/validators/manual_validator.rb
+++ b/app/models/validators/manual_validator.rb
@@ -1,5 +1,4 @@
 require "delegate"
-require "validators/safe_html_validator"
 
 class ManualValidator < SimpleDelegator
   include ActiveModel::Validations

--- a/app/models/validators/section_validator.rb
+++ b/app/models/validators/section_validator.rb
@@ -1,5 +1,4 @@
 require "delegate"
-require "validators/safe_html_validator"
 
 class SectionValidator < SimpleDelegator
   include ActiveModel::Validations

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,9 @@ module ManualsPublisher
     # Enable the asset pipeline
     config.assets.enabled = true
     config.assets.initialize_on_precompile = true
+
+    # These paths are non-standard (they are subdirectories of
+    # app/models) so they need to be added to the autoload_paths
+    config.autoload_paths << "#{Rails.root}/app/models/builders"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,6 @@ module ManualsPublisher
     # These paths are non-standard (they are subdirectories of
     # app/models) so they need to be added to the autoload_paths
     config.autoload_paths << "#{Rails.root}/app/models/builders"
+    config.autoload_paths << "#{Rails.root}/app/models/validators"
   end
 end

--- a/spec/models/validators/change_note_validator_spec.rb
+++ b/spec/models/validators/change_note_validator_spec.rb
@@ -1,7 +1,5 @@
 require "spec_helper"
 
-require "validators/change_note_validator"
-
 RSpec.describe ChangeNoteValidator do
   subject(:validatable) {
     ChangeNoteValidator.new(entity)


### PR DESCRIPTION
Fixes #907 

On master, running `be rails r 'puts ActiveSupport::Dependencies.autoload_paths'` shows the following application paths in the `autoload_paths`

```
/app/assets
/app/controllers
/app/exporters
/app/helpers
/app/lib
/app/models
/app/observers
/app/repositories
/app/services
/app/view_adapters
/app/workers
```

This PR adds 

```
/app/models/builders
/app/models/validators
```

so that we don't have to explicitly require files in those paths in order for the application to work in development (where `config.cache_classes = false`). 

I tried to find the relevant lines in the Rails 3.2 code that shows that only one level of subdirectory under `app` is added to `autoload_paths` by default, but I couldn't. It is [mentioned in the rails guides for recent versions of rails](http://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-paths).