### PR TITLE
Rename document to section (part 2)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,9 +70,9 @@ module ApplicationHelper
     end
   end
 
-  def preview_path_for_section(manual, document)
-    if document.persisted?
-      preview_manual_section_path(manual, document)
+  def preview_path_for_section(manual, section)
+    if section.persisted?
+      preview_manual_section_path(manual, section)
     else
       preview_new_section_path(manual)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,14 @@
 # encoding: UTF-8
 
 module ApplicationHelper
-  def state(document)
-    state = document.publication_state
+  def state(manual)
+    state = manual.publication_state
 
-    if %w(published withdrawn).include?(state) && document.draft?
+    if %w(published withdrawn).include?(state) && manual.draft?
       state << " with new draft"
     end
 
-    classes = if document.draft?
+    classes = if manual.draft?
                 "label label-primary"
               else
                 "label label-default"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,8 +86,8 @@ module ApplicationHelper
     "#{Plek.current.website_root}/government/organisations/#{organisation_slug}"
   end
 
-  def content_preview_url(document)
-    "#{Plek.current.find('draft-origin')}/#{document.slug}"
+  def content_preview_url(manual)
+    "#{Plek.current.find('draft-origin')}/#{manual.slug}"
   end
 
   def publish_text(manual, slug_unique)

--- a/app/lib/manual_update_type.rb
+++ b/app/lib/manual_update_type.rb
@@ -15,14 +15,14 @@ class ManualUpdateType
     # Otherwise our update type status depends on the update type status
     # of our children if any of them are major we are major (and they
     # have to send a major for their first edition too).
-    all_documents_are_minor? ? "minor" : "major"
+    all_sections_are_minor? ? "minor" : "major"
   end
 
 private
 
   attr_reader :manual
 
-  def all_documents_are_minor?
+  def all_sections_are_minor?
     manual.
       sections.
       select(&:needs_exporting?).

--- a/app/models/builders/section_builder.rb
+++ b/app/models/builders/section_builder.rb
@@ -3,11 +3,11 @@ require "securerandom"
 class SectionBuilder
   def call(manual, attrs)
     section_factory = SectionFactory.new(manual)
-    document = section_factory.call(SecureRandom.uuid, [])
+    section = section_factory.call(SecureRandom.uuid, [])
 
-    document.update(attrs.reverse_merge(defaults))
+    section.update(attrs.reverse_merge(defaults))
 
-    document
+    section
   end
 
 private

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -10,7 +10,7 @@ class ReorderSectionsService
     persist
     export_draft_manual_to_publishing_api
 
-    [manual, documents]
+    [manual, sections]
   end
 
 private
@@ -18,14 +18,14 @@ private
   attr_reader :manual_repository, :context
 
   def update
-    manual.reorder_sections(document_order)
+    manual.reorder_sections(section_order)
   end
 
   def persist
     manual_repository.store(manual)
   end
 
-  def documents
+  def sections
     manual.sections
   end
 
@@ -37,7 +37,7 @@ private
     context.params.fetch("manual_id")
   end
 
-  def document_order
+  def section_order
     context.params.fetch("section_order")
   end
 

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -69,11 +69,11 @@
     </div>
     <% if manual.sections.any? %>
     <ul class="document-list">
-     <% manual.sections.each do |document| %>
+     <% manual.sections.each do |section| %>
         <li class="document">
-          <%= link_to(document.title, manual_section_path(manual, document), class: 'document-title') %>
+          <%= link_to(section.title, manual_section_path(manual, section), class: 'document-title') %>
           <ul class="metadata">
-            <li class="text-muted">Updated <%= time_ago_in_words(document.updated_at) %> ago</li>
+            <li class="text-muted">Updated <%= time_ago_in_words(section.updated_at) %> ago</li>
           </ul>
         </li>
       <% end %>

--- a/bin/find_duplicate_documents
+++ b/bin/find_duplicate_documents
@@ -11,8 +11,8 @@ end
 
 slug_hash.reject! { |_slug, document_ids| document_ids.size == 1 }
 
-slug_hash.each do |slug, documents|
-  documents.each do |document_id, data|
+slug_hash.each do |slug, sections|
+  sections.each do |document_id, data|
     puts [slug, document_id, data[:state], data[:created_at], data[:editions]].join(",")
   end
 end

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -54,5 +54,5 @@ Then(/^I cannot publish manuals$/) do
 end
 
 Then(/^I cannot remove a section from the manual$/) do
-  check_section_withdraw_link_not_visible(@manual, @documents.first)
+  check_section_withdraw_link_not_visible(@manual, @sections.first)
 end

--- a/features/step_definitions/access_control_steps.rb
+++ b/features/step_definitions/access_control_steps.rb
@@ -54,5 +54,5 @@ Then(/^I cannot publish manuals$/) do
 end
 
 Then(/^I cannot remove a section from the manual$/) do
-  check_document_withdraw_link_not_visible(@manual, @documents.first)
+  check_section_withdraw_link_not_visible(@manual, @documents.first)
 end

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -1,6 +1,6 @@
 When(/^I attach a file and give it a title$/) do
   @attachment_title = "My attachment"
-  add_attachment_to_section(@document_title, @attachment_title)
+  add_attachment_to_section(@section_title, @attachment_title)
 end
 
 Then(/^I can see a link to the file with the title in the section preview$/) do
