### PR TITLE
Simplify scoped manual repository

### DIFF
--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -1,7 +1,7 @@
 class ManualPublishTaskAssociationMarshaller
-  def initialize(decorator:, collection:)
+  def initialize(decorator:)
     @decorator = decorator
-    @collection = collection
+    @collection = ManualPublishTask
   end
 
   def load(manual, _record)

--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -1,6 +1,11 @@
 class ManualPublishTaskAssociationMarshaller
-  def initialize(decorator:)
-    @decorator = decorator
+  def initialize
+    @decorator = ->(manual, attrs) {
+      ManualWithPublishTasks.new(
+        manual,
+        attrs,
+      )
+    }
   end
 
   def load(manual, _record)

--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -1,11 +1,10 @@
 class ManualPublishTaskAssociationMarshaller
   def initialize(decorator:)
     @decorator = decorator
-    @collection = ManualPublishTask
   end
 
   def load(manual, _record)
-    tasks = collection.for_manual(manual)
+    tasks = ManualPublishTask.for_manual(manual)
 
     decorator.call(manual, publish_tasks: tasks)
   end
@@ -17,5 +16,5 @@ class ManualPublishTaskAssociationMarshaller
 
 private
 
-  attr_reader :collection, :decorator
+  attr_reader :decorator
 end

--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -1,25 +1,12 @@
 class ManualPublishTaskAssociationMarshaller
-  def initialize
-    @decorator = ->(manual, attrs) {
-      ManualWithPublishTasks.new(
-        manual,
-        attrs,
-      )
-    }
-  end
-
   def load(manual, _record)
     tasks = ManualPublishTask.for_manual(manual)
 
-    decorator.call(manual, publish_tasks: tasks)
+    ManualWithPublishTasks.new(manual, publish_tasks: tasks)
   end
 
   def dump(_manual, _record)
     # PublishTasks are read only
     nil
   end
-
-private
-
-  attr_reader :decorator
 end

--- a/app/repositories/marshallers/section_association_marshaller.rb
+++ b/app/repositories/marshallers/section_association_marshaller.rb
@@ -1,6 +1,6 @@
 class SectionAssociationMarshaller
-  def initialize
-    @decorator = ->(manual, attrs) {
+  class Decorator
+    def call(manual, attrs)
       ManualValidator.new(
         NullValidator.new(
           ManualWithSections.new(
@@ -10,7 +10,7 @@ class SectionAssociationMarshaller
           )
         )
       )
-    }
+    end
   end
 
   def load(manual, record)
@@ -28,7 +28,7 @@ class SectionAssociationMarshaller
       end
     }
 
-    decorator.call(manual, sections: sections, removed_sections: removed_sections)
+    Decorator.new.call(manual, sections: sections, removed_sections: removed_sections)
   end
 
   def dump(manual, record)

--- a/app/repositories/marshallers/section_association_marshaller.rb
+++ b/app/repositories/marshallers/section_association_marshaller.rb
@@ -1,6 +1,16 @@
 class SectionAssociationMarshaller
-  def initialize(decorator:)
-    @decorator = decorator
+  def initialize
+    @decorator = ->(manual, attrs) {
+      ManualValidator.new(
+        NullValidator.new(
+          ManualWithSections.new(
+            SectionBuilder.new,
+            manual,
+            attrs,
+          )
+        )
+      )
+    }
   end
 
   def load(manual, record)

--- a/app/repositories/scoped_manual_repository.rb
+++ b/app/repositories/scoped_manual_repository.rb
@@ -6,19 +6,7 @@ class ScopedManualRepository
   def initialize(collection)
     @repository = ManualRepository.new(
       association_marshallers: [
-        SectionAssociationMarshaller.new(
-          decorator: ->(manual, attrs) {
-            ManualValidator.new(
-              NullValidator.new(
-                ManualWithSections.new(
-                  SectionBuilder.new,
-                  manual,
-                  attrs,
-                )
-              )
-            )
-          }
-        ),
+        SectionAssociationMarshaller.new,
         ManualPublishTaskAssociationMarshaller.new
       ],
       collection: collection,

--- a/app/repositories/scoped_manual_repository.rb
+++ b/app/repositories/scoped_manual_repository.rb
@@ -19,14 +19,7 @@ class ScopedManualRepository
             )
           }
         ),
