### PR TITLE
Rename document_id to section_id

### DIFF
--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -76,7 +76,7 @@ private
     field :state, type: String
     field :version_number, type: Integer
     field :document_ids, type: Array, as: :section_ids
-    field :removed_document_ids, type: Array, as: :removed_section_ids
+    field :removed_section_ids, type: Array
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean
 

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -75,7 +75,7 @@ private
     field :body, type: String
     field :state, type: String
     field :version_number, type: Integer
-    field :document_ids, type: Array, as: :section_ids
+    field :section_ids, type: Array
     field :removed_section_ids, type: Array
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -75,7 +75,7 @@ private
     field :body, type: String
     field :state, type: String
     field :version_number, type: Integer
-    field :document_ids, type: Array
+    field :document_ids, type: Array, as: :section_ids
     field :removed_document_ids, type: Array, as: :removed_section_ids
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -76,7 +76,7 @@ private
     field :state, type: String
     field :version_number, type: Integer
     field :document_ids, type: Array
-    field :removed_document_ids, type: Array
+    field :removed_document_ids, type: Array, as: :removed_section_ids
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -166,7 +166,7 @@ protected
       state: "draft",
       version_number: 1,
       # TODO: Remove persistence conern
-      document_id: id,
+      section_id: id,
     }
   end
 

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -6,7 +6,7 @@ class SectionEdition
 
   store_in "manual_section_editions"
 
-  field :document_id,          type: String
+  field :document_id,          type: String, as: :section_id
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String
@@ -18,7 +18,7 @@ class SectionEdition
   field :public_updated_at, type: DateTime
   field :exported_at, type: DateTime
 
-  validates :document_id, presence: true
+  validates :section_id, presence: true
   validates :slug, presence: true
 
   embeds_many :attachments, cascade_callbacks: true

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -6,7 +6,7 @@ class SectionEdition
 
   store_in "manual_section_editions"
 