@@ -12,7 +12,7 @@ When(/^I edit the attachment$/) do
   @new_attachment_file_name = "text_file.txt"
 
   edit_attachment(
-    @document_title,
+    @section_title,
     @attachment_title,
     @new_attachment_title,
     @new_attachment_file_name,
@@ -21,7 +21,7 @@ end
 
 Then(/^I see the updated attachment on the section edit page$/) do
   check_for_attachment_update(
-    @document_title,
+    @section_title,
     @new_attachment_title,
     @new_attachment_file_name,
   )

--- a/features/step_definitions/deleting_manuals_steps.rb
+++ b/features/step_definitions/deleting_manuals_steps.rb
@@ -24,7 +24,7 @@ end
 Then(/^the manual and its sections are deleted$/) do
   check_manual_does_not_exist_with(@manual_fields)
   check_draft_has_been_discarded_in_publishing_api(@manual.id)
-  check_draft_has_been_discarded_in_publishing_api(@document.id)
+  check_draft_has_been_discarded_in_publishing_api(@section.id)
 end
 
 Then(/^the manual and its sections still exist$/) do

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -106,11 +106,11 @@ Then(/^I see errors for the title field$/) do
 end
 
 When(/^I create a section for the manual$/) do
-  @document_title = "Created Section 1"
+  @section_title = "Created Section 1"
   @document_slug = [@manual_slug, "created-section-1"].join("/")
 
   @section_fields = {
-    section_title: @document_title,
+    section_title: @section_title,
     section_summary: "Section 1 summary",
     section_body: "Section 1 body",
   }
@@ -121,12 +121,12 @@ When(/^I create a section for the manual$/) do
 end
 
 When(/^I create a section for the manual with a change note$/) do
-  @document_title = "Created Section 1"
+  @section_title = "Created Section 1"
   @document_slug = [@manual_slug, "created-section-1"].join("/")
 
   @change_note = "Adding a brand new exciting section"
   @section_fields = {
-    section_title: @document_title,
+    section_title: @section_title,
     section_summary: "Section 1 summary",
     section_body: "Section 1 body",
     change_note: @change_note
@@ -152,7 +152,7 @@ Then(/^the section and table of contents will have been sent to the draft publis
           title: "Contents",
           child_sections: [
             {
-              title: @document_title,
+              title: @section_title,
               description: @section_fields[:section_summary],
               base_path: "/#{@document_slug}",
             }
@@ -192,11 +192,11 @@ Then(/^the updated section at the new slug and updated table of contents will ha
 end
 
 Given(/^a draft section exists for the manual$/) do
-  @document_title = "New section"
+  @section_title = "New section"
   @document_slug = "guidance/example-manual-title/new-section"
 
   @section_fields = {
-    section_title: @document_title,
+    section_title: @section_title,
     section_summary: "New section summary",
     section_body: "New section body",
   }
@@ -381,11 +381,11 @@ Given(/^a published manual with some sections was created without the UI$/) do
 end
 
 When(/^I create a section for the manual as a minor change without the UI$/) do
-  @document_title = "Created Section 1"
+  @section_title = "Created Section 1"
   @document_slug = [@manual_slug, "created-section-1"].join("/")
 
   @section_fields = {
-    title: @document_title,
+    title: @section_title,
     summary: "Section 1 summary",
     body: "Section 1 body",
     minor_update: true

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -684,14 +684,14 @@ When(/^I reorder the sections$/) do
   elems = page.all(".reorderable-document-list li.ui-sortable-handle")
   elems[0].drag_to(elems[1])
   click_on("Save section order")
-  @reordered_document_attributes = [
+  @reordered_section_attributes = [
     @attributes_for_sections[1],
     @attributes_for_sections[0]
   ]
 end
 
 Then(/^the order of the sections in the manual should have been updated$/) do
-  @reordered_document_attributes.map { |doc| doc[:title] }.each.with_index do |title, index|
+  @reordered_section_attributes.map { |doc| doc[:title] }.each.with_index do |title, index|
     expect(page).to have_css(".document-list li.document:nth-child(#{index + 1}) .document-title", text: title)
   end
 end
@@ -702,7 +702,7 @@ Then(/^the new order should be visible in the preview environment$/) do
       child_section_groups: [
         {
           title: "Contents",
-          child_sections: @reordered_document_attributes.map do |doc|
+          child_sections: @reordered_section_attributes.map do |doc|
             {
               title: doc[:fields][:section_title],
               description: doc[:fields][:section_summary],

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -107,7 +107,7 @@ end
 
 When(/^I create a section for the manual$/) do
   @section_title = "Created Section 1"
-  @document_slug = [@manual_slug, "created-section-1"].join("/")
+  @section_slug = [@manual_slug, "created-section-1"].join("/")
 
   @section_fields = {
     section_title: @section_title,
@@ -122,7 +122,7 @@ end
 
 When(/^I create a section for the manual with a change note$/) do
   @section_title = "Created Section 1"
-  @document_slug = [@manual_slug, "created-section-1"].join("/")
+  @section_slug = [@manual_slug, "created-section-1"].join("/")
 
   @change_note = "Adding a brand new exciting section"
   @section_fields = {
@@ -154,7 +154,7 @@ Then(/^the section and table of contents will have been sent to the draft publis
             {
               title: @section_title,
               description: @section_fields[:section_summary],
-              base_path: "/#{@document_slug}",
+              base_path: "/#{@section_slug}",
             }
           ]
         }
@@ -193,7 +193,7 @@ end
 
 Given(/^a draft section exists for the manual$/) do
   @section_title = "New section"
-  @document_slug = "guidance/example-manual-title/new-section"
+  @section_slug = "guidance/example-manual-title/new-section"
 
   @section_fields = {
     section_title: @section_title,
@@ -382,7 +382,7 @@ end
 
 When(/^I create a section for the manual as a minor change without the UI$/) do
   @section_title = "Created Section 1"
-  @document_slug = [@manual_slug, "created-section-1"].join("/")
+  @section_slug = [@manual_slug, "created-section-1"].join("/")
 
   @section_fields = {
     title: @section_title,

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -56,7 +56,7 @@ Given(/^a draft manual exists with some sections$/) do
 
   create_manual(@manual_fields)
 
-  @attributes_for_documents = create_documents_for_manual(
+  @attributes_for_documents = create_sections_for_manual(
     manual_fields: @manual_fields,
     count: 2,
   )
@@ -331,7 +331,7 @@ Given(/^a published manual exists$/) do
 
   create_manual(@manual_fields)
 
-  create_documents_for_manual(
+  create_sections_for_manual(
     manual_fields: @manual_fields,
     count: 2,
   )

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -265,7 +265,7 @@ Then(/^the manual and all its sections are published$/) do
       @manual,
       document,
       @manual_fields,
-      document_fields(document),
+      section_fields(document),
     )
   end
 end
@@ -312,7 +312,7 @@ Then(/^the manual and its new section are published$/) do
     @manual,
     @new_document,
     @manual_fields,
-    document_fields(@new_document),
+    section_fields(@new_document),
   )
 end
 

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -56,7 +56,7 @@ Given(/^a draft manual exists with some sections$/) do
 
   create_manual(@manual_fields)
 
-  @attributes_for_documents = create_sections_for_manual(
+  @attributes_for_sections = create_sections_for_manual(
     manual_fields: @manual_fields,
     count: 2,
   )
@@ -685,8 +685,8 @@ When(/^I reorder the sections$/) do
   elems[0].drag_to(elems[1])
   click_on("Save section order")
   @reordered_document_attributes = [
-    @attributes_for_documents[1],
-    @attributes_for_documents[0]
+    @attributes_for_sections[1],
+    @attributes_for_sections[0]
   ]
 end
 

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -272,16 +272,16 @@ end
 
 Then(/^the manual and the edited section are published$/) do
   check_manual_and_sections_were_published(
-    @manual, @updated_document, @manual_fields, @updated_fields
+    @manual, @updated_section, @manual_fields, @updated_fields
   )
 end
 
 Then(/^the updated section is available to preview$/) do
-  check_section_is_drafted_to_publishing_api(@updated_document.id)
+  check_section_is_drafted_to_publishing_api(@updated_section.id)
   sections = @sections.map do |document|
     {
-      title: document == @updated_document ? @updated_fields[:section_title] : document.title,
-      description: document == @updated_document ? @updated_fields[:section_summary] : document.summary,
+      title: document == @updated_section ? @updated_fields[:section_title] : document.title,
+      description: document == @updated_section ? @updated_fields[:section_summary] : document.summary,
       base_path: "/#{document.slug}",
     }
   end
@@ -302,7 +302,7 @@ Then(/^the updated section is available to preview$/) do
 end
 
 Then(/^the sections that I didn't edit were not republished$/) do
-  @sections.reject { |d| d.id == @updated_document.id }.each do |document|
+  @sections.reject { |d| d.id == @updated_section.id }.each do |document|
     check_section_was_not_published(document)
   end
 end
@@ -400,47 +400,47 @@ end
 
 When(/^I edit one of the manual's sections(?: as a major change)?$/) do
   WebMock::RequestRegistry.instance.reset!
-  @updated_document = @sections.first
+  @updated_section = @sections.first
 
   @updated_fields = {
-    section_title: @updated_document.title,
+    section_title: @updated_section.title,
     section_summary: "Updated section",
     section_body: "Updated section",
     change_note: "Updated section",
   }
 
-  edit_section(@manual_title || @manual.title, @updated_document.title, @updated_fields) do
+  edit_section(@manual_title || @manual.title, @updated_section.title, @updated_fields) do
     choose("Major update")
   end
 end
 
 When(/^I edit one of the manual's sections without a change note$/) do
   WebMock::RequestRegistry.instance.reset!
-  @updated_document = @sections.first
+  @updated_section = @sections.first
 
   @updated_fields = {
-    section_title: @updated_document.title,
+    section_title: @updated_section.title,
     section_summary: "Updated section",
     section_body: "Updated section",
     change_note: "",
   }
 
-  edit_section(@manual_title || @manual.title, @updated_document.title, @updated_fields) do
+  edit_section(@manual_title || @manual.title, @updated_section.title, @updated_fields) do
     choose("Major update")
   end
 end
 
 When(/^I edit one of the manual's sections as a minor change$/) do
   WebMock::RequestRegistry.instance.reset!
-  @updated_document = @sections.first
+  @updated_section = @sections.first
 
   @updated_fields = {
-    section_title: @updated_document.title,
+    section_title: @updated_section.title,
     section_summary: "Updated section",
     section_body: "Updated section",
   }
 
-  edit_section(@manual_title || @manual.title, @updated_document.title, @updated_fields) do
+  edit_section(@manual_title || @manual.title, @updated_section.title, @updated_fields) do
     choose("Minor update")
   end
 end
@@ -481,7 +481,7 @@ end
 Then(/^the section is updated without a change note$/) do
   check_section_exists_with(
     @manual_title,
-    section_title: @updated_document.title,
+    section_title: @updated_section.title,
     section_summary: @updated_fields[:section_summary],
   )
 end
@@ -507,19 +507,19 @@ end
 Then(/^the section is published as a major update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
 end
 
 Then(/^the section is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
+  check_section_is_drafted_to_publishing_api((@updated_section || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
 end
 
 Then(/^the section is published as a minor update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_document || @document).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @document).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
 end
 
 Then(/^I can see the change note and update type form when editing existing sections$/) do
@@ -541,7 +541,7 @@ end
 
 Then(/^the change note form for the section is clear$/) do
   go_to_manual_page(@manual.title)
-  click_on((@updated_document || @document).title)
+  click_on((@updated_section || @document).title)
   click_on "Edit section"
 
   check_that_change_note_fields_are_present(minor_update: false, note: "")
@@ -549,7 +549,7 @@ end
 
 Then(/^the change note form for the section contains my note$/) do
   go_to_manual_page(@manual.title)
-  click_on((@updated_document || @document).title)
+  click_on((@updated_section || @document).title)
   click_on "Edit section"
 
   check_that_change_note_fields_are_present(note_field_only: true, note: @change_note)

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -310,9 +310,9 @@ end
 Then(/^the manual and its new section are published$/) do
   check_manual_and_sections_were_published(
     @manual,
-    @new_document,
+    @new_section,
     @manual_fields,
-    section_fields(@new_document),
+    section_fields(@new_section),
   )
 end
 
@@ -566,7 +566,7 @@ When(/^I add another section to the manual$/) do
 
   create_section(@manual_title, fields)
 
-  @new_document = most_recently_created_manual.sections.to_a.last
+  @new_section = most_recently_created_manual.sections.to_a.last
 end
 
 Then(/^I see no visible change note in the section edit form$/) do

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -109,13 +109,13 @@ When(/^I create a section for the manual$/) do
   @document_title = "Created Section 1"
   @document_slug = [@manual_slug, "created-section-1"].join("/")
 
-  @document_fields = {
+  @section_fields = {
     section_title: @document_title,
     section_summary: "Section 1 summary",
     section_body: "Section 1 body",
   }
 
-  create_section(@manual_fields.fetch(:title), @document_fields)
+  create_section(@manual_fields.fetch(:title), @section_fields)
 
   @document = most_recently_created_manual.sections.to_a.last
 end
@@ -125,14 +125,14 @@ When(/^I create a section for the manual with a change note$/) do
   @document_slug = [@manual_slug, "created-section-1"].join("/")
 
   @change_note = "Adding a brand new exciting section"
-  @document_fields = {
+  @section_fields = {
     section_title: @document_title,
     section_summary: "Section 1 summary",
     section_body: "Section 1 body",
     change_note: @change_note
   }
 
-  create_section(@manual_fields.fetch(:title), @document_fields)
+  create_section(@manual_fields.fetch(:title), @section_fields)
 
   @document = most_recently_created_manual.sections.to_a.last
 end
@@ -140,7 +140,7 @@ end
 Then(/^I see the manual has the new section$/) do
   visit manuals_path
   click_on @manual_fields.fetch(:title)
-  expect(page).to have_content(@document_fields.fetch(:section_title))
+  expect(page).to have_content(@section_fields.fetch(:section_title))
 end
 
 Then(/^the section and table of contents will have been sent to the draft publishing api$/) do
@@ -153,7 +153,7 @@ Then(/^the section and table of contents will have been sent to the draft publis
           child_sections: [
             {
               title: @document_title,
-              description: @document_fields[:section_summary],
+              description: @section_fields[:section_summary],
               base_path: "/#{@document_slug}",
             }
           ]
@@ -177,7 +177,7 @@ Then(/^the updated section at the new slug and updated table of contents will ha
           child_sections: [
             {
               title: @new_title,
-              description: @document_fields[:section_summary],
+              description: @section_fields[:section_summary],
               base_path: "/#{@new_slug}",
             }
           ]
@@ -195,13 +195,13 @@ Given(/^a draft section exists for the manual$/) do
   @document_title = "New section"
   @document_slug = "guidance/example-manual-title/new-section"
 
-  @document_fields = {
+  @section_fields = {
     section_title: @document_title,
     section_summary: "New section summary",
     section_body: "New section body",
   }
 
-  create_section(@manual_fields.fetch(:title), @document_fields)
+  create_section(@manual_fields.fetch(:title), @section_fields)
 
   @document = most_recently_created_manual.sections.to_a.last
 
@@ -216,7 +216,7 @@ When(/^I edit the section$/) do
   @new_slug = "#{@manual_slug}/a-new-section-title"
   edit_section(
     @manual_fields.fetch(:title),
-    @document_fields.fetch(:section_title),
+    @section_fields.fetch(:section_title),
     section_title: @new_title,
   )
 end
@@ -229,7 +229,7 @@ Then(/^the section should have been updated$/) do
 end
 
 Then(/^the manual's sections won't have changed$/) do
-  expect(page).to have_content(@document_fields.fetch(:section_title))
+  expect(page).to have_content(@section_fields.fetch(:section_title))
 end
 
 When(/^I create a section with empty fields$/) do
@@ -384,14 +384,14 @@ When(/^I create a section for the manual as a minor change without the UI$/) do
   @document_title = "Created Section 1"
   @document_slug = [@manual_slug, "created-section-1"].join("/")
 
-  @document_fields = {
+  @section_fields = {
     title: @document_title,
     summary: "Section 1 summary",
     body: "Section 1 body",
     minor_update: true
   }
 
-  @document = create_section_without_ui(@manual, @document_fields, organisation_slug: GDS::SSO.test_user.organisation_slug)
+  @document = create_section_without_ui(@manual, @section_fields, organisation_slug: GDS::SSO.test_user.organisation_slug)
 
   go_to_manual_page(@manual.title)
 
@@ -450,7 +450,7 @@ When(/^I preview the section$/) do
 end
 
 When(/^I create a section to preview$/) do
-  @document_fields = {
+  @section_fields = {
     section_title: "Section 1",
     section_summary: "Section 1 summary",
     section_body: "Section 1 body",
@@ -458,7 +458,7 @@ When(/^I create a section to preview$/) do
 
   go_to_manual_page(@manual_fields[:title])
   click_on "Add section"
-  fill_in_fields(@document_fields)
+  fill_in_fields(@section_fields)
 end
 
 Then(/^I see the section body preview$/) do
@@ -583,7 +583,7 @@ When(/^I create another manual with the same slug$/) do
 end
 
 When(/^I create a section with duplicate title$/) do
-  create_section(@manual_fields.fetch(:title), @document_fields)
+  create_section(@manual_fields.fetch(:title), @section_fields)
 end
 
 Then(/^the manual and its sections have failed to publish$/) do

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -261,7 +261,7 @@ end
 
 Then(/^the manual and all its sections are published$/) do
   @documents.each do |document|
-    check_manual_and_documents_were_published(
+    check_manual_and_sections_were_published(
       @manual,
       document,
       @manual_fields,
@@ -271,7 +271,7 @@ Then(/^the manual and all its sections are published$/) do
 end
 
 Then(/^the manual and the edited section are published$/) do
-  check_manual_and_documents_were_published(
+  check_manual_and_sections_were_published(
     @manual, @updated_document, @manual_fields, @updated_fields
   )
 end
@@ -308,7 +308,7 @@ Then(/^the sections that I didn't edit were not republished$/) do
 end
 
 Then(/^the manual and its new section are published$/) do
-  check_manual_and_documents_were_published(
+  check_manual_and_sections_were_published(
     @manual,
     @new_document,
     @manual_fields,

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -62,8 +62,8 @@ Given(/^a draft manual exists with some sections$/) do
   )
 
   @manual = most_recently_created_manual
-  @documents = @manual.sections.to_a
-  @document = @documents.first
+  @sections = @manual.sections.to_a
+  @document = @sections.first
 
   WebMock::RequestRegistry.instance.reset!
 end
@@ -205,8 +205,8 @@ Given(/^a draft section exists for the manual$/) do
 
   @document = most_recently_created_manual.sections.to_a.last
 
-  @documents ||= []
-  @documents << @document
+  @sections ||= []
+  @sections << @document
 
   WebMock::RequestRegistry.instance.reset!
 end
@@ -260,7 +260,7 @@ When(/^I add another section and publish the manual later$/) do
 end
 
 Then(/^the manual and all its sections are published$/) do
-  @documents.each do |document|
+  @sections.each do |document|
     check_manual_and_sections_were_published(
       @manual,
       document,
@@ -278,7 +278,7 @@ end
 
 Then(/^the updated section is available to preview$/) do
   check_section_is_drafted_to_publishing_api(@updated_document.id)
-  sections = @documents.map do |document|
+  sections = @sections.map do |document|
     {
       title: document == @updated_document ? @updated_fields[:section_title] : document.title,
       description: document == @updated_document ? @updated_fields[:section_summary] : document.summary,
@@ -302,7 +302,7 @@ Then(/^the updated section is available to preview$/) do
 end
 
 Then(/^the sections that I didn't edit were not republished$/) do
-  @documents.reject { |d| d.id == @updated_document.id }.each do |document|
+  @sections.reject { |d| d.id == @updated_document.id }.each do |document|
     check_section_was_not_published(document)
   end
 end
@@ -337,7 +337,7 @@ Given(/^a published manual exists$/) do
   )
 
   @manual = most_recently_created_manual
-  @documents = @manual.sections.to_a
+  @sections = @manual.sections.to_a
 
   publish_manual
 
@@ -373,7 +373,7 @@ Given(/^a published manual with some sections was created without the UI$/) do
     },
     organisation_slug: GDS::SSO.test_user.organisation_slug
   )
-  @documents = [doc_1, doc_2]
+  @sections = [doc_1, doc_2]
 
   publish_manual_without_ui(@manual)
 
@@ -400,7 +400,7 @@ end
 
 When(/^I edit one of the manual's sections(?: as a major change)?$/) do
   WebMock::RequestRegistry.instance.reset!
-  @updated_document = @documents.first
+  @updated_document = @sections.first
 
   @updated_fields = {
     section_title: @updated_document.title,
@@ -416,7 +416,7 @@ end
 
 When(/^I edit one of the manual's sections without a change note$/) do
   WebMock::RequestRegistry.instance.reset!
-  @updated_document = @documents.first
+  @updated_document = @sections.first
 
   @updated_fields = {
     section_title: @updated_document.title,
@@ -432,7 +432,7 @@ end
 
 When(/^I edit one of the manual's sections as a minor change$/) do
   WebMock::RequestRegistry.instance.reset!
-  @updated_document = @documents.first
+  @updated_document = @sections.first
 
   @updated_fields = {
     section_title: @updated_document.title,
@@ -523,7 +523,7 @@ Then(/^the section is published as a minor update including a change note draft$
 end
 
 Then(/^I can see the change note and update type form when editing existing sections$/) do
-  @documents.each do |document|
+  @sections.each do |document|
     go_to_manual_page(@manual.title)
     click_on document.title
     click_on "Edit section"
@@ -570,7 +570,7 @@ When(/^I add another section to the manual$/) do
 end
 
 Then(/^I see no visible change note in the section edit form$/) do
-  document = @documents.first
+  document = @sections.first
   check_change_note_value(@manual_title, document.title, "")
 end
 
@@ -668,7 +668,7 @@ When(/^a DevOps specialist withdraws the manual for me$/) do
 end
 
 Then(/^the manual should be withdrawn$/) do
-  check_manual_is_withdrawn(@manual, @documents)
+  check_manual_is_withdrawn(@manual, @sections)
 end
 
 Then(/^the manual should belong to "(.*?)"$/) do |organisation_slug|

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -260,12 +260,12 @@ When(/^I add another section and publish the manual later$/) do
 end
 
 Then(/^the manual and all its sections are published$/) do
-  @sections.each do |document|
+  @sections.each do |section|
     check_manual_and_sections_were_published(
       @manual,
-      document,
+      section,
       @manual_fields,
-      section_fields(document),
+      section_fields(section),
     )
   end
 end
@@ -278,11 +278,11 @@ end
 
 Then(/^the updated section is available to preview$/) do
   check_section_is_drafted_to_publishing_api(@updated_section.id)
-  sections = @sections.map do |document|
+  sections = @sections.map do |section|
     {
-      title: document == @updated_section ? @updated_fields[:section_title] : document.title,
-      description: document == @updated_section ? @updated_fields[:section_summary] : document.summary,
-      base_path: "/#{document.slug}",
+      title: section == @updated_section ? @updated_fields[:section_title] : section.title,
+      description: section == @updated_section ? @updated_fields[:section_summary] : section.summary,
+      base_path: "/#{section.slug}",
     }
   end
   manual_table_of_contents_attributes = {
@@ -302,8 +302,8 @@ Then(/^the updated section is available to preview$/) do
 end
 
 Then(/^the sections that I didn't edit were not republished$/) do
-  @sections.reject { |d| d.id == @updated_section.id }.each do |document|
-    check_section_was_not_published(document)
+  @sections.reject { |s| s.id == @updated_section.id }.each do |section|
+    check_section_was_not_published(section)
   end
 end
 
@@ -355,7 +355,7 @@ Given(/^a published manual with some sections was created without the UI$/) do
 
   @manual = create_manual_without_ui(@manual_fields, organisation_slug: GDS::SSO.test_user.organisation_slug)
 
-  doc_1 = create_section_without_ui(
+  sec_1 = create_section_without_ui(
     @manual,
     {
       title: "1st example section",
@@ -364,7 +364,7 @@ Given(/^a published manual with some sections was created without the UI$/) do
     },
     organisation_slug: GDS::SSO.test_user.organisation_slug
   )
-  doc_2 = create_section_without_ui(
+  sec_2 = create_section_without_ui(
     @manual,
     {
       title: "2nd example section",
@@ -373,7 +373,7 @@ Given(/^a published manual with some sections was created without the UI$/) do
     },
     organisation_slug: GDS::SSO.test_user.organisation_slug
   )
-  @sections = [doc_1, doc_2]
+  @sections = [sec_1, sec_2]
 
   publish_manual_without_ui(@manual)
 
@@ -523,9 +523,9 @@ Then(/^the section is published as a minor update including a change note draft$
 end
 
 Then(/^I can see the change note and update type form when editing existing sections$/) do
-  @sections.each do |document|
+  @sections.each do |section|
     go_to_manual_page(@manual.title)
-    click_on document.title
+    click_on section.title
     click_on "Edit section"
 
     check_that_change_note_fields_are_present
@@ -570,8 +570,8 @@ When(/^I add another section to the manual$/) do
 end
 
 Then(/^I see no visible change note in the section edit form$/) do
-  document = @sections.first
-  check_change_note_value(@manual_title, document.title, "")
+  section = @sections.first
+  check_change_note_value(@manual_title, section.title, "")
 end
 
 When(/^I add invalid HTML to the section body$/) do
@@ -691,7 +691,7 @@ When(/^I reorder the sections$/) do
 end
 
 Then(/^the order of the sections in the manual should have been updated$/) do
-  @reordered_section_attributes.map { |doc| doc[:title] }.each.with_index do |title, index|
+  @reordered_section_attributes.map { |sec| sec[:title] }.each.with_index do |title, index|
     expect(page).to have_css(".document-list li.document:nth-child(#{index + 1}) .document-title", text: title)
   end
 end
@@ -702,11 +702,11 @@ Then(/^the new order should be visible in the preview environment$/) do
       child_section_groups: [
         {
           title: "Contents",
-          child_sections: @reordered_section_attributes.map do |doc|
+          child_sections: @reordered_section_attributes.map do |sec|
             {
-              title: doc[:fields][:section_title],
-              description: doc[:fields][:section_summary],
-              base_path: "/#{doc[:slug]}",
+              title: sec[:fields][:section_title],
+              description: sec[:fields][:section_summary],
+              base_path: "/#{sec[:slug]}",
             }
           end
         }

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -63,7 +63,7 @@ Given(/^a draft manual exists with some sections$/) do
 
   @manual = most_recently_created_manual
   @sections = @manual.sections.to_a
-  @document = @sections.first
+  @section = @sections.first
 
   WebMock::RequestRegistry.instance.reset!
 end
@@ -117,7 +117,7 @@ When(/^I create a section for the manual$/) do
 
   create_section(@manual_fields.fetch(:title), @section_fields)
 
-  @document = most_recently_created_manual.sections.to_a.last
+  @section = most_recently_created_manual.sections.to_a.last
 end
 
 When(/^I create a section for the manual with a change note$/) do
@@ -134,7 +134,7 @@ When(/^I create a section for the manual with a change note$/) do
 
   create_section(@manual_fields.fetch(:title), @section_fields)
 
-  @document = most_recently_created_manual.sections.to_a.last
+  @section = most_recently_created_manual.sections.to_a.last
 end
 
 Then(/^I see the manual has the new section$/) do
@@ -144,7 +144,7 @@ Then(/^I see the manual has the new section$/) do
 end
 
 Then(/^the section and table of contents will have been sent to the draft publishing api$/) do
-  check_section_is_drafted_to_publishing_api(@document.id)
+  check_section_is_drafted_to_publishing_api(@section.id)
   manual_table_of_contents_attributes = {
     details: {
       child_section_groups: [
@@ -168,7 +168,7 @@ Then(/^the section and table of contents will have been sent to the draft publis
 end
 
 Then(/^the updated section at the new slug and updated table of contents will have been sent to the draft publishing api$/) do
-  check_section_is_drafted_to_publishing_api(@document.id)
+  check_section_is_drafted_to_publishing_api(@section.id)
   manual_table_of_contents_attributes = {
     details: {
       child_section_groups: [
@@ -203,10 +203,10 @@ Given(/^a draft section exists for the manual$/) do
 
   create_section(@manual_fields.fetch(:title), @section_fields)
 
-  @document = most_recently_created_manual.sections.to_a.last
+  @section = most_recently_created_manual.sections.to_a.last
 
   @sections ||= []
-  @sections << @document
+  @sections << @section
 
   WebMock::RequestRegistry.instance.reset!
 end
@@ -391,7 +391,7 @@ When(/^I create a section for the manual as a minor change without the UI$/) do
     minor_update: true
   }
 
-  @document = create_section_without_ui(@manual, @section_fields, organisation_slug: GDS::SSO.test_user.organisation_slug)
+  @section = create_section_without_ui(@manual, @section_fields, organisation_slug: GDS::SSO.test_user.organisation_slug)
 
   go_to_manual_page(@manual.title)
 
@@ -507,19 +507,19 @@ end
 Then(/^the section is published as a major update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
 end
 
 Then(/^the section is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @document).id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
 end
 
 Then(/^the section is published as a minor update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @document).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
 end
 
 Then(/^I can see the change note and update type form when editing existing sections$/) do
@@ -541,7 +541,7 @@ end
 
 Then(/^the change note form for the section is clear$/) do
   go_to_manual_page(@manual.title)
-  click_on((@updated_section || @document).title)
+  click_on((@updated_section || @section).title)
   click_on "Edit section"
 
   check_that_change_note_fields_are_present(minor_update: false, note: "")
@@ -549,7 +549,7 @@ end
 
 Then(/^the change note form for the section contains my note$/) do
   go_to_manual_page(@manual.title)
-  click_on((@updated_section || @document).title)
+  click_on((@updated_section || @section).title)
   click_on "Edit section"
 
   check_that_change_note_fields_are_present(note_field_only: true, note: @change_note)

--- a/features/step_definitions/previously_published_manual_steps.rb
+++ b/features/step_definitions/previously_published_manual_steps.rb
@@ -79,33 +79,33 @@ Then(/^the manual and its sections are (re|)published with all public timestamps
   how_many_times = (republished == "re" ? 2 : 1)
 
   check_manual_is_drafted_and_published_with_all_public_timestamps(@manual, @originally_published_at, how_many_times: how_many_times)
-  check_section_is_drafted_and_published_with_all_public_timestamps(@document, @originally_published_at, how_many_times: how_many_times)
+  check_section_is_drafted_and_published_with_all_public_timestamps(@section, @originally_published_at, how_many_times: how_many_times)
 end
 
 Then(/^the manual and its sections are (re|)published with the first published timestamp set to the previously published date, but not the public updated timestamp$/) do |republished|
   how_many_times = (republished == "re" ? 2 : 1)
 
   check_manual_is_drafted_and_published_with_first_published_date_only(@manual, @originally_published_at, how_many_times: how_many_times)
-  check_section_is_drafted_and_published_with_first_published_date_only(@document, @originally_published_at, how_many_times: how_many_times)
+  check_section_is_drafted_and_published_with_first_published_date_only(@section, @originally_published_at, how_many_times: how_many_times)
 end
 
 Then(/^the manual and its sections are (re|)published with all public timestamps set to the new previously published date$/) do |republished|
   how_many_times = (republished == "re" ? 2 : 1)
 
   check_manual_is_drafted_and_published_with_all_public_timestamps(@manual, @new_originally_published_at, how_many_times: how_many_times)
-  check_section_is_drafted_and_published_with_all_public_timestamps(@document, @new_originally_published_at, how_many_times: how_many_times)
+  check_section_is_drafted_and_published_with_all_public_timestamps(@section, @new_originally_published_at, how_many_times: how_many_times)
 end
 
 Then(/^the manual and its sections are (re|)published with the first published timestamp set to the new published date, but not the public updated timestamp$/) do |republished|
   how_many_times = (republished == "re" ? 2 : 1)
 
   check_manual_is_drafted_and_published_with_first_published_date_only(@manual, @new_originally_published_at, how_many_times: how_many_times)
-  check_section_is_drafted_and_published_with_first_published_date_only(@document, @new_originally_published_at, how_many_times: how_many_times)
+  check_section_is_drafted_and_published_with_first_published_date_only(@section, @new_originally_published_at, how_many_times: how_many_times)
 end
 
 Then(/^the manual and its sections are (re|)published without any public timestamps$/) do |republished|
   how_many_times = (republished == "re" ? 2 : 1)
 
   check_manual_is_drafted_and_published_with_no_public_timestamps(@manual, how_many_times: how_many_times)
-  check_manual_is_drafted_and_published_with_no_public_timestamps(@document, how_many_times: how_many_times)
+  check_manual_is_drafted_and_published_with_no_public_timestamps(@section, how_many_times: how_many_times)
 end

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -5,7 +5,7 @@ end
 
 When(/^I remove the edited section from the manual$/) do
   withdraw_section(@manual_fields.fetch(:title), @updated_fields.fetch(:section_title))
-  @removed_document = @updated_document
+  @removed_document = @updated_section
 end
 
 When(/^I remove one of the sections from the manual$/) do

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -63,7 +63,7 @@ Then(/^the removed section change note is included$/) do
 
   check_manual_is_drafted_to_publishing_api(
     @manual.id,
-    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_section),
+    with_matcher: change_notes_sent_to_publishing_api_include_section(@removed_section),
     number_of_drafts: 1
   )
 end
@@ -74,6 +74,6 @@ Then(/^the removed section change note is not included$/) do
   check_manual_is_drafted_to_publishing_api(
     @manual.id,
     number_of_drafts: 0,
-    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_section)
+    with_matcher: change_notes_sent_to_publishing_api_include_section(@removed_section)
   )
 end

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -32,8 +32,8 @@ Then(/^the section is removed from the manual$/) do
   check_section_was_removed(@manual.id, @removed_section.id)
   check_draft_has_been_discarded_in_publishing_api(@removed_section.id)
 
-  # Check that no child section has the removed document's title
-  without_removed_document_matcher = ->(request) do
+  # Check that no child section has the removed section's title
+  without_removed_section_matcher = ->(request) do
     data = JSON.parse(request.body)
     contents = data["details"]["child_section_groups"].first
     contents["child_sections"].none? do |child_section|
@@ -41,7 +41,7 @@ Then(/^the section is removed from the manual$/) do
     end
   end
 
-  check_manual_is_drafted_to_publishing_api(@manual.id, with_matcher: without_removed_document_matcher)
+  check_manual_is_drafted_to_publishing_api(@manual.id, with_matcher: without_removed_section_matcher)
 end
 
 Then(/^the removed section is not published$/) do

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -1,43 +1,43 @@
 When(/^I remove the section from the manual$/) do
   withdraw_section(@manual_fields.fetch(:title), @section_fields.fetch(:section_title))
-  @removed_document = @document
+  @removed_section = @document
 end
 
 When(/^I remove the edited section from the manual$/) do
   withdraw_section(@manual_fields.fetch(:title), @updated_fields.fetch(:section_title))
-  @removed_document = @updated_section
+  @removed_section = @updated_section
 end
 
 When(/^I remove one of the sections from the manual$/) do
   withdraw_section(@manual_fields.fetch(:title), @sections.first.title)
-  @removed_document = @sections.first
+  @removed_section = @sections.first
 end
 
 When(/^I remove one of the sections from the manual with a major update omitting the note$/) do
   withdraw_section(@manual_fields.fetch(:title), @sections.first.title, minor_update: false)
-  @removed_document = @sections.first
+  @removed_section = @sections.first
 end
 
 When(/^I remove one of the sections from the manual with a major update$/) do
   withdraw_section(@manual_fields.fetch(:title), @sections.first.title, minor_update: false, change_note: "Removing #{@sections.first.title} section as content is covered elsewhere.")
-  @removed_document = @sections.first
+  @removed_section = @sections.first
 end
 
 When(/^I remove one of the sections from the manual with a minor update$/) do
   withdraw_section(@manual_fields.fetch(:title), @sections.first.title, minor_update: true, change_note: "Should never have published this section, let's pretend we never did with this secret removal.")
-  @removed_document = @sections.first
+  @removed_section = @sections.first
 end
 
 Then(/^the section is removed from the manual$/) do
-  check_section_was_removed(@manual.id, @removed_document.id)
-  check_draft_has_been_discarded_in_publishing_api(@removed_document.id)
+  check_section_was_removed(@manual.id, @removed_section.id)
+  check_draft_has_been_discarded_in_publishing_api(@removed_section.id)
 
   # Check that no child section has the removed document's title
   without_removed_document_matcher = ->(request) do
     data = JSON.parse(request.body)
     contents = data["details"]["child_section_groups"].first
     contents["child_sections"].none? do |child_section|
-      child_section["title"] == @removed_document.title
+      child_section["title"] == @removed_section.title
     end
   end
 
@@ -46,34 +46,34 @@ end
 
 Then(/^the removed section is not published$/) do
   check_manual_was_published(@manual)
-  check_section_was_not_published(@removed_document)
+  check_section_was_not_published(@removed_section)
 end
 
 Then(/^the removed section is withdrawn with a redirect to the manual$/) do
   check_manual_was_published(@manual)
-  check_section_was_withdrawn_with_redirect(@removed_document, "/#{@manual.slug}")
+  check_section_was_withdrawn_with_redirect(@removed_section, "/#{@manual.slug}")
 end
 
 Then(/^the removed section is archived$/) do
-  check_section_is_archived_in_db(@manual, @removed_document.id)
+  check_section_is_archived_in_db(@manual, @removed_section.id)
 end
 
 Then(/^the removed section change note is included$/) do
-  @removed_document = section_repository(@manual).fetch(@removed_document.id)
+  @removed_section = section_repository(@manual).fetch(@removed_section.id)
 
   check_manual_is_drafted_to_publishing_api(
     @manual.id,
-    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_document),
+    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_section),
     number_of_drafts: 1
   )
 end
 
 Then(/^the removed section change note is not included$/) do
-  @removed_document = section_repository(@manual).fetch(@removed_document.id)
+  @removed_section = section_repository(@manual).fetch(@removed_section.id)
 
   check_manual_is_drafted_to_publishing_api(
     @manual.id,
     number_of_drafts: 0,
-    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_document)
+    with_matcher: change_notes_sent_to_publishing_api_include_document(@removed_section)
   )
 end

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -1,5 +1,5 @@
 When(/^I remove the section from the manual$/) do
-  withdraw_section(@manual_fields.fetch(:title), @document_fields.fetch(:section_title))
+  withdraw_section(@manual_fields.fetch(:title), @section_fields.fetch(:section_title))
   @removed_document = @document
 end
 

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -9,23 +9,23 @@ When(/^I remove the edited section from the manual$/) do
 end
 
 When(/^I remove one of the sections from the manual$/) do
-  withdraw_section(@manual_fields.fetch(:title), @documents.first.title)
-  @removed_document = @documents.first
+  withdraw_section(@manual_fields.fetch(:title), @sections.first.title)
+  @removed_document = @sections.first
 end
 
 When(/^I remove one of the sections from the manual with a major update omitting the note$/) do
-  withdraw_section(@manual_fields.fetch(:title), @documents.first.title, minor_update: false)
-  @removed_document = @documents.first
+  withdraw_section(@manual_fields.fetch(:title), @sections.first.title, minor_update: false)
+  @removed_document = @sections.first
 end
 
 When(/^I remove one of the sections from the manual with a major update$/) do
-  withdraw_section(@manual_fields.fetch(:title), @documents.first.title, minor_update: false, change_note: "Removing #{@documents.first.title} section as content is covered elsewhere.")
-  @removed_document = @documents.first
+  withdraw_section(@manual_fields.fetch(:title), @sections.first.title, minor_update: false, change_note: "Removing #{@sections.first.title} section as content is covered elsewhere.")
+  @removed_document = @sections.first
 end
 
 When(/^I remove one of the sections from the manual with a minor update$/) do
-  withdraw_section(@manual_fields.fetch(:title), @documents.first.title, minor_update: true, change_note: "Should never have published this section, let's pretend we never did with this secret removal.")
-  @removed_document = @documents.first
+  withdraw_section(@manual_fields.fetch(:title), @sections.first.title, minor_update: true, change_note: "Should never have published this section, let's pretend we never did with this secret removal.")
+  @removed_document = @sections.first
 end
 
 Then(/^the section is removed from the manual$/) do

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -1,6 +1,6 @@
 When(/^I remove the section from the manual$/) do
   withdraw_section(@manual_fields.fetch(:title), @section_fields.fetch(:section_title))
-  @removed_section = @document
+  @removed_section = @section
 end
 
 When(/^I remove the edited section from the manual$/) do

--- a/features/support/attachment_helpers.rb
+++ b/features/support/attachment_helpers.rb
@@ -10,7 +10,27 @@ module AttachmentHelpers
       click_on("Edit")
     end
 
-    add_attachment_to_document(document_title, attachment_title)
+    unless current_path.include?("edit")
+      click_link "Edit"
+    end
+
+    click_on "Add attachment"
+    fill_in "Title", with: attachment_title
+    attach_file "File", File.expand_path("../fixtures/greenpaper.pdf", File.dirname(__FILE__))
+
+    stub_request(:post, "#{test_asset_manager_base_url}/assets")
+      .to_return(
+        body: JSON.dump(asset_manager_response),
+        status: 201,
+      )
+
+    stub_request(:get, "#{test_asset_manager_base_url}/assets/#{asset_id}")
+      .to_return(
+        body: JSON.dump(asset_manager_response),
+        status: 200,
+      )
+
+    click_on "Save attachment"
   end
 
   def asset_id
@@ -65,30 +85,6 @@ module AttachmentHelpers
   def check_for_attachment_update(_document_title, _attachment_title, _attachment_file_name)
     expect(page).to have_css(".attachments li", text: @new_attachment_title)
     expect(page).to have_css(".attachments li", text: @new_attachment_file_name)
-  end
-
-  def add_attachment_to_document(_document_title, attachment_title)
-    unless current_path.include?("edit")
-      click_link "Edit"
-    end
-
-    click_on "Add attachment"
-    fill_in "Title", with: attachment_title
-    attach_file "File", File.expand_path("../fixtures/greenpaper.pdf", File.dirname(__FILE__))
-
-    stub_request(:post, "#{test_asset_manager_base_url}/assets")
-      .to_return(
-        body: JSON.dump(asset_manager_response),
-        status: 201,
-      )
-
-    stub_request(:get, "#{test_asset_manager_base_url}/assets/#{asset_id}")
-      .to_return(
-        body: JSON.dump(asset_manager_response),
-        status: 200,
-      )
-
-    click_on "Save attachment"
   end
 end
 RSpec.configuration.include AttachmentHelpers, type: :feature

--- a/features/support/attachment_helpers.rb
+++ b/features/support/attachment_helpers.rb
@@ -3,9 +3,9 @@ module AttachmentHelpers
     Plek.current.find("asset-manager")
   end
 
-  def add_attachment_to_section(document_title, attachment_title)
-    if page.has_css?("a", text: document_title)
-      click_on(document_title)
+  def add_attachment_to_section(section_title, attachment_title)
+    if page.has_css?("a", text: section_title)
+      click_on(section_title)
     elsif page.has_css?("a", text: "Edit")
       click_on("Edit")
     end
@@ -63,7 +63,7 @@ module AttachmentHelpers
     end
   end
 
-  def edit_attachment(_document_title, attachment_title, new_attachment_title, new_attachment_file_name)
+  def edit_attachment(_section_title, attachment_title, new_attachment_title, new_attachment_file_name)
     attachment_li = page.find(".attachments li", text: attachment_title)
 
     within(attachment_li) do
@@ -82,7 +82,7 @@ module AttachmentHelpers
     click_button "Save attachment"
   end
 
-  def check_for_attachment_update(_document_title, _attachment_title, _attachment_file_name)
+  def check_for_attachment_update(_section_title, _attachment_title, _attachment_file_name)
     expect(page).to have_css(".attachments li", text: @new_attachment_title)
     expect(page).to have_css(".attachments li", text: @new_attachment_file_name)
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -505,7 +505,7 @@ module ManualHelpers
     expect(page.body).to have_content(organisation_slug)
   end
 
-  def create_documents_for_manual(count:, manual_fields:)
+  def create_sections_for_manual(count:, manual_fields:)
     attributes_for_documents = (1..count).map do |n|
       title = "Section #{n}"
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -563,7 +563,7 @@ module ManualHelpers
     expect(page).to have_text("You don't have permission to withdraw manual sections.")
   end
 
-  def change_notes_sent_to_publishing_api_include_document(document)
+  def change_notes_sent_to_publishing_api_include_section(document)
     ->(request) do
       data = JSON.parse(request.body)
       change_notes = data["details"]["change_notes"]

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -436,12 +436,12 @@ module ManualHelpers
   end
 
   def check_manual_cannot_be_published
-    document_fields = {
+    section_fields = {
       section_title: "Section 1",
       section_summary: "Section 1 summary",
       section_body: "Section 1 body",
     }
-    create_section(@manual_fields.fetch(:title), document_fields)
+    create_section(@manual_fields.fetch(:title), section_fields)
 
     go_to_manual_page(@manual_fields.fetch(:title))
     expect(page).not_to have_button("Publish")

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -543,7 +543,7 @@ module ManualHelpers
     RepositoryRegistry.new.manual_repository.all.first
   end
 
-  def document_fields(document)
+  def section_fields(document)
     {
       section_title: document.title,
       section_summary: document.summary,

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -551,7 +551,7 @@ module ManualHelpers
     }
   end
 
-  def check_document_withdraw_link_not_visible(manual, document)
+  def check_section_withdraw_link_not_visible(manual, document)
     # Don't give them the option...
     go_to_manual_page(manual.title)
     click_on document.title

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -527,7 +527,7 @@ module ManualHelpers
     attributes_for_documents
   end
 
-  def create_documents_for_manual_without_ui(manual:, count:)
+  def create_sections_for_manual_without_ui(manual:, count:)
     (1..count).map do |n|
       attributes = {
         title: "Section #{n}",

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -405,9 +405,9 @@ module ManualHelpers
     fill_in("Section body", with: body_text + snippet)
   end
 
-  def check_change_note_value(manual_title, document_title, expected_value)
+  def check_change_note_value(manual_title, section_title, expected_value)
     go_to_manual_page(manual_title)
-    click_on document_title
+    click_on section_title
     click_on "Edit section"
 
     change_note_field_value = page.find("textarea[name='section[change_note]']").text

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -226,7 +226,7 @@ module ManualHelpers
     click_link manual_title
   end
 
-  def check_manual_and_documents_were_published(manual, document, manual_attrs, document_attrs)
+  def check_manual_and_sections_were_published(manual, document, manual_attrs, document_attrs)
     check_manual_is_published_to_publishing_api(manual.id)
     check_section_is_published_to_publishing_api(document.id)
 

--- a/lib/footnotes_section_heading_renderer.rb
+++ b/lib/footnotes_section_heading_renderer.rb
@@ -6,11 +6,11 @@ class FootnotesSectionHeadingRenderer < SimpleDelegator
   end
 
   def body
-    document.body.gsub(footnote_open_tag, "#{heading_tag}\\&")
+    section.body.gsub(footnote_open_tag, "#{heading_tag}\\&")
   end
 
   def attributes
-    document.attributes.merge(
+    section.attributes.merge(
       body: body,
     )
   end
@@ -25,7 +25,7 @@ private
     '<h2 id="footnotes">Footnotes</h2>'
   end
 
-  def document
+  def section
     __getobj__
   end
 end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -62,23 +62,23 @@ private
     if old_manual.editions.any?
       # Redirect all sections of the manual we're going to remove
       # to prevent dead bookmarked URLs.
-      old_section_ids.each do |document_id|
-        editions = all_editions_of_section(document_id)
+      old_section_ids.each do |section_id|
+        editions = all_editions_of_section(section_id)
         section_slug = editions.first.slug
 
         begin
-          if old_sections_reused_in_new_manual.include? document_id
+          if old_sections_reused_in_new_manual.include? section_id
             puts "Issuing gone for content item '/#{section_slug}' as it will be reused by a section in '#{new_manual.slug}'"
-            send_gone(document_id, section_slug)
+            send_gone(section_id, section_slug)
           else
             puts "Redirecting content item '/#{section_slug}' to '/#{old_manual.slug}'"
-            publishing_api.unpublish(document_id,
+            publishing_api.unpublish(section_id,
                                      type: "redirect",
                                      alternative_path: "/#{old_manual.slug}",
                                      discard_drafts: true)
           end
         rescue GdsApi::HTTPNotFound
-          puts "Content item with content_id #{document_id} not present in the publishing API"
+          puts "Content item with content_id #{section_id} not present in the publishing API"
         end
 
         # Destroy all the editons of this manual as it's going away
@@ -102,35 +102,35 @@ private
   end
 
   def _calculate_old_sections_reused_in_new_manual
-    old_document_ids_and_section_slugs = old_section_ids.map do |document_id|
-      [document_id, most_recent_edition_of_section(document_id).slug.gsub(to_slug, "")]
+    old_section_ids_and_section_slugs = old_section_ids.map do |section_id|
+      [section_id, most_recent_edition_of_section(section_id).slug.gsub(to_slug, "")]
     end
 
-    new_section_slugs = new_section_ids.map do |document_id|
-      most_recent_edition_of_section(document_id).slug.gsub(from_slug, "")
+    new_section_slugs = new_section_ids.map do |section_id|
+      most_recent_edition_of_section(section_id).slug.gsub(from_slug, "")
     end
 
-    old_document_ids_and_section_slugs.
-      select { |_document_id, slug| new_section_slugs.include? slug }.
-      map { |document_id, _slug| document_id }
+    old_section_ids_and_section_slugs.
+      select { |_section_id, slug| new_section_slugs.include? slug }.
+      map { |section_id, _slug| section_id }
   end
 
-  def most_recent_published_edition_of_section(document_id)
-    all_editions_of_section(document_id).select { |edition| edition.state == "published" }.first
+  def most_recent_published_edition_of_section(section_id)
+    all_editions_of_section(section_id).select { |edition| edition.state == "published" }.first
   end
 
-  def most_recent_edition_of_section(document_id)
-    all_editions_of_section(document_id).first
+  def most_recent_edition_of_section(section_id)
+    all_editions_of_section(section_id).first
   end
 
-  def all_editions_of_section(document_id)
-    SectionEdition.where(document_id: document_id).order_by([:version_number, :desc])
+  def all_editions_of_section(section_id)
+    SectionEdition.where(document_id: section_id).order_by([:version_number, :desc])
   end
 
   def reslug
     # Reslug the manual sections
-    new_section_ids.each do |document_id|
-      sections = all_editions_of_section(document_id)
+    new_section_ids.each do |section_id|
+      sections = all_editions_of_section(section_id)
       sections.each do |section|
         reslug_msg = "Reslugging section '#{section.slug}'"
         new_section_slug = section.slug.gsub(from_slug, to_slug)
@@ -150,10 +150,10 @@ private
     end
 
     # Clean up manual sections belonging to the temporary manual path
-    new_section_ids.each do |document_id|
-      puts "Redirecting #{document_id} to '/#{to_slug}'"
-      most_recent_edition = most_recent_edition_of_section(document_id)
-      publishing_api.unpublish(document_id,
+    new_section_ids.each do |section_id|
+      puts "Redirecting #{section_id} to '/#{to_slug}'"
+      most_recent_edition = most_recent_edition_of_section(section_id)
+      publishing_api.unpublish(section_id,
                                type: "redirect",
                                alternative_path: "/#{most_recent_edition.slug}",
                                discard_drafts: true)
@@ -176,9 +176,9 @@ private
 
       puts "Publishing published edition of manual: #{manual_to_publish.id}"
       publishing_api.publish(manual_to_publish.id, "republish")
-      manual_to_publish.sections.each do |document|
-        puts "Publishing published edition of manual section: #{document.id}"
-        publishing_api.publish(document.id, "republish")
+      manual_to_publish.sections.each do |section|
+        puts "Publishing published edition of manual section: #{section.id}"
+        publishing_api.publish(section.id, "republish")
       end
     end
 
@@ -193,24 +193,24 @@ private
       organisation, manual
     ).call
 
-    manual.sections.each do |document|
-      puts "Sending a draft of manual section #{document.id} (version: #{document.version_number})"
+    manual.sections.each do |section|
+      puts "Sending a draft of manual section #{section.id} (version: #{section.version_number})"
       SectionPublishingAPIExporter.new(
-        organisation, manual, document
+        organisation, manual, section
       ).call
     end
   end
 
-  def send_gone(document_id, slug)
+  def send_gone(section_id, slug)
     # We should be able to use
-    #   publishing_api.unpublish(document_id, type: 'gone')
+    #   publishing_api.unpublish(section_id, type: 'gone')
     # here, but that doesn't leave the base_path in a state where
     # publishing_api will let us re-use it.  Sending a draft gone object
     # and then publishing it does though.  Might want to check if we can
     # go back to the unpublish version at some point though.
     gone_item = {
       base_path: "/#{slug}",
-      content_id: document_id,
+      content_id: section_id,
       document_type: "gone",
       publishing_app: "manuals-publisher",
       schema_name: "gone",
@@ -221,8 +221,8 @@ private
         }
       ]
     }
-    publishing_api.put_content(document_id, gone_item)
-    publishing_api.publish(document_id, "major")
+    publishing_api.put_content(section_id, gone_item)
+    publishing_api.publish(section_id, "major")
   end
 
   def publishing_api

--- a/lib/section_header_extractor.rb
+++ b/lib/section_header_extractor.rb
@@ -3,21 +3,21 @@ require "active_support/core_ext/hash"
 
 class SectionHeaderExtractor < SimpleDelegator
   def self.create
-    ->(doc) {
+    ->(section) {
       SectionHeaderExtractor.new(
         GovspeakHeaderExtractor.new,
-        doc,
+        section,
       )
     }
   end
 
-  def initialize(header_parser, doc)
+  def initialize(header_parser, section)
     @header_parser = header_parser
-    super(doc)
+    super(section)
   end
 
   def headers
-    header_parser.call(doc.body)
+    header_parser.call(section.body)
   end
 
   def serialized_headers
@@ -27,7 +27,7 @@ class SectionHeaderExtractor < SimpleDelegator
   def attributes
     {
       headers: serialized_headers,
-    }.merge(doc.attributes)
+    }.merge(section.attributes)
   end
 
 private
@@ -36,7 +36,7 @@ private
     :header_parser,
   )
 
-  def doc
+  def section
     __getobj__
   end
 end

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -20,7 +20,7 @@ describe ManualPublishingAPIExporter do
       :manual,
       id: "52ab9439-95c8-4d39-9b83-0a2050a0978b",
       attributes: manual_attributes,
-      sections: documents,
+      sections: sections,
       has_ever_been_published?: manual_attributes[:ever_been_published],
       originally_published_at: nil,
       use_originally_published_at_for_public_timestamp?: false,
@@ -29,19 +29,19 @@ describe ManualPublishingAPIExporter do
 
   let(:manual_slug) { "guidance/my-first-manual" }
 
-  let(:documents) {
+  let(:sections) {
     [
       double(
-        :document,
+        :section,
         id: "60023f27-0657-4812-9339-264f1c0fd90d",
-        attributes: document_attributes,
+        attributes: section_attributes,
         minor_update?: false,
         needs_exporting?: true,
       )
     ]
   }
 
-  let(:document_attributes) {
+  let(:section_attributes) {
     {
       title: "Document title",
       summary: "This is the first section",
@@ -141,7 +141,7 @@ describe ManualPublishingAPIExporter do
     expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema(ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME)
   end
 
-  it "exports the serialized document attributes" do
+  it "exports the serialized section attributes" do
     subject.call
 
     expect(publishing_api).to have_received(:put_content).with(
@@ -324,21 +324,21 @@ describe ManualPublishingAPIExporter do
     end
   end
 
-  context "when no documents need exporting" do
-    let(:documents) {
+  context "when no sections need exporting" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: false,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: false,
           has_ever_been_published?: true,
@@ -359,21 +359,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when one document needs exporting and it is a minor update" do
-    let(:documents) {
+  context "when one section needs exporting and it is a minor update" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: false,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: true,
@@ -394,21 +394,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when one document needs exporting and it is a minor update that has never been published" do
-    let(:documents) {
+  context "when one section needs exporting and it is a minor update that has never been published" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: false,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: false,
@@ -428,21 +428,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when one document needs exporting and it is a major update" do
-    let(:documents) {
+  context "when one section needs exporting and it is a major update" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: false,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: true,
           has_ever_been_published?: true,
@@ -463,21 +463,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when multiple documents need exporting, but none are major updates" do
-    let(:documents) {
+  context "when multiple sections need exporting, but none are major updates" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: true,
@@ -498,21 +498,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when multiple documents need exporting, but none are major updates, but one has never been published" do
-    let(:documents) {
+  context "when multiple sections need exporting, but none are major updates, but one has never been published" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: false,
@@ -531,21 +531,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when multiple documents need exporting, and at least one is a major updates" do
-    let(:documents) {
+  context "when multiple sections need exporting, and at least one is a major updates" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: true,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: true,
           needs_exporting?: true,
           has_ever_been_published?: true,
@@ -566,21 +566,21 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when multiple documents need exporting, and all are major updates" do
-    let(:documents) {
+  context "when multiple sections need exporting, and all are major updates" do
+    let(:sections) {
       [
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: true,
           has_ever_been_published?: true,
         ),
         double(
-          :document,
+          :section,
           id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: document_attributes,
+          attributes: section_attributes,
           minor_update?: false,
           needs_exporting?: true,
           has_ever_been_published?: true,

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -29,14 +29,14 @@ describe ManualPublishingAPILinksExporter do
         slug: "guidance/my-first-manual",
         organisation_slug: "cabinet-office",
       },
-      sections: documents,
+      sections: sections,
     )
   }
 
-  let(:documents) {
+  let(:sections) {
     [
-      double(:document, id: "c19ffb7d-448c-4cc8-bece-022662ef9611"),
-      double(:document, id: "f9c91a07-6a41-4b97-94a8-ecdc81997d49"),
+      double(:section, id: "c19ffb7d-448c-4cc8-bece-022662ef9611"),
+      double(:section, id: "f9c91a07-6a41-4b97-94a8-ecdc81997d49"),
     ]
   }
 

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -4,13 +4,13 @@ require "publishing_api_publisher"
 
 describe PublishingAPIPublisher do
   let(:publishing_api) { double(:publishing_api, publish: nil) }
-  let(:document_id) { "12345678-9abc-def0-1234-56789abcdef0" }
-  let(:document) { double(:document, id: document_id) }
+  let(:section_id) { "12345678-9abc-def0-1234-56789abcdef0" }
+  let(:section) { double(:section, id: section_id) }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
       described_class.new(
-        entity: document,
+        entity: section,
         update_type: "reticulate-splines"
       )
     }.to raise_error(ArgumentError, "update_type 'reticulate-splines' not recognised")
@@ -20,7 +20,7 @@ describe PublishingAPIPublisher do
     %w(major minor republish).each do |update_type|
       expect {
         described_class.new(
-          entity: document,
+          entity: section,
           update_type: update_type
         )
       }.not_to raise_error
@@ -30,7 +30,7 @@ describe PublishingAPIPublisher do
   it "accepts explicitly setting nil as the option for update_type" do
     expect {
       described_class.new(
-        entity: document,
+        entity: section,
         update_type: nil
       )
     }.not_to raise_error
@@ -44,29 +44,29 @@ describe PublishingAPIPublisher do
     context "when no explicit update_type is given" do
       subject do
         described_class.new(
-          entity: document
+          entity: section
         )
       end
 
-      it "asks the publishing api to publish the document" do
+      it "asks the publishing api to publish the section" do
         subject.call
 
-        expect(publishing_api).to have_received(:publish).with(document_id, nil)
+        expect(publishing_api).to have_received(:publish).with(section_id, nil)
       end
     end
 
     context "when an explicit update_type is given" do
       subject do
         described_class.new(
-          entity: document,
+          entity: section,
           update_type: "republish"
         )
       end
 
-      it "asks the publishing api to publish the document with the specific update_type" do
+      it "asks the publishing api to publish the section with the specific update_type" do
         subject.call
 
-        expect(publishing_api).to have_received(:publish).with(document_id, "republish")
+        expect(publishing_api).to have_received(:publish).with(section_id, "republish")
       end
     end
   end

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Publishing manuals", type: :feature do
     it "drafts the manual and sections and publishes them to the Publishing API" do
       @documents.each do |document|
         check_section_is_drafted_to_publishing_api(document.id, number_of_drafts: 2)
-        check_manual_and_sections_were_published(@manual, document, manual_fields, document_fields(document))
+        check_manual_and_sections_were_published(@manual, document, manual_fields, section_fields(document))
       end
     end
 

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Publishing manuals", type: :feature do
     it "drafts the manual and sections and publishes them to the Publishing API" do
       @documents.each do |document|
         check_section_is_drafted_to_publishing_api(document.id, number_of_drafts: 2)
-        check_manual_and_documents_were_published(@manual, document, manual_fields, document_fields(document))
+        check_manual_and_sections_were_published(@manual, document, manual_fields, document_fields(document))
       end
     end
 

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Publishing manuals", type: :feature do
     before do
       manual = create_manual_without_ui(manual_fields)
 
-      @documents = [].tap do |documents|
+      @sections = [].tap do |documents|
         documents << create_section_without_ui(manual, title: "Section 1 major", summary: "Section 1 summary", body: "Section body")
         documents << create_section_without_ui(manual, title: "Section 1", summary: "Section 1 minor summary", body: "Section body minor update", minor_update: true)
       end
@@ -36,7 +36,7 @@ RSpec.describe "Publishing manuals", type: :feature do
     end
 
     it "drafts the manual and sections and publishes them to the Publishing API" do
-      @documents.each do |document|
+      @sections.each do |document|
         check_section_is_drafted_to_publishing_api(document.id, number_of_drafts: 2)
         check_manual_and_sections_were_published(@manual, document, manual_fields, section_fields(document))
       end
@@ -48,7 +48,7 @@ RSpec.describe "Publishing manuals", type: :feature do
     end
 
     it "sets the exported_at timestamp on the document" do
-      expect(@documents.first.latest_edition.reload.exported_at).to be_within(1.second).of publish_time
+      expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of publish_time
     end
   end
 end

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe "Publishing manuals", type: :feature do
     before do
       manual = create_manual_without_ui(manual_fields)
 
-      @sections = [].tap do |documents|
-        documents << create_section_without_ui(manual, title: "Section 1 major", summary: "Section 1 summary", body: "Section body")
-        documents << create_section_without_ui(manual, title: "Section 1", summary: "Section 1 minor summary", body: "Section body minor update", minor_update: true)
+      @sections = [].tap do |sections|
+        sections << create_section_without_ui(manual, title: "Section 1 major", summary: "Section 1 summary", body: "Section body")
+        sections << create_section_without_ui(manual, title: "Section 1", summary: "Section 1 minor summary", body: "Section body minor update", minor_update: true)
       end
 
-      # Re-fetch manual to include documents
+      # Re-fetch manual to include sections
       @manual = manual_repository.fetch(manual.id)
 
       Timecop.freeze(publish_time) do
@@ -36,18 +36,18 @@ RSpec.describe "Publishing manuals", type: :feature do
     end
 
     it "drafts the manual and sections and publishes them to the Publishing API" do
-      @sections.each do |document|
-        check_section_is_drafted_to_publishing_api(document.id, number_of_drafts: 2)
-        check_manual_and_sections_were_published(@manual, document, manual_fields, section_fields(document))
+      @sections.each do |section|
+        check_section_is_drafted_to_publishing_api(section.id, number_of_drafts: 2)
+        check_manual_and_sections_were_published(@manual, section, manual_fields, section_fields(section))
       end
     end
 
-    it "creates publication logs for major updates to documents only" do
+    it "creates publication logs for major updates to sections only" do
       expect(PublicationLog.count).to eq 1
       expect(PublicationLog.first.title).to eq "Section 1 major"
     end
 
-    it "sets the exported_at timestamp on the document" do
+    it "sets the exported_at timestamp on the section" do
       expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of publish_time
     end
   end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Republishing manuals", type: :feature do
 
   def create_manual_with_sections(published: true)
     manual = create_manual_without_ui(manual_fields)
-    @documents = create_documents_for_manual_without_ui(manual: manual, count: 2)
+    @documents = create_sections_for_manual_without_ui(manual: manual, count: 2)
 
     # Re-fetch manual to include documents
     @manual = manual_repository.fetch(manual.id)

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Republishing manuals", type: :feature do
   def edit_manual_and_sections
     @edited_manual = edit_manual_without_ui(@manual, edited_manual_fields)
 
-    @edited_documents = @sections.map do |document|
+    @edited_sections = @sections.map do |document|
       edit_section_without_ui(@manual, document, edited_section_fields(document))
     end
 
@@ -118,7 +118,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     before do
       create_manual_with_sections(published: true)
 
-      @edited_document = edit_manual_and_sections
+      @edited_section = edit_manual_and_sections
 
       republish_manuals_without_ui
     end
@@ -150,7 +150,7 @@ RSpec.describe "Republishing manuals", type: :feature do
       # all we can check is that it was only published once
       check_manual_is_published_to_publishing_api(@manual.id, times: 1)
       check_manual_is_not_published_to_rummager_with_attrs(@manual.slug, edited_manual_fields)
-      @edited_documents.each do |document|
+      @edited_sections.each do |document|
         check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
           title: document.title,
           description: document.summary,
@@ -163,7 +163,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not set the exported timestamp of the draft version of the section" do
-      expect(@edited_documents.first.latest_edition.reload.exported_at).to be_nil
+      expect(@edited_sections.first.latest_edition.reload.exported_at).to be_nil
     end
 
     it "does not set the exported timestamp of the previously published version of the section" do

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Republishing manuals", type: :feature do
 
   def create_manual_with_sections(published: true)
     manual = create_manual_without_ui(manual_fields)
-    @documents = create_sections_for_manual_without_ui(manual: manual, count: 2)
+    @sections = create_sections_for_manual_without_ui(manual: manual, count: 2)
 
     # Re-fetch manual to include documents
     @manual = manual_repository.fetch(manual.id)
@@ -45,7 +45,7 @@ RSpec.describe "Republishing manuals", type: :feature do
   def edit_manual_and_sections
     @edited_manual = edit_manual_without_ui(@manual, edited_manual_fields)
 
-    @edited_documents = @documents.map do |document|
+    @edited_documents = @sections.map do |document|
       edit_section_without_ui(@manual, document, edited_section_fields(document))
     end
 
@@ -70,7 +70,7 @@ RSpec.describe "Republishing manuals", type: :feature do
       })
       check_manual_is_published_to_publishing_api(@manual.id)
       check_manual_is_published_to_rummager(@manual.slug, manual_fields)
-      @documents.each do |document|
+      @sections.each do |document|
         check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
           title: document.attributes[:title],
           description: document.attributes[:summary],
@@ -81,7 +81,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not change the exported timestamp" do
-      expect(@documents.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
+      expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe "Republishing manuals", type: :feature do
       })
       check_manual_is_not_published_to_publishing_api(@manual.id)
       check_manual_is_not_published_to_rummager(@manual.slug)
-      @documents.each do |document|
+      @sections.each do |document|
         check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
           title: document.attributes[:title],
           description: document.attributes[:summary],
@@ -110,7 +110,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not change the exported timestamp" do
-      expect(@documents.first.latest_edition.reload.exported_at).to be_nil
+      expect(@sections.first.latest_edition.reload.exported_at).to be_nil
     end
   end
 
@@ -130,7 +130,7 @@ RSpec.describe "Republishing manuals", type: :feature do
       })
       check_manual_is_published_to_publishing_api(@manual.id)
       check_manual_is_published_to_rummager(@manual.slug, manual_fields)
-      @documents.each do |document|
+      @sections.each do |document|
         edited_fields = edited_section_fields(document)
         check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
           title: edited_fields[:title],
@@ -167,7 +167,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not set the exported timestamp of the previously published version of the section" do
-      expect(@documents.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
+      expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
     end
   end
 end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     manual = create_manual_without_ui(manual_fields)
     @sections = create_sections_for_manual_without_ui(manual: manual, count: 2)
 
-    # Re-fetch manual to include documents
+    # Re-fetch manual to include sections
     @manual = manual_repository.fetch(manual.id)
 
     if published
@@ -45,8 +45,8 @@ RSpec.describe "Republishing manuals", type: :feature do
   def edit_manual_and_sections
     @edited_manual = edit_manual_without_ui(@manual, edited_manual_fields)
 
-    @edited_sections = @sections.map do |document|
-      edit_section_without_ui(@manual, document, edited_section_fields(document))
+    @edited_sections = @sections.map do |section|
+      edit_section_without_ui(@manual, section, edited_section_fields(section))
     end
 
     WebMock::RequestRegistry.instance.reset!
@@ -70,13 +70,13 @@ RSpec.describe "Republishing manuals", type: :feature do
       })
       check_manual_is_published_to_publishing_api(@manual.id)
       check_manual_is_published_to_rummager(@manual.slug, manual_fields)
-      @sections.each do |document|
-        check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
-          title: document.attributes[:title],
-          description: document.attributes[:summary],
+      @sections.each do |section|
+        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+          title: section.attributes[:title],
+          description: section.attributes[:summary],
         })
-        check_section_is_published_to_publishing_api(document.id)
-        check_section_is_published_to_rummager(document.slug, section_fields(document), manual_fields)
+        check_section_is_published_to_publishing_api(section.id)
+        check_section_is_published_to_rummager(section.slug, section_fields(section), manual_fields)
       end
     end
 
@@ -99,13 +99,13 @@ RSpec.describe "Republishing manuals", type: :feature do
       })
       check_manual_is_not_published_to_publishing_api(@manual.id)
       check_manual_is_not_published_to_rummager(@manual.slug)
-      @sections.each do |document|
-        check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
-          title: document.attributes[:title],
-          description: document.attributes[:summary],
+      @sections.each do |section|
+        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+          title: section.attributes[:title],
+          description: section.attributes[:summary],
         })
-        check_section_is_not_published_to_publishing_api(document.id)
-        check_section_is_not_published_to_rummager(document.slug)
+        check_section_is_not_published_to_publishing_api(section.id)
+        check_section_is_not_published_to_rummager(section.slug)
       end
     end
 
@@ -130,14 +130,14 @@ RSpec.describe "Republishing manuals", type: :feature do
       })
       check_manual_is_published_to_publishing_api(@manual.id)
       check_manual_is_published_to_rummager(@manual.slug, manual_fields)
-      @sections.each do |document|
-        edited_fields = edited_section_fields(document)
-        check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
+      @sections.each do |section|
+        edited_fields = edited_section_fields(section)
+        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
           title: edited_fields[:title],
           description: edited_fields[:summary],
         })
-        check_section_is_published_to_publishing_api(document.id)
-        check_section_is_published_to_rummager(document.slug, section_fields(document), manual_fields)
+        check_section_is_published_to_publishing_api(section.id)
+        check_section_is_published_to_rummager(section.slug, section_fields(section), manual_fields)
       end
     end
 
@@ -150,15 +150,15 @@ RSpec.describe "Republishing manuals", type: :feature do
       # all we can check is that it was only published once
       check_manual_is_published_to_publishing_api(@manual.id, times: 1)
       check_manual_is_not_published_to_rummager_with_attrs(@manual.slug, edited_manual_fields)
-      @edited_sections.each do |document|
-        check_section_is_drafted_to_publishing_api(document.id, extra_attributes: {
-          title: document.title,
-          description: document.summary,
+      @edited_sections.each do |section|
+        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+          title: section.title,
+          description: section.summary,
         })
         # we can't check that it's not published (because one version will be)
         # all we can check is that it was only published once
-        check_section_is_published_to_publishing_api(document.id, times: 1)
-        check_section_is_not_published_to_rummager_with_attrs(document.slug, section_fields(document), edited_manual_fields)
+        check_section_is_published_to_publishing_api(section.id, times: 1)
+        check_section_is_not_published_to_rummager_with_attrs(section.slug, section_fields(section), edited_manual_fields)
       end
     end
 

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Republishing manuals", type: :feature do
           description: document.attributes[:summary],
         })
         check_section_is_published_to_publishing_api(document.id)
-        check_section_is_published_to_rummager(document.slug, document_fields(document), manual_fields)
+        check_section_is_published_to_rummager(document.slug, section_fields(document), manual_fields)
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe "Republishing manuals", type: :feature do
           description: edited_fields[:summary],
         })
         check_section_is_published_to_publishing_api(document.id)
-        check_section_is_published_to_rummager(document.slug, document_fields(document), manual_fields)
+        check_section_is_published_to_rummager(document.slug, section_fields(document), manual_fields)
       end
     end
 
@@ -158,7 +158,7 @@ RSpec.describe "Republishing manuals", type: :feature do
         # we can't check that it's not published (because one version will be)
         # all we can check is that it was only published once
         check_section_is_published_to_publishing_api(document.id, times: 1)
-        check_section_is_not_published_to_rummager_with_attrs(document.slug, document_fields(document), edited_manual_fields)
+        check_section_is_not_published_to_rummager_with_attrs(document.slug, section_fields(document), edited_manual_fields)
       end
     end
 

--- a/spec/footnotes_section_heading_renderer_spec.rb
+++ b/spec/footnotes_section_heading_renderer_spec.rb
@@ -4,12 +4,12 @@ require "footnotes_section_heading_renderer"
 
 RSpec.describe FootnotesSectionHeadingRenderer do
   subject(:renderer) {
-    FootnotesSectionHeadingRenderer.new(document)
+    FootnotesSectionHeadingRenderer.new(section)
   }
 
-  let(:document) { double(:document, body: html_fragment) }
+  let(:section) { double(:section, body: html_fragment) }
 
-  context "with footnotes in the document body" do
+  context "with footnotes in the section body" do
     let(:html_fragment) {
       '
         <h2 id="heading">First heading</h2>

--- a/spec/lib/manual_update_type_spec.rb
+++ b/spec/lib/manual_update_type_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ManualUpdateType do
   describe "for a manual that has been published before" do
     before { allow(manual).to receive(:has_ever_been_published?).and_return true }
 
-    context "and has no documents" do
+    context "and has no sections" do
       before { allow(manual).to receive(:sections).and_return [] }
 
       it "is 'minor'" do
@@ -48,7 +48,7 @@ RSpec.describe ManualUpdateType do
           allow(section_3).to receive(:needs_exporting?).and_return true
         end
 
-        it "is 'minor' when all documents are minor updates that have been published before" do
+        it "is 'minor' when all sections are minor updates that have been published before" do
           allow(section_1).to receive(:minor_update?).and_return true
           allow(section_2).to receive(:minor_update?).and_return true
           allow(section_3).to receive(:minor_update?).and_return true
@@ -59,7 +59,7 @@ RSpec.describe ManualUpdateType do
           expect(subject).to eql "minor"
         end
 
-        it "is 'major' when at least one document is a minor update that has never been published before" do
+        it "is 'major' when at least one section is a minor update that has never been published before" do
           allow(section_1).to receive(:minor_update?).and_return true
           allow(section_2).to receive(:minor_update?).and_return true
           allow(section_3).to receive(:minor_update?).and_return true
@@ -70,7 +70,7 @@ RSpec.describe ManualUpdateType do
           expect(subject).to eql "major"
         end
 
-        it "is 'major' when at least one documents is a major update" do
+        it "is 'major' when at least one sections is a major update" do
           allow(section_1).to receive(:minor_update?).and_return false
           allow(section_2).to receive(:minor_update?).and_return true
           allow(section_3).to receive(:minor_update?).and_return true

--- a/spec/models/manual_with_sections_spec.rb
+++ b/spec/models/manual_with_sections_spec.rb
@@ -4,13 +4,13 @@ require "manual_with_sections"
 
 describe ManualWithSections do
   subject(:manual_with_sections) {
-    ManualWithSections.new(document_builder, manual, sections: documents)
+    ManualWithSections.new(section_builder, manual, sections: sections)
   }
 
   let(:manual) { double(:manual, publish: nil) }
-  let(:document_builder) { double(:document_builder) }
-  let(:documents) { [document] }
-  let(:document) { double(:document, publish!: nil) }
+  let(:section_builder) { double(:section_builder) }
+  let(:sections) { [section] }
+  let(:section) { double(:section, publish!: nil) }
 
   let(:id) { double(:id) }
   let(:updated_at) { double(:updated_at) }
@@ -34,35 +34,35 @@ describe ManualWithSections do
       it "passes a block which publishes" do
         manual_with_sections.publish
 
-        expect(document).to have_received(:publish!)
+        expect(section).to have_received(:publish!)
       end
     end
 
     context "when the manual publish does not succeed" do
-      it "does not publish the documents" do
+      it "does not publish the sections" do
         manual_with_sections.publish
 
-        expect(document).not_to have_received(:publish!)
+        expect(section).not_to have_received(:publish!)
       end
     end
   end
 
   describe "#reorder_sections" do
-    let(:documents) {
+    let(:sections) {
       [
-        alpha_document,
-        beta_document,
-        gamma_document,
+        alpha_section,
+        beta_section,
+        gamma_section,
       ]
     }
 
-    let(:alpha_document) { double(:document, id: "alpha") }
-    let(:beta_document) { double(:document, id: "beta") }
-    let(:gamma_document) { double(:document, id: "gamma") }
+    let(:alpha_section) { double(:section, id: "alpha") }
+    let(:beta_section) { double(:section, id: "beta") }
+    let(:gamma_section) { double(:section, id: "gamma") }
 
-    let(:document_order) { %w(gamma alpha beta) }
+    let(:section_order) { %w(gamma alpha beta) }
 
-    it "reorders the documents to match the given order" do
+    it "reorders the sections to match the given order" do
       manual_with_sections.reorder_sections(%w(
         gamma
         alpha
@@ -70,13 +70,13 @@ describe ManualWithSections do
       ))
 
       expect(manual_with_sections.sections.to_a).to eq([
-        gamma_document,
-        alpha_document,
-        beta_document,
+        gamma_section,
+        alpha_section,
+        beta_section,
       ])
     end
 
-    it "raises an error if document_order doesn't contain all IDs" do
+    it "raises an error if section_order doesn't contain all IDs" do
       expect {
         manual_with_sections.reorder_sections(%w(
           alpha
@@ -85,7 +85,7 @@ describe ManualWithSections do
       }.to raise_error(ArgumentError)
     end
 
-    it "raises an error if document_order contains non-existent IDs" do
+    it "raises an error if section_order contains non-existent IDs" do
       expect {
         manual_with_sections.reorder_sections(%w(
           alpha
@@ -96,7 +96,7 @@ describe ManualWithSections do
       }.to raise_error(ArgumentError)
     end
 
-    it "raises an error if document_order contains duplicate IDs" do
+    it "raises an error if section_order contains duplicate IDs" do
       expect {
         manual_with_sections.reorder_sections(%w(
           alpha
@@ -111,38 +111,38 @@ describe ManualWithSections do
   describe "#remove_section" do
     subject(:manual_with_sections) {
       ManualWithSections.new(
-        document_builder,
+        section_builder,
         manual,
-        sections: documents,
-        removed_sections: removed_documents,
+        sections: sections,
+        removed_sections: removed_sections,
       )
     }
 
-    let(:documents) {
+    let(:sections) {
       [
-        document_a,
-        document_b,
+        section_a,
+        section_b,
       ]
     }
-    let(:document_a) { double(:document, id: "a") }
-    let(:document_b) { double(:document, id: "b") }
+    let(:section_a) { double(:section, id: "a") }
+    let(:section_b) { double(:section, id: "b") }
 
-    let(:removed_documents) { [document_c] }
-    let(:document_c) { double(:document, id: "c") }
+    let(:removed_sections) { [section_c] }
+    let(:section_c) { double(:section, id: "c") }
 
-    it "removes the document from #documents" do
-      manual_with_sections.remove_section(document_a.id)
+    it "removes the section from #sections" do
+      manual_with_sections.remove_section(section_a.id)
 
-      expect(manual_with_sections.sections.to_a).to eq([document_b])
+      expect(manual_with_sections.sections.to_a).to eq([section_b])
     end
 
-    it "adds the document to #removed_sections" do
-      manual_with_sections.remove_section(document_a.id)
+    it "adds the section to #removed_sections" do
+      manual_with_sections.remove_section(section_a.id)
 
       expect(manual_with_sections.removed_sections.to_a).to eq(
         [
-          document_c,
-          document_a,
+          section_c,
+          section_a,
         ]
       )
     end

--- a/spec/models/publication_log_spec.rb
+++ b/spec/models/publication_log_spec.rb
@@ -78,7 +78,7 @@ describe PublicationLog, hits_db: true do
         expect(PublicationLog.change_notes_for(slug)).to eq(change_notes_for_first_doc)
       end
 
-      context "and some are for documents with similar slugs" do
+      context "and some are for sections with similar slugs" do
         let!(:similar_slug) { "guidance/my-slug-belongs-to-me" }
 
         let!(:change_note_for_similar_slug) {
@@ -95,8 +95,8 @@ describe PublicationLog, hits_db: true do
         end
       end
 
-      context "and some are for child documents of the slug" do
-        let!(:child_slug) { "guidance/my-slug/my-lovely-document-slug" }
+      context "and some are for child sections of the slug" do
+        let!(:child_slug) { "guidance/my-slug/my-lovely-section-slug" }
 
         let!(:change_note_for_child_slug) {
           PublicationLog.create(

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -2,22 +2,22 @@ require "spec_helper"
 
 describe Section do
   subject(:doc) {
-    Section.new(slug_generator, document_id, editions, edition_factory)
+    Section.new(slug_generator, section_id, editions, edition_factory)
   }
 
   def key_classes_for(hash)
     hash.keys.map(&:class).uniq
   end
 
-  let(:document_id)         { "a-document-id" }
-  let(:slug)                { double(:slug) }
-  let(:published_slug)      { double(:published_slug) }
-  let(:slug_generator)      { double(:slug_generator, call: slug) }
-  let(:edition_factory)     { double(:edition_factory, call: new_edition) }
-  let(:new_edition)         { double(:new_edition, published?: false, draft?: true, assign_attributes: nil, version_number: 2) }
-  let(:attachments)         { double(:attachments) }
+  let(:section_id) { "a-section-id" }
+  let(:slug) { double(:slug) }
+  let(:published_slug) { double(:published_slug) }
+  let(:slug_generator) { double(:slug_generator, call: slug) }
+  let(:edition_factory) { double(:edition_factory, call: new_edition) }
+  let(:new_edition) { double(:new_edition, published?: false, draft?: true, assign_attributes: nil, version_number: 2) }
+  let(:attachments) { double(:attachments) }
 
-  let(:edition_messages)    {
+  let(:edition_messages) {
     {
       build_attachment: nil,
       assign_attributes: nil,
@@ -240,7 +240,7 @@ describe Section do
       end
     end
 
-    context "document is new, with no previous editions" do
+    context "section is new, with no previous editions" do
       let(:editions) { [] }
       let(:attrs)    { { title: "Test title" } }
 
@@ -250,12 +250,12 @@ describe Section do
         expect(edition_factory).to have_received(:call).with(
           version_number: 1,
           state: "draft",
-          document_id: document_id,
+          document_id: section_id,
         )
       end
     end
 
-    context "before the document is published" do
+    context "before the section is published" do
       context "with an existing draft edition" do
         let(:editions) { [draft_edition_v1] }
 
@@ -284,7 +284,7 @@ describe Section do
       end
     end
 
-    context "when the current document is published" do
+    context "when the current section is published" do
       let(:editions) { [published_edition_v1] }
 
       let(:params) { { title: "It is a new title" } }
@@ -381,7 +381,7 @@ describe Section do
       end
     end
 
-    context "when the current document is withdrawn" do
+    context "when the current section is withdrawn" do
       let(:editions) { [withdrawn_edition_v2] }
 
       let(:params) { { title: "It is a new title" } }
@@ -499,9 +499,9 @@ describe Section do
   end
 
   describe "#attributes" do
-    let(:relevant_document_attrs) {
+    let(:relevant_section_attrs) {
       {
-        "title" => "document_title",
+        "title" => "section_title",
       }
     }
 
@@ -513,7 +513,7 @@ describe Section do
 
     let(:edition) {
       draft_edition_v2.tap do |e|
-        allow(e).to receive(:attributes).and_return(relevant_document_attrs.merge(undesirable_edtion_attrs))
+        allow(e).to receive(:attributes).and_return(relevant_section_attrs.merge(undesirable_edtion_attrs))
       end
     }
 
@@ -531,13 +531,13 @@ describe Section do
 
     it "returns the latest edition's attributes" do
       expect(doc.attributes).to include(
-        relevant_document_attrs.symbolize_keys
+        relevant_section_attrs.symbolize_keys
       )
     end
 
-    it "returns a has including the document's id" do
+    it "returns a has including the section's id" do
       expect(doc.attributes).to include(
-        id: document_id,
+        id: section_id,
       )
     end
   end

--- a/spec/section_header_extractor_spec.rb
+++ b/spec/section_header_extractor_spec.rb
@@ -4,28 +4,28 @@ require "section_header_extractor"
 
 describe SectionHeaderExtractor do
   subject(:header_extractor) {
-    SectionHeaderExtractor.new(parser, doc)
+    SectionHeaderExtractor.new(parser, section)
   }
 
-  let(:doc)     { double(:doc, body: doc_body, attributes: doc_attributes) }
-  let(:parser)  { double(:parser, call: header_metadata) }
+  let(:section) { double(:section, body: section_body, attributes: section_attributes) }
+  let(:parser) { double(:parser, call: header_metadata) }
 
-  let(:doc_body)          { double(:doc_body) }
-  let(:doc_attributes)    { { body: doc_body } }
-  let(:header_metadata)   { [header_metadatum] }
-  let(:header_metadatum)  { double(:header_metadatum, headers: [], to_h: serialized_metadata) }
+  let(:section_body) { double(:section_body) }
+  let(:section_attributes) { { body: section_body } }
+  let(:header_metadata) { [header_metadatum] }
+  let(:header_metadatum) { double(:header_metadatum, headers: [], to_h: serialized_metadata) }
   let(:serialized_metadata) { double(:serialized_metadata) }
 
   it "is a true decorator" do
-    expect(doc).to receive(:arbitrary_message)
+    expect(section).to receive(:arbitrary_message)
     header_extractor.arbitrary_message
   end
 
   describe "#headers" do
-    it "parses the document body with the govspeak parser" do
+    it "parses the section body with the govspeak parser" do
       header_extractor.headers
 
-      expect(parser).to have_received(:call).with(doc_body)
+      expect(parser).to have_received(:call).with(section_body)
     end
 
     it "returns header metadata from Govspeak" do
@@ -40,8 +40,8 @@ describe SectionHeaderExtractor do
   end
 
   describe "#attributes" do
-    it "returns the document attributes with header metadata added" do
-      expect(header_extractor.attributes).to include(doc_attributes)
+    it "returns the section attributes with header metadata added" do
+      expect(header_extractor.attributes).to include(section_attributes)
       expect(header_extractor.attributes).to include(headers: [serialized_metadata])
     end
   end


### PR DESCRIPTION
This follows on from #914.

I think this changes most of the remaining occurrences of "document" to "section". The main exceptions are:

*  `SectionEdition#document_id`, `ManualRecord#document_ids` & `ManualRecord#removed_document_ids` fields.
* A few places where an object can be either a `Manual` **or** a `Section`.
* HTML element IDs / CSS classes & selectors.

I'm sorry that there are a lot of commits, but they are mostly pretty small and the tests should pass after every commit.