### PR TITLE
Extract DuplicateDocumentFinder

### DIFF
--- a/bin/find_duplicate_documents
+++ b/bin/find_duplicate_documents
@@ -1,18 +1,6 @@
 #!/usr/bin/env ruby
 
 require File.expand_path("../../config/environment", __FILE__)
+require 'duplicate_document_finder'
 
-slug_hash = {}
-SectionEdition.all.each do |edition|
-  slug_hash[edition.slug] ||= {}
-  slug_hash[edition.slug][edition.document_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0 }
-  slug_hash[edition.slug][edition.document_id][:editions] += 1
-end
-
-slug_hash.reject! { |_slug, document_ids| document_ids.size == 1 }
-
-slug_hash.each do |slug, sections|
-  sections.each do |document_id, data|
-    puts [slug, document_id, data[:state], data[:created_at], data[:editions]].join(",")
-  end
-end
+DuplicateDocumentFinder.new.execute

--- a/lib/duplicate_document_finder.rb
+++ b/lib/duplicate_document_finder.rb
@@ -1,0 +1,22 @@
+class DuplicateDocumentFinder
+  def initialize(io = STDOUT)
+    @io = io
+  end
+
+  def execute
+    slug_hash = {}
+    SectionEdition.all.each do |edition|
+      slug_hash[edition.slug] ||= {}
+      slug_hash[edition.slug][edition.document_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0 }
+      slug_hash[edition.slug][edition.document_id][:editions] += 1
+    end
+
+    slug_hash.reject! { |_slug, document_ids| document_ids.size == 1 }
+
+    slug_hash.each do |slug, sections|
+      sections.each do |document_id, data|
+        @io.puts [slug, document_id, data[:state], data[:created_at], data[:editions]].join(",")
+      end
+    end
+  end
+end

--- a/spec/lib/duplicate_document_finder_spec.rb
+++ b/spec/lib/duplicate_document_finder_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "duplicate_document_finder"
+
+describe DuplicateDocumentFinder do
+  subject {
+    described_class.new(io)
+  }
+
+  let(:io) { double(:io) }
+
+  before {
+    allow(io).to receive(:puts)
+  }
+
+  context 'when there are multiple editions with different slugs' do
+    before {
+      FactoryGirl.create(:section_edition, slug: 'slug-1')
+      FactoryGirl.create(:section_edition, slug: 'slug-2')
+    }
+
+    it "doesn't report them as duplicates" do
+      subject.execute
+
+      expect(io).to_not receive(:puts)
+    end
+  end
+
+  context 'when there are multiple editions with the same slug and same document id' do
+    before {
+      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
+    }
+
+    it "doesn't report them as duplicates" do
+      subject.execute
+
+      expect(io).to_not receive(:puts)
+    end
+  end
+
+  context 'when there are multiple editions with the same slug and different document ids' do
+    let!(:edition_1) {
+      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
+    }
+    let!(:edition_2) {
+      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 2)
+    }
+
+    it "reports them as duplicates" do
+      edition_1_data = [
+        edition_1.slug, edition_1.document_id, edition_1.state, edition_1.created_at, 1
+      ]
+      edition_2_data = [
+        edition_2.slug, edition_2.document_id, edition_2.state, edition_2.created_at, 1
+      ]
+
+      expect(io).to receive(:puts).with(edition_1_data.join(','))
+      expect(io).to receive(:puts).with(edition_2_data.join(','))
+
+      subject.execute
+    end
+  end
+end


### PR DESCRIPTION
This addresses one of the three scripts mentioned in issue #855.

And add a spec to test the behaviour.

The spec isn't ideal but I think it's probably good enough to give us
some confidence that we won't break this script while we continue to
refactor the app.