-  field :document_id,          type: String, as: :section_id
+  field :section_id,          type: String
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String
@@ -39,7 +39,7 @@ class SectionEdition
 
   scope :with_slug_prefix, ->(slug) { where(slug: /^#{slug}.*/) }
 
-  index "document_id"
+  index "section_id"
   index "state"
   index "updated_at"
 

--- a/app/repositories/marshallers/section_association_marshaller.rb
+++ b/app/repositories/marshallers/section_association_marshaller.rb
@@ -16,7 +16,7 @@ class SectionAssociationMarshaller
   def load(manual, record)
     section_repository = SectionRepository.new(manual: manual)
 
-    sections = Array(record.document_ids).map { |section_id|
+    sections = Array(record.section_ids).map { |section_id|
       section_repository.fetch(section_id)
     }
 
@@ -42,7 +42,7 @@ class SectionAssociationMarshaller
       section_repository.store(section)
     end
 
-    record.document_ids = manual.sections.map(&:id)
+    record.section_ids = manual.sections.map(&:id)
     record.removed_section_ids = manual.removed_sections.map(&:id)
 
     nil

--- a/app/repositories/marshallers/section_association_marshaller.rb
+++ b/app/repositories/marshallers/section_association_marshaller.rb
@@ -20,7 +20,7 @@ class SectionAssociationMarshaller
       section_repository.fetch(section_id)
     }
 
-    removed_sections = Array(record.removed_document_ids).map { |section_id|
+    removed_sections = Array(record.removed_section_ids).map { |section_id|
       begin
         section_repository.fetch(section_id)
       rescue KeyError
@@ -43,7 +43,7 @@ class SectionAssociationMarshaller
     end
 
     record.document_ids = manual.sections.map(&:id)
-    record.removed_document_ids = manual.removed_sections.map(&:id)
+    record.removed_section_ids = manual.removed_sections.map(&:id)
 
     nil
   end

--- a/app/repositories/section_repository.rb
+++ b/app/repositories/section_repository.rb
@@ -103,7 +103,7 @@ private
     collection.all
       .order_by([:updated_at, :desc])
       .only(:document_id, :updated_at)
-      .map(&:document_id)
+      .map(&:section_id)
       .uniq
   end
 

--- a/app/repositories/section_repository.rb
+++ b/app/repositories/section_repository.rb
@@ -25,7 +25,7 @@ class SectionRepository
 
   def [](id)
     editions = section_editions
-      .where(document_id: id)
+      .where(section_id: id)
       .order_by([:version_number, :desc])
       .limit(2)
       .to_a
@@ -50,7 +50,7 @@ class SectionRepository
     if section.draft?
       section_editions.where(
         :slug => section.slug,
-        :document_id.ne => section.id,
+        :section_id.ne => section.id,
         :state => "published"
       ).empty?
     else
@@ -69,7 +69,7 @@ class SectionRepository
   end
 
   def count
-    section_editions.distinct(:document_id).count
+    section_editions.distinct(:section_id).count
   end
 
 private
@@ -102,7 +102,7 @@ private
   def only_section_ids_for(collection)
     collection.all
       .order_by([:updated_at, :desc])
-      .only(:document_id, :updated_at)
+      .only(:section_id, :updated_at)
       .map(&:section_id)
       .uniq
   end

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -94,7 +94,7 @@ private
   end
 
   def build_section(section_id)
-    all_editions = SectionEdition.where(document_id: section_id).order_by([:version_number, :desc]).to_a
+    all_editions = SectionEdition.where(section_id: section_id).order_by([:version_number, :desc]).to_a
     Section.new(
       ->(_title) { raise RuntimeError, "read only manual" },
       section_id,

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -24,7 +24,7 @@ private
 
     build_manual_for(manual_record, manual_record.latest_edition) do
       {
-        sections: get_latest_version_of_sections(manual_record.latest_edition.document_ids),
+        sections: get_latest_version_of_sections(manual_record.latest_edition.section_ids),
         removed_sections: get_latest_version_of_sections(manual_record.latest_edition.removed_section_ids),
       }
     end
@@ -36,7 +36,7 @@ private
     if manual_record.latest_edition.state == "published"
       build_manual_for(manual_record, manual_record.latest_edition) do
         {
-          sections: get_latest_version_of_sections(manual_record.latest_edition.document_ids),
+          sections: get_latest_version_of_sections(manual_record.latest_edition.section_ids),
           removed_sections: get_latest_version_of_sections(manual_record.latest_edition.removed_section_ids),
         }
       end
@@ -45,7 +45,7 @@ private
       if previous_edition.state == "published"
         build_manual_for(manual_record, previous_edition) do
           {
-            sections: get_published_version_of_sections(previous_edition.document_ids),
+            sections: get_published_version_of_sections(previous_edition.section_ids),
             removed_sections: get_latest_version_of_sections(previous_edition.removed_section_ids)
           }
         end

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -25,7 +25,7 @@ private
     build_manual_for(manual_record, manual_record.latest_edition) do
       {
         sections: get_latest_version_of_sections(manual_record.latest_edition.document_ids),
-        removed_sections: get_latest_version_of_sections(manual_record.latest_edition.removed_document_ids),
+        removed_sections: get_latest_version_of_sections(manual_record.latest_edition.removed_section_ids),
       }
     end
   end
@@ -37,7 +37,7 @@ private
       build_manual_for(manual_record, manual_record.latest_edition) do
         {
           sections: get_latest_version_of_sections(manual_record.latest_edition.document_ids),
-          removed_sections: get_latest_version_of_sections(manual_record.latest_edition.removed_document_ids),
+          removed_sections: get_latest_version_of_sections(manual_record.latest_edition.removed_section_ids),
         }
       end
     elsif manual_record.latest_edition.state == "draft"
@@ -46,7 +46,7 @@ private
         build_manual_for(manual_record, previous_edition) do
           {
             sections: get_published_version_of_sections(previous_edition.document_ids),
-            removed_sections: get_latest_version_of_sections(previous_edition.removed_document_ids)
+            removed_sections: get_latest_version_of_sections(previous_edition.removed_section_ids)
           }
         end
       else

--- a/db/migrate/20170329103706_rename_manual_record_editions_removed_document_ids_to_removed_section_ids.rb
+++ b/db/migrate/20170329103706_rename_manual_record_editions_removed_document_ids_to_removed_section_ids.rb
@@ -1,0 +1,17 @@
+class RenameManualRecordEditionsRemovedDocumentIdsToRemovedSectionIds < Mongoid::Migration
+  def self.up
+    ManualRecord::Edition.collection.update(
+      {},
+      { '$rename' => { 'removed_document_ids' => 'removed_section_ids' } },
+      { multi: true }
+    )
+  end
+
+  def self.down
+    ManualRecord::Edition.collection.update(
+      {},
+      { '$rename' => { 'removed_section_ids' => 'removed_document_ids' } },
+      { multi: true }
+    )
+  end
+end

--- a/db/migrate/20170329104723_rename_manual_record_editions_document_ids_to_section_ids.rb
+++ b/db/migrate/20170329104723_rename_manual_record_editions_document_ids_to_section_ids.rb
@@ -1,0 +1,17 @@
+class RenameManualRecordEditionsDocumentIdsToSectionIds < Mongoid::Migration
+  def self.up
+    ManualRecord::Edition.collection.update(
+      {},
+      { '$rename' => { 'document_ids' => 'section_ids' } },
+      { multi: true }
+    )
+  end
+
+  def self.down
+    ManualRecord::Edition.collection.update(
+      {},
+      { '$rename' => { 'section_ids' => 'document_ids' } },
+      { multi: true }
+    )
+  end
+end

--- a/db/migrate/20170329105700_rename_section_editions_document_id_to_section_id.rb
+++ b/db/migrate/20170329105700_rename_section_editions_document_id_to_section_id.rb
@@ -1,0 +1,17 @@
+class RenameSectionEditionsDocumentIdToSectionId < Mongoid::Migration
+  def self.up
+    SectionEdition.collection.update(
+      {},
+      { '$rename' => { 'document_id' => 'section_id' } },
+      { multi: true }
+    )
+  end
+
+  def self.down
+    SectionEdition.collection.update(
+      {},
+      { '$rename' => { 'section_id' => 'document_id' } },
+      { multi: true }
+    )
+  end
+end

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -20,11 +20,11 @@ class AttachmentReporting
       unique_pdf_attachment_file_ids_for_manual = Set.new
 
       # Rather than examine each manual edition and its set of section editions and attachments in turn,
-      # we instead get all unique document ids associated with this manual, then walk through
+      # we instead get all unique section ids associated with this manual, then walk through
       # the editions of these sections in version order to find unique PDF attachments and their
       # publication times.
-      all_unique_document_ids_for_manual(manual).each do |document_id|
-        section_editions = SectionEdition.where(document_id: document_id).order_by([:version_number, :asc])
+      all_unique_section_ids_for_manual(manual).each do |section_id|
+        section_editions = SectionEdition.where(document_id: section_id).order_by([:version_number, :asc])
 
         section_editions.each do |section_edition|
           next if section_edition_never_published?(section_edition)
@@ -79,7 +79,7 @@ private
     !POST_PUBLICATION_STATES.include?(section_edition.state)
   end
 
-  def all_unique_document_ids_for_manual(manual)
+  def all_unique_section_ids_for_manual(manual)
     manual.editions.map(&:document_ids).flatten.uniq
   end
 end

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -80,6 +80,6 @@ private
   end
 
   def all_unique_section_ids_for_manual(manual)
-    manual.editions.map(&:document_ids).flatten.uniq
+    manual.editions.map(&:section_ids).flatten.uniq
   end
 end

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -24,7 +24,7 @@ class AttachmentReporting
       # the editions of these sections in version order to find unique PDF attachments and their
       # publication times.
       all_unique_section_ids_for_manual(manual).each do |section_id|
-        section_editions = SectionEdition.where(document_id: section_id).order_by([:version_number, :asc])
+        section_editions = SectionEdition.where(section_id: section_id).order_by([:version_number, :asc])
 
         section_editions.each do |section_edition|
           next if section_edition_never_published?(section_edition)

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -81,7 +81,7 @@ private
     discard_draft_from_publishing_api(manual_record.manual_id)
 
     section_ids.each do |id|
-      SectionEdition.where(document_id: id).map(&:destroy)
+      SectionEdition.where(section_id: id).map(&:destroy)
     end
 
     manual_record.destroy

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -60,7 +60,7 @@ private
   end
 
   def section_ids_for(manual_record)
-    manual_record.editions.flat_map(&:document_ids).uniq
+    manual_record.editions.flat_map(&:section_ids).uniq
   end
 
   # Some of this method violates SRP -- we could move it out to a service if we

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -46,7 +46,7 @@ private
   end
 
   def user_must_confirm(manual_record)
-    number_of_sections = document_ids_for(manual_record).count
+    number_of_sections = section_ids_for(manual_record).count
     log "### PLEASE CONFIRM -------------------------------------"
     log "Manual to be deleted: #{manual_record.slug}"
     log "Organisation: #{manual_record.organisation_slug}"
@@ -59,7 +59,7 @@ private
     end
   end
 
-  def document_ids_for(manual_record)
+  def section_ids_for(manual_record)
     manual_record.editions.flat_map(&:document_ids).uniq
   end
 
@@ -75,12 +75,12 @@ private
   # I'm loth to do this at this stage, given how specific the requirement
   # driving writing of this script is.
   def complete_removal(manual_record)
-    document_ids = document_ids_for(manual_record)
+    section_ids = section_ids_for(manual_record)
 
-    document_ids.each { |id| discard_draft_from_publishing_api(id) }
+    section_ids.each { |id| discard_draft_from_publishing_api(id) }
     discard_draft_from_publishing_api(manual_record.manual_id)
 
-    document_ids.each do |id|
+    section_ids.each do |id|
       SectionEdition.where(document_id: id).map(&:destroy)
     end
 

--- a/lib/duplicate_document_finder.rb
+++ b/lib/duplicate_document_finder.rb
@@ -11,11 +11,11 @@ class DuplicateDocumentFinder
       slug_hash[edition.slug][edition.document_id][:editions] += 1
     end
 
-    slug_hash.reject! { |_slug, document_ids| document_ids.size == 1 }
+    slug_hash.reject! { |_slug, section_ids| section_ids.size == 1 }
 
     slug_hash.each do |slug, sections|
-      sections.each do |document_id, data|
-        @io.puts [slug, document_id, data[:state], data[:created_at], data[:editions]].join(",")
+      sections.each do |section_id, data|
+        @io.puts [slug, section_id, data[:state], data[:created_at], data[:editions]].join(",")
       end
     end
   end

--- a/lib/duplicate_document_finder.rb
+++ b/lib/duplicate_document_finder.rb
@@ -7,8 +7,8 @@ class DuplicateDocumentFinder
     slug_hash = {}
     SectionEdition.all.each do |edition|
       slug_hash[edition.slug] ||= {}
-      slug_hash[edition.slug][edition.document_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0 }
-      slug_hash[edition.slug][edition.document_id][:editions] += 1
+      slug_hash[edition.slug][edition.section_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0 }
+      slug_hash[edition.slug][edition.section_id][:editions] += 1
     end
 
     slug_hash.reject! { |_slug, section_ids| section_ids.size == 1 }

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -31,8 +31,8 @@ private
     slug_hash = {}
     SectionEdition.all.each do |edition|
       slug_hash[edition.slug] ||= {}
-      slug_hash[edition.slug][edition.document_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.document_id, slug: edition.slug }
-      slug_hash[edition.slug][edition.document_id][:editions] += 1
+      slug_hash[edition.slug][edition.section_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.section_id, slug: edition.slug }
+      slug_hash[edition.slug][edition.section_id][:editions] += 1
     end
 
     slug_hash.reject! { |_slug, documents| documents.size == 1 }

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -4,11 +4,11 @@ class DuplicateDraftDeleter
   def call
     duplicated_editions_not_in_publishing_api = duplicated_editions.reject { |data| in_publishing_api?(data[:content_id]) }
     content_ids = duplicated_editions_not_in_publishing_api.map { |data| data[:content_id] }
-    editions_to_delete = SectionEdition.where(:document_id.in => content_ids)
+    editions_to_delete = SectionEdition.where(:section_id.in => content_ids)
 
     puts "The following #{editions_to_delete.count} editions are unknown to Publishing API and will be deleted:"
     editions_to_delete.each do |edition|
-      puts [edition[:slug], edition[:document_id], edition[:state], edition[:created_at]].join(",")
+      puts [edition[:slug], edition[:section_id], edition[:state], edition[:created_at]].join(",")
       edition.delete
     end
   end

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -54,7 +54,7 @@ private
   end
 
   def build_logs_for_all_other_suitable_section_editions
-    edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.document_ids)
+    edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.section_ids)
 
     edition_ordering.sort_by_section_ids_and_created_at.each do |edition|
       PublicationLog.create!(
@@ -69,7 +69,7 @@ private
   end
 
   def section_editions_for_first_manual_edition
-    @section_editions_for_first_manual_edition ||= SectionEdition.where(:document_id.in => first_manual_edition.document_ids, :minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
+    @section_editions_for_first_manual_edition ||= SectionEdition.where(:document_id.in => first_manual_edition.section_ids, :minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
   end
 
   def first_manual_edition

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -12,24 +12,24 @@ class ManualPublicationLogFilter
   end
 
   class EditionOrdering
-    def initialize(section_editions, document_ids)
+    def initialize(section_editions, section_ids)
       @section_editions = section_editions
-      @document_ids = document_ids
+      @section_ids = section_ids
     end
 
-    def sort_by_document_ids_and_created_at
-      editions_not_matching_supplied_sections = @section_editions.where(:document_id.nin => @document_ids)
-      editions_matching_supplied_sections = @section_editions.where(:document_id.in => @document_ids)
+    def sort_by_section_ids_and_created_at
+      editions_not_matching_supplied_sections = @section_editions.where(:document_id.nin => @section_ids)
+      editions_matching_supplied_sections = @section_editions.where(:document_id.in => @section_ids)
 
-      order_by_document_ids(editions_matching_supplied_sections).concat(editions_not_matching_supplied_sections.order_by([:created_at, :asc]).to_a)
+      order_by_section_ids(editions_matching_supplied_sections).concat(editions_not_matching_supplied_sections.order_by([:created_at, :asc]).to_a)
     end
 
   private
 
-    def order_by_document_ids(section_editions)
+    def order_by_section_ids(section_editions)
       section_editions.to_a.sort do |a, b|
-        a_index = @document_ids.index(a.document_id)
-        b_index = @document_ids.index(b.document_id)
+        a_index = @section_ids.index(a.document_id)
+        b_index = @section_ids.index(b.document_id)
 
         a_index <=> b_index
       end
@@ -56,7 +56,7 @@ private
   def build_logs_for_all_other_suitable_section_editions
     edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.document_ids)
 
-    edition_ordering.sort_by_document_ids_and_created_at.each do |edition|
+    edition_ordering.sort_by_section_ids_and_created_at.each do |edition|
       PublicationLog.create!(
         title: edition.title,
         slug: edition.slug,

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -18,8 +18,8 @@ class ManualPublicationLogFilter
     end
 
     def sort_by_section_ids_and_created_at
-      editions_not_matching_supplied_sections = @section_editions.where(:document_id.nin => @section_ids)
-      editions_matching_supplied_sections = @section_editions.where(:document_id.in => @section_ids)
+      editions_not_matching_supplied_sections = @section_editions.where(:section_id.nin => @section_ids)
+      editions_matching_supplied_sections = @section_editions.where(:section_id.in => @section_ids)
 
       order_by_section_ids(editions_matching_supplied_sections).concat(editions_not_matching_supplied_sections.order_by([:created_at, :asc]).to_a)
     end
@@ -69,7 +69,7 @@ private
   end
 
   def section_editions_for_first_manual_edition
-    @section_editions_for_first_manual_edition ||= SectionEdition.where(:document_id.in => first_manual_edition.section_ids, :minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
+    @section_editions_for_first_manual_edition ||= SectionEdition.where(:section_id.in => first_manual_edition.section_ids, :minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
   end
 
   def first_manual_edition

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -28,8 +28,8 @@ class ManualPublicationLogFilter
 
     def order_by_section_ids(section_editions)
       section_editions.to_a.sort do |a, b|
-        a_index = @section_ids.index(a.document_id)
-        b_index = @section_ids.index(b.document_id)
+        a_index = @section_ids.index(a.section_id)
+        b_index = @section_ids.index(b.section_id)
 
         a_index <=> b_index
       end
@@ -49,7 +49,7 @@ private
         updated_at: first_manual_edition.updated_at
       )
 
-      section_edition.document_id
+      section_edition.section_id
     end
   end
 

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -37,11 +37,11 @@ private
   end
 
   def old_section_ids
-    @old_section_ids ||= old_manual.editions.flat_map(&:document_ids).uniq
+    @old_section_ids ||= old_manual.editions.flat_map(&:section_ids).uniq
   end
 
   def new_section_ids
-    @new_section_ids ||= new_manual.editions.flat_map(&:document_ids).uniq
+    @new_section_ids ||= new_manual.editions.flat_map(&:section_ids).uniq
   end
 
   def validate_manuals

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -124,7 +124,7 @@ private
   end
 
   def all_editions_of_section(section_id)
-    SectionEdition.where(document_id: section_id).order_by([:version_number, :desc])
+    SectionEdition.where(section_id: section_id).order_by([:version_number, :desc])
   end
 
   def reslug

--- a/lib/marked_section_deleter.rb
+++ b/lib/marked_section_deleter.rb
@@ -22,7 +22,7 @@ class MarkedSectionDeleter
     @logger.puts "The following #{unknown_editions.count} are unknown to Publishing API and are safe to delete:"
     unknown_editions.each do |edition|
       @logger.puts [edition[:slug], edition[:content_id], edition[:state], edition[:created_at]].join(",")
-      SectionEdition.where(document_id: edition[:content_id]).delete_all unless dry_run
+      SectionEdition.where(section_id: edition[:content_id]).delete_all unless dry_run
     end
 
     @logger.puts "The following #{known_editions.count} are known to Publishing API and will be deleted after the draft is discarded:"
@@ -30,7 +30,7 @@ class MarkedSectionDeleter
       @logger.puts [edition[:slug], edition[:content_id], edition[:state], edition[:created_at]].join(",")
       unless dry_run
         publishing_api.discard_draft(edition[:content_id])
-        SectionEdition.where(document_id: edition[:content_id]).delete_all
+        SectionEdition.where(section_id: edition[:content_id]).delete_all
       end
     end
   end

--- a/lib/marked_section_deleter.rb
+++ b/lib/marked_section_deleter.rb
@@ -14,7 +14,7 @@ class MarkedSectionDeleter
 
     @logger.puts "The following #{duplicated_editions.count} editions have been marked as XX for deletion:"
     duplicated_editions.each do |edition|
-      @logger.puts [edition[:slug], edition[:document_id], edition[:state], edition[:created_at]].join(",")
+      @logger.puts [edition[:slug], edition[:section_id], edition[:state], edition[:created_at]].join(",")
     end
 
     known_editions, unknown_editions = duplicated_editions.partition { |edition| in_publishing_api?(edition[:content_id]) }
@@ -53,8 +53,8 @@ class MarkedSectionDeleter
     slug_hash = {}
     marked_editions.all.each do |edition|
       slug_hash[edition.slug] ||= {}
-      slug_hash[edition.slug][edition.document_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.document_id, slug: edition.slug }
-      slug_hash[edition.slug][edition.document_id][:editions] += 1
+      slug_hash[edition.slug][edition.section_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.section_id, slug: edition.slug }
+      slug_hash[edition.slug][edition.section_id][:editions] += 1
     end
 
     slug_hash.values.map(&:values).flatten(1)

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -90,7 +90,7 @@ private
 
   def context_for_section_edition_update
     params_hash = {
-      "id" => current_section_edition.document_id,
+      "id" => current_section_edition.section_id,
       "section" => {
         title: current_section_edition.title,
         summary: current_section_edition.summary,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
   end
 
   factory :section_edition do
-    document_id { BSON::ObjectId.new }
+    section_id { BSON::ObjectId.new }
     sequence(:slug) { |n| "test-section-edition-#{n}" }
     sequence(:title) { |n| "Test Section Edition #{n}" }
     summary "My summary"

--- a/spec/lib/attachment_reporting_spec.rb
+++ b/spec/lib/attachment_reporting_spec.rb
@@ -85,11 +85,11 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
       state: "published",
       version_number: 1,
       section_ids: [
-        early_section_edition_with_pdf.document_id,
-        early_section_edition_with_non_pdf.document_id,
-        early_section_edition_draft_with_pdf.document_id,
-        more_recent_section_edition.document_id,
-        very_recent_section_edition.document_id
+        early_section_edition_with_pdf.section_id,
+        early_section_edition_with_non_pdf.section_id,
+        early_section_edition_draft_with_pdf.section_id,
+        more_recent_section_edition.section_id,
+        very_recent_section_edition.section_id
       ],
     )
   }
@@ -116,7 +116,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
       state: "published",
       version_number: 1,
       section_ids: [
-        very_recent_draft_patent_section_edition.document_id
+        very_recent_draft_patent_section_edition.section_id
       ],
     )
   }

--- a/spec/lib/attachment_reporting_spec.rb
+++ b/spec/lib/attachment_reporting_spec.rb
@@ -84,7 +84,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
     highway_code_manual_record.editions.create!(
       state: "published",
       version_number: 1,
-      document_ids: [
+      section_ids: [
         early_section_edition_with_pdf.document_id,
         early_section_edition_with_non_pdf.document_id,
         early_section_edition_draft_with_pdf.document_id,
@@ -115,7 +115,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
     patent_manual_record.editions.create!(
       state: "published",
       version_number: 1,
-      document_ids: [
+      section_ids: [
         very_recent_draft_patent_section_edition.document_id
       ],
     )

--- a/spec/lib/duplicate_document_finder_spec.rb
+++ b/spec/lib/duplicate_document_finder_spec.rb
@@ -27,8 +27,8 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with the same slug and same section id' do
     before {
-      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
-      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 1)
     }
 
     it "doesn't report them as duplicates" do
@@ -40,18 +40,18 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with the same slug and different section ids' do
     let!(:edition_1) {
-      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 1)
     }
     let!(:edition_2) {
-      FactoryGirl.create(:section_edition, slug: 'slug', document_id: 2)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 2)
     }
 
     it "reports them as duplicates" do
       edition_1_data = [
-        edition_1.slug, edition_1.document_id, edition_1.state, edition_1.created_at, 1
+        edition_1.slug, edition_1.section_id, edition_1.state, edition_1.created_at, 1
       ]
       edition_2_data = [
-        edition_2.slug, edition_2.document_id, edition_2.state, edition_2.created_at, 1
+        edition_2.slug, edition_2.section_id, edition_2.state, edition_2.created_at, 1
       ]
 
       expect(io).to receive(:puts).with(edition_1_data.join(','))

--- a/spec/lib/duplicate_document_finder_spec.rb
+++ b/spec/lib/duplicate_document_finder_spec.rb
@@ -25,7 +25,7 @@ describe DuplicateDocumentFinder do
     end
   end
 
-  context 'when there are multiple editions with the same slug and same document id' do
+  context 'when there are multiple editions with the same slug and same section id' do
     before {
       FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
       FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
@@ -38,7 +38,7 @@ describe DuplicateDocumentFinder do
     end
   end
 
-  context 'when there are multiple editions with the same slug and different document ids' do
+  context 'when there are multiple editions with the same slug and different section ids' do
     let!(:edition_1) {
       FactoryGirl.create(:section_edition, slug: 'slug', document_id: 1)
     }

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -9,7 +9,7 @@ describe DuplicateDraftDeleter do
     original_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
-      document_id: original_content_id,
+      section_id: original_content_id,
       state: "draft",
     )
     publishing_api_has_item(content_id: original_content_id)
@@ -17,12 +17,12 @@ describe DuplicateDraftDeleter do
     duplicate_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
-      document_id: duplicate_content_id,
+      section_id: duplicate_content_id,
       state: "draft",
     )
     FactoryGirl.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
-      document_id: duplicate_content_id,
+      section_id: duplicate_content_id,
       state: "archived",
     )
     publishing_api_does_not_have_item(duplicate_content_id)
@@ -37,12 +37,12 @@ describe DuplicateDraftDeleter do
   it "leaves non-duplicated editions alone" do
     content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
-     document_id: content_id,
+     section_id: content_id,
     )
 
     another_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
-      document_id: another_content_id,
+      section_id: another_content_id,
     )
 
     expect { DuplicateDraftDeleter.new.call }.to output.to_stdout

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -30,8 +30,8 @@ describe DuplicateDraftDeleter do
     expected_output = /The following 2 editions are unknown to Publishing API and will be deleted:.*#{duplicate_content_id}/m
     expect { DuplicateDraftDeleter.new.call }.to output(expected_output).to_stdout
 
-    expect(SectionEdition.where(document_id: original_content_id)).to be_present
-    expect(SectionEdition.where(document_id: duplicate_content_id)).to be_empty
+    expect(SectionEdition.where(section_id: original_content_id)).to be_present
+    expect(SectionEdition.where(section_id: duplicate_content_id)).to be_empty
   end
 
   it "leaves non-duplicated editions alone" do
@@ -47,7 +47,7 @@ describe DuplicateDraftDeleter do
 
     expect { DuplicateDraftDeleter.new.call }.to output.to_stdout
 
-    expect(SectionEdition.where(document_id: content_id)).to be_present
-    expect(SectionEdition.where(document_id: another_content_id)).to be_present
+    expect(SectionEdition.where(section_id: content_id)).to be_present
+    expect(SectionEdition.where(section_id: another_content_id)).to be_present
   end
 end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -97,7 +97,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     manual_record.editions.create!(
       state: "published",
       version_number: 1,
-      document_ids: [
+      section_ids: [
         section_a_edition_published_version_1_major_update.document_id,
         section_b_edition_published_version_1_major_update.document_id,
         section_c_edition_archived_version_1_major_update.document_id,
@@ -111,7 +111,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     manual_record.editions.create!(
       state: "published",
       version_number: 2,
-      document_ids: [
+      section_ids: [
         section_a_edition_published_version_2_major_update.document_id,
         section_b_edition_published_version_2_minor_update.document_id,
         section_c_edition_archived_version_1_major_update.document_id,

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -22,7 +22,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       :section_edition,
       state: "published",
       slug: section_a_edition_published_version_1_major_update.slug,
-      document_id: section_a_edition_published_version_1_major_update.document_id,
+      section_id: section_a_edition_published_version_1_major_update.section_id,
       exported_at: section_edition_exported_time,
       version_number: 2
     )
@@ -43,7 +43,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       :section_edition,
       state: "published",
       slug: section_b_edition_published_version_1_major_update.slug,
-      document_id: section_b_edition_published_version_1_major_update.document_id,
+      section_id: section_b_edition_published_version_1_major_update.section_id,
       exported_at: section_edition_exported_time,
       minor_update: true,
       version_number: 2
@@ -98,9 +98,9 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       state: "published",
       version_number: 1,
       section_ids: [
-        section_a_edition_published_version_1_major_update.document_id,
-        section_b_edition_published_version_1_major_update.document_id,
-        section_c_edition_archived_version_1_major_update.document_id,
+        section_a_edition_published_version_1_major_update.section_id,
+        section_b_edition_published_version_1_major_update.section_id,
+        section_c_edition_archived_version_1_major_update.section_id,
       ],
       created_at: first_manual_edition_creation_time,
       updated_at: first_manual_edition_creation_time
@@ -112,11 +112,11 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       state: "published",
       version_number: 2,
       section_ids: [
-        section_a_edition_published_version_2_major_update.document_id,
-        section_b_edition_published_version_2_minor_update.document_id,
-        section_c_edition_archived_version_1_major_update.document_id,
-        section_d_edition_draft_version_1_major_update.document_id,
-        section_e_edition_published_version_1_major_update.document_id
+        section_a_edition_published_version_2_major_update.section_id,
+        section_b_edition_published_version_2_minor_update.section_id,
+        section_c_edition_archived_version_1_major_update.section_id,
+        section_d_edition_draft_version_1_major_update.section_id,
+        section_e_edition_published_version_1_major_update.section_id
       ],
       created_at: second_manual_edition_creation_time,
       updated_at: first_manual_edition_creation_time
@@ -197,14 +197,14 @@ describe ManualPublicationLogFilter::EditionOrdering do
 
     let!(:section_ids) {
       [
-        edition_in_first_position.document_id,
-        edition_in_second_position.document_id,
-        edition_in_third_position.document_id,
+        edition_in_first_position.section_id,
+        edition_in_second_position.section_id,
+        edition_in_third_position.section_id,
       ]
     }
 
     let(:expected_section_order) {
-      section_ids.concat([other_edition_older.document_id, other_edition_newer.document_id])
+      section_ids.concat([other_edition_older.section_id, other_edition_newer.section_id])
     }
 
     let(:subject) { described_class.new(SectionEdition.all, section_ids) }
@@ -212,7 +212,7 @@ describe ManualPublicationLogFilter::EditionOrdering do
     it "returns editions in the supplied section id and created_at order" do
       ordered_editions = subject.sort_by_section_ids_and_created_at
 
-      expect(ordered_editions.map(&:document_id)).to eq expected_section_order
+      expect(ordered_editions.map(&:section_id)).to eq expected_section_order
     end
   end
 end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -187,7 +187,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
 end
 
 describe ManualPublicationLogFilter::EditionOrdering do
-  describe ".sort_by_document_ids_and_created_at" do
+  describe ".sort_by_section_ids_and_created_at" do
     let!(:edition_in_third_position) { FactoryGirl.create :section_edition }
     let!(:edition_in_first_position) { FactoryGirl.create :section_edition }
     let!(:edition_in_second_position) { FactoryGirl.create :section_edition }
@@ -195,7 +195,7 @@ describe ManualPublicationLogFilter::EditionOrdering do
     let!(:other_edition_newer) { FactoryGirl.create :section_edition, created_at: Time.now - 1.day }
     let!(:other_edition_older) { FactoryGirl.create :section_edition, created_at: Time.now - 1.week }
 
-    let!(:document_ids) {
+    let!(:section_ids) {
       [
         edition_in_first_position.document_id,
         edition_in_second_position.document_id,
@@ -204,13 +204,13 @@ describe ManualPublicationLogFilter::EditionOrdering do
     }
 
     let(:expected_section_order) {
-      document_ids.concat([other_edition_older.document_id, other_edition_newer.document_id])
+      section_ids.concat([other_edition_older.document_id, other_edition_newer.document_id])
     }
 
-    let(:subject) { described_class.new(SectionEdition.all, document_ids) }
+    let(:subject) { described_class.new(SectionEdition.all, section_ids) }
 
-    it "returns editions in the supplied document id and created_at order" do
-      ordered_editions = subject.sort_by_document_ids_and_created_at
+    it "returns editions in the supplied section id and created_at order" do
+      ordered_editions = subject.sort_by_section_ids_and_created_at
 
       expect(ordered_editions.map(&:document_id)).to eq expected_section_order
     end

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -66,7 +66,7 @@ describe ManualRelocator do
 
     context "validating manuals can be relocated" do
       it "raises an error if the existing manual has never been published" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "draft")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "draft")
 
         expect {
           subject.move!
@@ -74,8 +74,8 @@ describe ManualRelocator do
       end
 
       it "raises an error if the existing manual has been published, but is currently withdrawn" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 2, state: "withdrawn")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 2, state: "withdrawn")
 
         expect {
           subject.move!
@@ -83,8 +83,8 @@ describe ManualRelocator do
       end
 
       it "raises an error if the temporary manual has never been published" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "draft")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "draft")
 
         expect {
           subject.move!
@@ -92,9 +92,9 @@ describe ManualRelocator do
       end
 
       it "raises an error if the temporary manual has been published, but is currently withdrawn" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "withdrawn")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "withdrawn")
 
         expect {
           subject.move!
@@ -102,8 +102,8 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the existing manual is currently published" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
 
         expect {
           subject.move!
@@ -111,10 +111,10 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the existing manual is currently published, regardless of the previous edition state" do
-        previous_edition = ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "withdrawn")
+        previous_edition = ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "withdrawn")
         existing_manual.editions << previous_edition
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 2, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 2, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
 
         expect {
           subject.move!
@@ -132,9 +132,9 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the existing manual has previously been published, but is currently draft" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 2, state: "draft")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 2, state: "draft")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
 
         expect {
           subject.move!
@@ -142,8 +142,8 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the temp manual is currently published" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
 
         expect {
           subject.move!
@@ -151,10 +151,10 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the temp manual is currently published, regardless of the previous edition state" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        previous_edition = ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "withdrawn")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        previous_edition = ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "withdrawn")
         temp_manual.editions << previous_edition
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
 
         expect {
           subject.move!
@@ -172,9 +172,9 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the temp manual has previously been published, but is currently draft" do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "draft")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "draft")
 
         expect {
           subject.move!
@@ -184,7 +184,7 @@ describe ManualRelocator do
 
     context "with valid manuals" do
       before do
-        existing_manual.editions << ManualRecord::Edition.new(document_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
       end
 
       shared_examples_for "removing the existing manual" do
@@ -265,7 +265,7 @@ describe ManualRelocator do
 
       context "when the temp manual has no draft" do
         before do
-          temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+          temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
           subject.move!
         end
 
@@ -333,8 +333,8 @@ describe ManualRelocator do
         let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
 
         before do
-          temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
-          temp_manual.editions << ManualRecord::Edition.new(document_ids: %w(abcdef bcdefg cdefgh), state: "draft", version_number: 2, body: "This is in draft")
+          temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
+          temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), state: "draft", version_number: 2, body: "This is in draft")
           subject.move!
         end
 

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -45,13 +45,13 @@ describe ManualRelocator do
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }
-    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", document_id: "12345", version_number: 1, state: "published") }
-    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", document_id: "23456", version_number: 1, state: "published") }
-    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", document_id: "abcdef", version_number: 1, state: "published") }
-    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg", version_number: 1, state: "published") }
+    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_id: "12345", version_number: 1, state: "published") }
+    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_id: "23456", version_number: 1, state: "published") }
+    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_id: "abcdef", version_number: 1, state: "published") }
+    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_id: "bcdefg", version_number: 1, state: "published") }
 