-        ManualPublishTaskAssociationMarshaller.new(
-          decorator: ->(manual, attrs) {
-            ManualWithPublishTasks.new(
-              manual,
-              attrs,
-            )
-          }
-        ),
+        ManualPublishTaskAssociationMarshaller.new
       ],
       collection: collection,
     )

--- a/app/repositories/scoped_manual_repository.rb
+++ b/app/repositories/scoped_manual_repository.rb
@@ -20,7 +20,6 @@ class ScopedManualRepository
           }
         ),
         ManualPublishTaskAssociationMarshaller.new(
-          collection: ManualPublishTask,
           decorator: ->(manual, attrs) {
             ManualWithPublishTasks.new(
               manual,

--- a/spec/repositories/marshallers/section_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/section_association_marshaller_spec.rb
@@ -15,7 +15,7 @@ describe SectionAssociationMarshaller do
     )
   }
 
-  let(:entity) { double(:entity) }
+  let(:manual) { double(:manual) }
   let(:record) {
     double(
       :record,
@@ -37,7 +37,7 @@ describe SectionAssociationMarshaller do
   let(:removed_sections) { [removed_section] }
 
   before do
-    allow(SectionRepository).to receive(:new).with(manual: entity).and_return(section_repository)
+    allow(SectionRepository).to receive(:new).with(manual: manual).and_return(section_repository)
   end
 
   describe "#load" do
@@ -49,41 +49,41 @@ describe SectionAssociationMarshaller do
     end
 
     it "fetches associated sections and removed sections by ids" do
-      marshaller.load(entity, record)
+      marshaller.load(manual, record)
 
       expect(section_repository).to have_received(:fetch).with(section_id)
       expect(section_repository).to have_received(:fetch).
         with(removed_section_id)
     end
 
-    it "decorates the entity with the attributes" do
+    it "decorates the manual with the attributes" do
       allow(ManualWithSections).to receive(:new)
       allow(SectionBuilder).to receive(:new).and_return(:section_builder)
       allow(NullValidator).to receive(:new)
       allow(ManualValidator).to receive(:new)
 
-      marshaller.load(entity, record)
+      marshaller.load(manual, record)
 
-      expect(ManualWithSections).to have_received(:new).with(:section_builder, entity, sections: [section], removed_sections: [removed_section])
+      expect(ManualWithSections).to have_received(:new).with(:section_builder, manual, sections: [section], removed_sections: [removed_section])
       expect(NullValidator).to have_received(:new)
       expect(ManualValidator).to have_received(:new)
     end
 
-    it "returns the decorated entity" do
+    it "returns the decorated manual" do
       expect(
-        marshaller.load(entity, record)
-      ).to eq(entity)
+        marshaller.load(manual, record)
+      ).to eq(manual)
     end
   end
 
   describe "#dump" do
     before do
-      allow(entity).to receive(:sections).and_return(sections)
-      allow(entity).to receive(:removed_sections).and_return(removed_sections)
+      allow(manual).to receive(:sections).and_return(sections)
+      allow(manual).to receive(:removed_sections).and_return(removed_sections)
     end
 
     it "saves associated sections and removed sections" do
-      marshaller.dump(entity, record)
+      marshaller.dump(manual, record)
 
       expect(section_repository).to have_received(:store).with(section)
       expect(section_repository).to have_received(:store).
@@ -91,20 +91,20 @@ describe SectionAssociationMarshaller do
     end
 
     it "updates associated document ids on the record" do
-      marshaller.dump(entity, record)
+      marshaller.dump(manual, record)
 
       expect(record).to have_received(:document_ids=).with(section_ids)
     end
 
     it "updates associated removed document ids on the record" do
-      marshaller.dump(entity, record)
+      marshaller.dump(manual, record)
 
       expect(record).to have_received(:removed_document_ids=).
         with(removed_section_ids)
     end
 
     it "returns nil" do
-      expect(marshaller.dump(entity, record)).to eq(nil)
+      expect(marshaller.dump(manual, record)).to eq(nil)
     end
   end
 end

--- a/spec/repositories/marshallers/section_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/section_association_marshaller_spec.rb
@@ -36,8 +36,12 @@ describe SectionAssociationMarshaller do
   let(:removed_section) { double(:removed_section, id: removed_section_id) }
   let(:removed_sections) { [removed_section] }
 
+  let(:decorator) { double(:decorator) }
+  let(:decorated_manual) { double(:decorated_manual) }
+
   before do
     allow(SectionRepository).to receive(:new).with(manual: manual).and_return(section_repository)
+    allow(SectionAssociationMarshaller::Decorator).to receive(:new).and_return(decorator)
   end
 
   describe "#load" do
@@ -46,6 +50,7 @@ describe SectionAssociationMarshaller do
         with(section_id).and_return(section)
       allow(section_repository).to receive(:fetch).
         with(removed_section_id).and_return(removed_section)
+      allow(decorator).to receive(:call).and_return(decorated_manual)
     end
 
     it "fetches associated sections and removed sections by ids" do
@@ -57,22 +62,15 @@ describe SectionAssociationMarshaller do
     end
 
     it "decorates the manual with the attributes" do
-      allow(ManualWithSections).to receive(:new)
-      allow(SectionBuilder).to receive(:new).and_return(:section_builder)
-      allow(NullValidator).to receive(:new)
-      allow(ManualValidator).to receive(:new)
-
       marshaller.load(manual, record)
 
-      expect(ManualWithSections).to have_received(:new).with(:section_builder, manual, sections: [section], removed_sections: [removed_section])
-      expect(NullValidator).to have_received(:new)
-      expect(ManualValidator).to have_received(:new)
+      expect(decorator).to have_received(:call).with(manual, sections: [section], removed_sections: [removed_section])
     end
 
     it "returns the decorated manual" do
       expect(
         marshaller.load(manual, record)
-      ).to eq(manual)
+      ).to eq(decorated_manual)
     end
   end
 

--- a/spec/repositories/marshallers/section_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/section_association_marshaller_spec.rb
@@ -4,12 +4,8 @@ require "marshallers/section_association_marshaller"
 
 describe SectionAssociationMarshaller do
   subject(:marshaller) {
-    SectionAssociationMarshaller.new(
-      decorator: decorator,
-    )
+    SectionAssociationMarshaller.new
   }
-
-  let(:decorator) { double(:decorator, call: nil) }
 
   let(:section_repository) {
     double(
@@ -45,14 +41,11 @@ describe SectionAssociationMarshaller do
   end
 
   describe "#load" do
-    let(:decorated_entity) { double(:decorated_entity) }
-
     before do
       allow(section_repository).to receive(:fetch).
         with(section_id).and_return(section)
       allow(section_repository).to receive(:fetch).
         with(removed_section_id).and_return(removed_section)
-      allow(decorator).to receive(:call).and_return(decorated_entity)
     end
 
     it "fetches associated sections and removed sections by ids" do
@@ -64,16 +57,22 @@ describe SectionAssociationMarshaller do
     end
 
     it "decorates the entity with the attributes" do
+      allow(ManualWithSections).to receive(:new)
+      allow(SectionBuilder).to receive(:new).and_return(:section_builder)
+      allow(NullValidator).to receive(:new)
+      allow(ManualValidator).to receive(:new)
+
       marshaller.load(entity, record)
 
-      expect(decorator).to have_received(:call).
-        with(entity, sections: sections, removed_sections: removed_sections)
+      expect(ManualWithSections).to have_received(:new).with(:section_builder, entity, sections: [section], removed_sections: [removed_section])
+      expect(NullValidator).to have_received(:new)
+      expect(ManualValidator).to have_received(:new)
     end
 
     it "returns the decorated entity" do
       expect(
         marshaller.load(entity, record)
-      ).to eq(decorated_entity)
+      ).to eq(entity)
     end
   end
 


### PR DESCRIPTION
This PR inlines the arguments of `SectionAssociationMarshaller` and `ManualPublishTaskAssociationMarshaller` making the code a bit easier to follow. It's still not really clear to me why these marshallers exist but hopefully reducing some of the indirection will eventually let us work out where their behaviour really belongs. 