### PR TITLE
Inline PublishManualWorker in QueuePublishManualService

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -123,7 +123,6 @@ class ManualsController < ApplicationController
 
   def publish
     service = QueuePublishManualService.new(
-      PublishManualWorker,
       repository,
       manual_id,
     )

--- a/app/services/queue_publish_manual_service.rb
+++ b/app/services/queue_publish_manual_service.rb
@@ -1,8 +1,7 @@
 require "manual_publish_task"
 
 class QueuePublishManualService
-  def initialize(worker, repository, manual_id)
-    @worker = worker
+  def initialize(repository, manual_id)
     @repository = repository
     @manual_id = manual_id
   end
@@ -10,7 +9,7 @@ class QueuePublishManualService
   def call
     if manual.draft?
       task = create_publish_task(manual)
-      worker.perform_async(task.to_param, govuk_header_params)
+      PublishManualWorker.perform_async(task.to_param, govuk_header_params)
       manual
     else
       raise InvalidStateError.new(
@@ -22,7 +21,6 @@ class QueuePublishManualService
 private
 
   attr_reader(
-    :worker,
     :repository,
     :manual_id,
   )

--- a/spec/services/queue_publish_manual_service_spec.rb
+++ b/spec/services/queue_publish_manual_service_spec.rb
@@ -5,14 +5,14 @@ require "ostruct"
 RSpec.describe QueuePublishManualService do
   let(:manual_id) { double(:manual_id) }
   let(:repository) { double(:repository) }
-  let(:worker) { double(:worker, perform_async: nil) }
   let(:manual) { double(:manual, id: manual_id, version_number: 1, draft?: draft) }
   let(:draft) { true }
 
-  subject { QueuePublishManualService.new(worker, repository, manual_id) }
+  subject { QueuePublishManualService.new(repository, manual_id) }
 
   before do
     allow(repository).to receive(:fetch) { manual }
+    allow(PublishManualWorker).to receive(:perform_async)
   end
 
   context "when the manual is a draft" do
@@ -20,7 +20,7 @@ RSpec.describe QueuePublishManualService do
 
     it "worker performs task asynchronously" do
       subject.call
-      expect(worker).to have_received(:perform_async)
+      expect(PublishManualWorker).to have_received(:perform_async)
     end
   end
 


### PR DESCRIPTION
`QueuePublishManualService#initialize` only ever receives
`PublishManualWorker` as its worker argument. It makes it clearer what
the service does if this is in-lined into the service.