-    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", document_id: "34567", version_number: 1, state: "published") }
-    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", document_id: "cdefgh", version_number: 1, state: "published") }
+    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", section_id: "34567", version_number: 1, state: "published") }
+    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", section_id: "cdefgh", version_number: 1, state: "published") }
 
     let!(:existing_publication_log) { FactoryGirl.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
     let!(:temporary_publication_log) { FactoryGirl.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }
@@ -214,12 +214,12 @@ describe ManualRelocator do
         end
 
         it "unpublishes the existing manual's sections with redirects to the existing slug" do
-          assert_publishing_api_unpublish(existing_section_1.document_id,
+          assert_publishing_api_unpublish(existing_section_1.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(existing_section_2.document_id,
+          assert_publishing_api_unpublish(existing_section_2.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}",
                                           discard_drafts: true)
@@ -228,7 +228,7 @@ describe ManualRelocator do
         it "issues a gone for existing manual's sections that would be reused one of the new manual's sections" do
           gone_object = {
             base_path: "/#{existing_section_3.slug}",
-            content_id: existing_section_3.document_id,
+            content_id: existing_section_3.section_id,
             document_type: "gone",
             publishing_app: "manuals-publisher",
             schema_name: "gone",
@@ -240,8 +240,8 @@ describe ManualRelocator do
             ]
           }
 
-          assert_publishing_api_put_content(existing_section_3.document_id, request_json_matches(gone_object))
-          assert_publishing_api_publish(existing_section_3.document_id)
+          assert_publishing_api_put_content(existing_section_3.section_id, request_json_matches(gone_object))
+          assert_publishing_api_publish(existing_section_3.section_id)
         end
 
         it "destroys the existing manual's sections" do
@@ -291,17 +291,17 @@ describe ManualRelocator do
         end
 
         it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
-          assert_publishing_api_unpublish(temporary_section_1.document_id,
+          assert_publishing_api_unpublish(temporary_section_1.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_1",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_2.document_id,
+          assert_publishing_api_unpublish(temporary_section_2.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_2",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_3.document_id,
+          assert_publishing_api_unpublish(temporary_section_3.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/section_3",
                                           discard_drafts: true)
@@ -316,21 +316,21 @@ describe ManualRelocator do
         end
 
         it "sends a new draft of each of the temporary manual's sections with the existing slug version of their path as a route" do
-          assert_publishing_api_put_content(temporary_section_1.document_id, with_route_matcher("/#{existing_slug}/temp_section_1"))
-          assert_publishing_api_put_content(temporary_section_2.document_id, with_route_matcher("/#{existing_slug}/temp_section_2"))
-          assert_publishing_api_put_content(temporary_section_3.document_id, with_route_matcher("/#{existing_slug}/section_3"))
+          assert_publishing_api_put_content(temporary_section_1.section_id, with_route_matcher("/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.section_id, with_route_matcher("/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_3.section_id, with_route_matcher("/#{existing_slug}/section_3"))
         end
 
         it "sends a publish request for each of the temporary manual's sections" do
-          assert_publishing_api_publish(temporary_section_1.document_id)
-          assert_publishing_api_publish(temporary_section_2.document_id)
-          assert_publishing_api_publish(temporary_section_3.document_id)
+          assert_publishing_api_publish(temporary_section_1.section_id)
+          assert_publishing_api_publish(temporary_section_2.section_id)
+          assert_publishing_api_publish(temporary_section_3.section_id)
         end
       end
 
       context "when the temp manual has a draft" do
-        let!(:temporary_section_1_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", document_id: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
-        let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", document_id: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
+        let!(:temporary_section_1_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_id: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
+        let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_id: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
 
         before do
           temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
@@ -360,17 +360,17 @@ describe ManualRelocator do
         end
 
         it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
-          assert_publishing_api_unpublish(temporary_section_1.document_id,
+          assert_publishing_api_unpublish(temporary_section_1.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_1",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_2.document_id,
+          assert_publishing_api_unpublish(temporary_section_2.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_2",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_3.document_id,
+          assert_publishing_api_unpublish(temporary_section_3.section_id,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/section_3",
                                           discard_drafts: true)
@@ -389,23 +389,23 @@ describe ManualRelocator do
         end
 
         it "sends a draft of each of the temporary manual's published sections with the existing slug version of their path as a route" do
-          assert_publishing_api_put_content(temporary_section_1.document_id, with_body_and_route_matcher(temporary_section_1.body, "/#{existing_slug}/temp_section_1"))
-          assert_publishing_api_put_content(temporary_section_2.document_id, with_body_and_route_matcher(temporary_section_2.body, "/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_1.section_id, with_body_and_route_matcher(temporary_section_1.body, "/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.section_id, with_body_and_route_matcher(temporary_section_2.body, "/#{existing_slug}/temp_section_2"))
         end
 
         it "sends a publish request for each of the temporary manual's published sections" do
-          assert_publishing_api_publish(temporary_section_1.document_id)
-          assert_publishing_api_publish(temporary_section_2.document_id)
+          assert_publishing_api_publish(temporary_section_1.section_id)
+          assert_publishing_api_publish(temporary_section_2.section_id)
         end
 
         it "does not send a publish request for any section only present in the new draft" do
-          assert_publishing_api_publish(temporary_section_3.document_id, nil, 0)
+          assert_publishing_api_publish(temporary_section_3.section_id, nil, 0)
         end
 
         it "sends a draft of each of the temporary manual's draft sections with the existing slug version of their path as a route" do
-          assert_publishing_api_put_content(temporary_section_1.document_id, with_body_and_route_matcher(temporary_section_1_v2.body, "/#{existing_slug}/temp_section_1"))
-          assert_publishing_api_put_content(temporary_section_2.document_id, with_body_and_route_matcher(temporary_section_2_v2.body, "/#{existing_slug}/temp_section_2"))
-          assert_publishing_api_put_content(temporary_section_3.document_id, with_body_and_route_matcher(temporary_section_3.body, "/#{existing_slug}/section_3"))
+          assert_publishing_api_put_content(temporary_section_1.section_id, with_body_and_route_matcher(temporary_section_1_v2.body, "/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.section_id, with_body_and_route_matcher(temporary_section_2_v2.body, "/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_3.section_id, with_body_and_route_matcher(temporary_section_3.body, "/#{existing_slug}/section_3"))
         end
       end
     end

--- a/spec/lib/marked_section_deleter_spec.rb
+++ b/spec/lib/marked_section_deleter_spec.rb
@@ -20,7 +20,7 @@ describe MarkedSectionDeleter do
     before {
       allow(publishing_api).
         to receive(:get_content).
-        with(edition.document_id).
+        with(edition.section_id).
         and_raise(GdsApi::HTTPNotFound.new(nil))
     }
 
@@ -39,11 +39,11 @@ describe MarkedSectionDeleter do
     before {
       allow(publishing_api).
         to receive(:get_content).
-        with(edition.document_id).
+        with(edition.section_id).
         and_return(double(:gds_api_response))
       allow(publishing_api).
         to receive(:discard_draft).
-        with(edition.document_id)
+        with(edition.section_id)
     }
 
     it "deletes the edition" do
@@ -55,7 +55,7 @@ describe MarkedSectionDeleter do
     it 'discards the draft from the publishing api' do
       expect(publishing_api).
         to receive(:discard_draft).
-        with(edition.document_id)
+        with(edition.section_id)
 
       subject.execute(dry_run: false)
     end

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -31,7 +31,7 @@ describe SectionReslugger do
       body: 'section-edition-body'
     )
     manual_record.editions.create!(
-      document_ids: [
+      section_ids: [
         'document-id'
       ]
     )

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -24,7 +24,7 @@ describe SectionReslugger do
       organisation_slug: 'organisation-slug'
     )
     SectionEdition.create!(
-      document_id: 'document-id',
+      section_id: 'section-id',
       slug: 'manual-slug/current-section-slug',
       title: 'section-edition-title',
       summary: 'section-edition-summary',
@@ -32,7 +32,7 @@ describe SectionReslugger do
     )
     manual_record.editions.create!(
       section_ids: [
-        'document-id'
+        'section-id'
       ]
     )
 

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -250,7 +250,7 @@ describe Section do
         expect(edition_factory).to have_received(:call).with(
           version_number: 1,
           state: "draft",
-          document_id: section_id,
+          section_id: section_id,
         )
       end
     end

--- a/spec/repositories/marshallers/section_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/section_association_marshaller_spec.rb
@@ -19,8 +19,8 @@ describe SectionAssociationMarshaller do
   let(:record) {
     double(
       :record,
-      document_ids: section_ids,
-      "document_ids=": nil,
+      section_ids: section_ids,
+      "section_ids=": nil,
       removed_section_ids: removed_section_ids,
       "removed_section_ids=": nil,
     )
@@ -91,7 +91,7 @@ describe SectionAssociationMarshaller do
     it "updates associated document ids on the record" do
       marshaller.dump(manual, record)
 
-      expect(record).to have_received(:document_ids=).with(section_ids)
+      expect(record).to have_received(:section_ids=).with(section_ids)
     end
 
     it "updates associated removed document ids on the record" do

--- a/spec/repositories/marshallers/section_association_marshaller_spec.rb
+++ b/spec/repositories/marshallers/section_association_marshaller_spec.rb
@@ -21,8 +21,8 @@ describe SectionAssociationMarshaller do
       :record,
       document_ids: section_ids,
       "document_ids=": nil,
-      removed_document_ids: removed_section_ids,
-      "removed_document_ids=": nil,
+      removed_section_ids: removed_section_ids,
+      "removed_section_ids=": nil,
     )
   }
 
@@ -97,7 +97,7 @@ describe SectionAssociationMarshaller do
     it "updates associated removed document ids on the record" do
       marshaller.dump(manual, record)
 
-      expect(record).to have_received(:removed_document_ids=).
+      expect(record).to have_received(:removed_section_ids=).
         with(removed_section_ids)
     end
 

--- a/spec/repositories/section_repository_spec.rb
+++ b/spec/repositories/section_repository_spec.rb
@@ -25,7 +25,7 @@ describe SectionRepository do
       :new_draft_edition,
       title: "Example section about oil reserves",
       slug: "example-section-about-oil-reserves",
-      "document_id=": nil,
+      "section_id=": nil,
       "slug=": nil,
       changed?: true,
       save!: true,
@@ -42,7 +42,7 @@ describe SectionRepository do
     double(
       :published_edition,
       title: "Example section about oil reserves #{version}",
-      "document_id=": nil,
+      "section_id=": nil,
       changed?: false,
       save!: nil,
       archive: nil,
@@ -68,7 +68,7 @@ describe SectionRepository do
         section_id = "section-id-#{n}"
 
         edition = FactoryGirl.create(:section_edition,
-                                     document_id: section_id,
+                                     section_id: section_id,
                                      updated_at: n.days.ago)
 
         allow(section_factory).to receive(:call)

--- a/spec/repositories/versioned_manual_repository_spec.rb
+++ b/spec/repositories/versioned_manual_repository_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe VersionedManualRepository do
   context "when the provided id refers to the first draft of a manual" do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-    let(:manual_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "draft") }
+    let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "draft") }
     let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "draft") }
     let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "draft") }
     before do
@@ -62,7 +62,7 @@ RSpec.describe VersionedManualRepository do
   context "when the provided id refers to manual that has been published once" do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-    let(:manual_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "published") }
+    let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "published") }
     let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
     let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
     before do
@@ -112,7 +112,7 @@ RSpec.describe VersionedManualRepository do
   context "when the provided id refers to manual that has been withdrawn once" do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-    let(:manual_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "withdrawn") }
+    let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "withdrawn") }
     let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "archived") }
     let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "archived") }
     before do
