### PR TITLE
Iterate over MONGODB_NODES in mongoid.yml

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -10,6 +10,9 @@ test:
   database: govuk_content_manuals_publisher_test
   autocreate_indexes: true
 
+<% mongo_nodes = (ENV['MONGODB_NODES'] || '').split("\n") %>
+<% first_mongo_node = mongo_nodes.shift %>
+
 production:
   database: govuk_content_production
   refresh_mode: :sync
@@ -17,4 +20,7 @@ production:
   refresh_interval: 120
   use_activesupport_time_zone: true
   hosts:
-    - <%= ENV['MONGODB_NODES'] %>
+    - <%= first_mongo_node %>
+      <% mongo_nodes.each do |node| %>
+      <%= node.strip %>
+      <% end %>


### PR DESCRIPTION
This reduces the coupling between this app and the [manuals_publisher
Puppet recipe in govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/manuals_publisher.pp).

The `MONGODB_NODES` variable contains a string like this:

```
- node1:27017
      - node2:27017
      - node3:27017
```

The whitespace is important as it allows this string to be inserted into
mongoid.yml and for the result to be valid (see commit https://github.com/alphagov/govuk-puppet/commit/06acc5ce08e11bee1d05d11e47c6afacb073a7f0 for
more info). The mongoid.yml file ends up containing something like:

```
production:
  hosts:
    - - node1:27017
      - node2:27017
      - node3:27017
```

I'm in the process of upgrading to Mongoid 3 which requires a change to
the format of mongoid.yml. Significantly the indentation of the hosts
setting changes which means that inserting `MONGODB_NODES` no longer
results in valid YAML.

The update in this commit treats `MONGODB_NODES` as an array and strips
the leading whitespace from each host so that we don't have to update
the Puppet recipe if/when this file changes.

I tested the change locally by setting `MONGODB_NODES` to the example
above and adding some debug output to `Mongoid::Config.load!` in the
mongoid gem. I confirmed that I get the `settings` hash yielded in the
`load!` method before and after this change.

I think the proper solution is to switch to using `MONGODB_URI` (as
documented in issue #930) but I think this is a good enough to allow me
to proceed with the Mongoid upgrade for now.
