### PR TITLE
Extract User#manual_records to DRY up controller methods

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -228,23 +228,11 @@ private
   end
 
   def repository
-    if current_user_is_gds_editor?
-      ScopedManualRepository.new(ManualRecord.all)
-    else
-      ScopedManualRepository.new(
-        ManualRecord.where(organisation_slug: current_organisation_slug)
-      )
-    end
+    ScopedManualRepository.new(current_user.manual_records)
   end
 
   def associationless_repository
-    if current_user_is_gds_editor?
-      ManualRepository.new(collection: ManualRecord.all)
-    else
-      ManualRepository.new(
-        collection: ManualRecord.where(organisation_slug: current_organisation_slug)
-      )
-    end
+    ManualRepository.new(collection: current_user.manual_records)
   end
 
   def authorize_user_for_publishing

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -65,20 +65,6 @@ class SectionAttachmentsController < ApplicationController
 private
 
   def repository
-    if current_user_is_gds_editor?
-      gds_editor_repository
-    else
-      organisational_repository
-    end
-  end
-
-  def gds_editor_repository
-    ScopedManualRepository.new(ManualRecord.all)
-  end
-
-  def organisational_repository
-    ScopedManualRepository.new(
-      ManualRecord.where(organisation_slug: current_organisation_slug)
-    )
+    ScopedManualRepository.new(current_user.manual_records)
   end
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -175,13 +175,7 @@ class SectionsController < ApplicationController
 private
 
   def manual_repository
-    if current_user_is_gds_editor?
-      ScopedManualRepository.new(ManualRecord.all)
-    else
-      ScopedManualRepository.new(
-        ManualRecord.where(organisation_slug: current_organisation_slug)
-      )
-    end
+    ScopedManualRepository.new(current_user.manual_records)
   end
 
   def authorize_user_for_withdrawing

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,13 @@ class User
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :name, :uid
   attr_accessible :email, :name, :uid, :permissions, as: :oauth
+
+  def manual_records
+    permission_checker = PermissionChecker.new(self)
+    if permission_checker.is_gds_editor?
+      ManualRecord.all
+    else
+      ManualRecord.where(organisation_slug: organisation_slug)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,4 +3,31 @@ require 'gds-sso/lint/user_spec'
 
 describe User, type: :model do
   it_behaves_like "a gds-sso user class"
+
+  describe '#manual_records' do
+    let(:permission_checker) { double(:permission_checker) }
+
+    before do
+      allow(PermissionChecker).to receive(:new).and_return(permission_checker)
+      allow(permission_checker).to receive(:is_gds_editor?).and_return(is_gds_editor)
+      allow(ManualRecord).to receive(:all).and_return(:all_manual_records)
+      allow(ManualRecord).to receive(:where).with(organisation_slug: subject.organisation_slug).and_return(:manual_records_for_organisation)
+    end
+
+    context 'when user is a GDS editor' do
+      let(:is_gds_editor) { true }
+
+      it 'returns all manual records' do
+        expect(subject.manual_records).to eq(:all_manual_records)
+      end
+    end
+
+    context 'when user is not a GDS editor' do
+      let(:is_gds_editor) { false }
+
+      it "returns only the manual records for the user's organisation" do
+        expect(subject.manual_records).to eq(:manual_records_for_organisation)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The logic for scoping the manual records to be used by the various repositories was repeated in each of the three controllers.

I paired with @chrislo on this change which extracts the duplicate logic into `User#manual_records`. While `User#manual_records` may not be the best long-term home for this logic, we think it's definitely an improvement. On a similar note, it's not ideal that we're using the `PermissionChecker` inside `User#manual`, but we think it'll do for now.

One benefit of this change is that we've been able to write a unit test for the extracted logic.