@@ -139,8 +139,8 @@ RSpec.describe VersionedManualRepository do
   context "when the provided id refers to manual that has been published once and has a new draft waiting" do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-    let(:manual_published_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 1, state: "published") }
-    let(:manual_draft_edition) { ManualRecord::Edition.new(document_ids: %w(12345 67890), version_number: 2, state: "draft") }
+    let(:manual_published_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "published") }
+    let(:manual_draft_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 2, state: "draft") }
     before do
       manual.editions << manual_published_edition
       manual.editions << manual_draft_edition

--- a/spec/repositories/versioned_manual_repository_spec.rb
+++ b/spec/repositories/versioned_manual_repository_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe VersionedManualRepository do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
     let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "draft") }
-    let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "draft") }
-    let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "draft") }
+    let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 1, state: "draft") }
+    let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 1, state: "draft") }
     before do
       manual.editions << manual_edition
     end
@@ -63,8 +63,8 @@ RSpec.describe VersionedManualRepository do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
     let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "published") }
-    let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
-    let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
+    let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
+    let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
     before do
       manual.editions << manual_edition
     end
@@ -113,8 +113,8 @@ RSpec.describe VersionedManualRepository do
     let(:manual_id) { SecureRandom.uuid }
     let(:manual) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
     let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "withdrawn") }
