### PR TITLE
Rename record arg -> edition for *Marshaller#load & #dump

### DIFF
--- a/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
+++ b/app/repositories/marshallers/manual_publish_task_association_marshaller.rb
@@ -1,11 +1,11 @@
 class ManualPublishTaskAssociationMarshaller
-  def load(manual, _record)
+  def load(manual, _edition)
     tasks = ManualPublishTask.for_manual(manual)
 
     ManualWithPublishTasks.new(manual, publish_tasks: tasks)
   end
 
-  def dump(_manual, _record)
+  def dump(_manual, _edition)
     # PublishTasks are read only
     nil
   end

--- a/app/repositories/marshallers/section_association_marshaller.rb
+++ b/app/repositories/marshallers/section_association_marshaller.rb
@@ -13,14 +13,14 @@ class SectionAssociationMarshaller
     end
   end
 
-  def load(manual, record)
+  def load(manual, edition)
     section_repository = SectionRepository.new(manual: manual)
 
-    sections = Array(record.section_ids).map { |section_id|
+    sections = Array(edition.section_ids).map { |section_id|
       section_repository.fetch(section_id)
     }
 
-    removed_sections = Array(record.removed_section_ids).map { |section_id|
+    removed_sections = Array(edition.removed_section_ids).map { |section_id|
       begin
         section_repository.fetch(section_id)
       rescue KeyError
@@ -31,7 +31,7 @@ class SectionAssociationMarshaller
     Decorator.new.call(manual, sections: sections, removed_sections: removed_sections)
   end
 
-  def dump(manual, record)
+  def dump(manual, edition)
     section_repository = SectionRepository.new(manual: manual)
 
     manual.sections.each do |section|
@@ -42,8 +42,8 @@ class SectionAssociationMarshaller
       section_repository.store(section)
     end
 
-    record.section_ids = manual.sections.map(&:id)
-    record.removed_section_ids = manual.removed_sections.map(&:id)
+    edition.section_ids = manual.sections.map(&:id)
+    edition.removed_section_ids = manual.removed_sections.map(&:id)
 
     nil
   end


### PR DESCRIPTION
As far as I can tell, these methods are only being called from `ManualRepository#store` and `ManualRepository#build_manual_for`. In both of those cases, the 2nd argument is an instance of a `ManualRecord::Edition` and not a `ManualRecord` as the name "record" seems to imply.

Using the name "edition" is less confusing.
