### PR TITLE
Remove unused options from mongoid.yml

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -14,7 +14,6 @@ production:
   database: govuk_content_production
   refresh_mode: :sync
   logger: false
-  refresh_interval: 120
   use_activesupport_time_zone: true
   hosts:
     - <%= ENV['MONGODB_NODES'] %>

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -12,7 +12,6 @@ test:
 
 production:
   database: govuk_content_production
-  refresh_mode: :sync
   logger: false
   use_activesupport_time_zone: true
   hosts:


### PR DESCRIPTION
As far as I can tell these options have no effect. They're not options in Mongoid and don't appear to be options in the underlying mongo gem either.

These options were added in c371b95 but the commit note doesn't explain anything about them. In the comments on that commit, the original author has explained that the setting was copied from alphagov-deployment and that there's no explanation in that repo either.

Removing them should make it easier to upgrade Mongoid in a separate branch.