### PR TITLE
Add repository marshallers to load path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module ManualsPublisher
     # app/models) so they need to be added to the autoload_paths
     config.autoload_paths << "#{Rails.root}/app/models/builders"
     config.autoload_paths << "#{Rails.root}/app/models/validators"
+    config.autoload_paths << "#{Rails.root}/app/repositories/marshallers"
   end
 end


### PR DESCRIPTION
This avoids some exceptions which were happening in development.