-    let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "archived") }
-    let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "archived") }
+    let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 1, state: "archived") }
+    let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 1, state: "archived") }
     before do
       manual.editions << manual_edition
     end
@@ -147,10 +147,10 @@ RSpec.describe VersionedManualRepository do
     end
 
     context "including new drafts of all sections" do
-      let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
-      let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
-      let!(:section_1_draft) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 2, state: "draft") }
-      let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 2, state: "draft") }
+      let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
+      let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
+      let!(:section_1_draft) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 2, state: "draft") }
+      let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 2, state: "draft") }
 
       context "the published version returned" do
         subject { repository.get_manual(manual_id)[:published] }
@@ -216,8 +216,8 @@ RSpec.describe VersionedManualRepository do
     end
 
     context "without new drafts of any sections" do
-      let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
-      let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
+      let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
+      let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
 
       context "the published version returned" do
         subject { repository.get_manual(manual_id)[:published] }
@@ -283,9 +283,9 @@ RSpec.describe VersionedManualRepository do
     end
 
     context "including new drafts of some sections" do
-      let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", document_id: "12345", version_number: 1, state: "published") }
-      let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 1, state: "published") }
-      let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", document_id: "67890", version_number: 2, state: "draft") }
+      let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
+      let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
+      let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual.slug}/section-2", section_id: "67890", version_number: 2, state: "draft") }
 
       context "the published version returned" do
         subject { repository.get_manual(manual_id)[:published] }


### PR DESCRIPTION
This PR continues the renaming theme from #914 & #919.

The first 4 commits fix some things that were missed in those PRs.

The next 3 commits alias the relevant Mongoid fields to the new name (using the `as` option) which has the effect of renaming the accessor-like methods. Calls to those methods are renamed within the same commit.

The last 3 commits remove the field aliases and rename the underlying fields in Mongo for all the existing records. Use of the underlying field names (e.g. in queries) are renamed within the same commit.

The tests all pass after each commit.