### PR TITLE
Use methods on Manual vs manual repositories classes from ManualsController services

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -11,7 +11,6 @@ class ManualsController < ApplicationController
 
   def index
     service = ListManualsService.new(
-      manual_repository: associationless_repository,
       context: self,
     )
     all_manuals = service.call

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -50,6 +50,7 @@ class ManualsController < ApplicationController
       manual_repository: repository,
       manual_builder: ManualBuilder.create,
       attributes: create_manual_params,
+      context: self,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -120,7 +120,6 @@ class ManualsController < ApplicationController
 
   def publish
     service = QueuePublishManualService.new(
-      repository: repository,
       manual_id: manual_id,
       context: self,
     )

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -138,6 +138,7 @@ class ManualsController < ApplicationController
       renderer: ManualRenderer.new,
       manual_id: params[:id],
       attributes: update_manual_params,
+      context: self,
     )
     manual = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -47,7 +47,6 @@ class ManualsController < ApplicationController
 
   def create
     service = CreateManualService.new(
-      manual_repository: repository,
       manual_builder: ManualBuilder.create,
       attributes: create_manual_params,
       context: self,

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -230,10 +230,6 @@ private
     ScopedManualRepository.new(current_user.manual_records)
   end
 
-  def associationless_repository
-    ManualRepository.new(collection: current_user.manual_records)
-  end
-
   def authorize_user_for_publishing
     unless current_user_can_publish?
       redirect_to(

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -105,6 +105,7 @@ class ManualsController < ApplicationController
       manual_repository: repository,
       manual_id: manual_id,
       attributes: publication_date_manual_params,
+      context: self,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -120,8 +120,8 @@ class ManualsController < ApplicationController
 
   def publish
     service = QueuePublishManualService.new(
-      repository,
-      manual_id,
+      repository: repository,
+      manual_id: manual_id,
     )
     manual = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -122,6 +122,7 @@ class ManualsController < ApplicationController
     service = QueuePublishManualService.new(
       repository: repository,
       manual_id: manual_id,
+      context: self,
     )
     manual = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -23,9 +23,9 @@ class ManualsController < ApplicationController
       manual_id: manual_id,
       context: self,
     )
-    manual, metadata = service.call
-    slug_unique = metadata.fetch(:slug_unique)
-    clashing_sections = metadata.fetch(:clashing_sections)
+    manual = service.call
+    slug_unique = manual.slug_unique?(current_user)
+    clashing_sections = manual.clashing_sections
 
     unless slug_unique
       flash.now[:error] = "Warning: This manual's URL is already used on GOV.UK. You can't publish it until you change the title."
@@ -68,7 +68,7 @@ class ManualsController < ApplicationController
       manual_id: manual_id,
       context: self,
     )
-    manual, _metadata = service.call
+    manual = service.call
 
     render(:edit, locals: { manual: manual_form(manual) })
   end
@@ -96,7 +96,7 @@ class ManualsController < ApplicationController
       manual_id: manual_id,
       context: self,
     )
-    manual, _metadata = service.call
+    manual = service.call
 
     render(:edit_original_publication_date, locals: { manual: manual_form(manual) })
   end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -22,6 +22,7 @@ class ManualsController < ApplicationController
     service = ShowManualService.new(
       manual_repository: repository,
       manual_id: manual_id,
+      context: self,
     )
     manual, metadata = service.call
     slug_unique = metadata.fetch(:slug_unique)
@@ -67,6 +68,7 @@ class ManualsController < ApplicationController
     service = ShowManualService.new(
       manual_repository: repository,
       manual_id: manual_id,
+      context: self,
     )
     manual, _metadata = service.call
 
@@ -95,6 +97,7 @@ class ManualsController < ApplicationController
     service = ShowManualService.new(
       manual_repository: repository,
       manual_id: manual_id,
+      context: self,
     )
     manual, _metadata = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -133,7 +133,6 @@ class ManualsController < ApplicationController
 
   def preview
     service = PreviewManualService.new(
-      repository: repository,
       builder: ManualBuilder.create,
       renderer: ManualRenderer.new,
       manual_id: params[:id],

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -74,7 +74,6 @@ class ManualsController < ApplicationController
 
   def update
     service = UpdateManualService.new(
-      manual_repository: repository,
       manual_id: manual_id,
       attributes: update_manual_params,
       context: self,

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -224,10 +224,6 @@ private
     ManualViewAdapter.new(manual)
   end
 
-  def repository
-    ScopedManualRepository.new(current_user.manual_records)
-  end
-
   def authorize_user_for_publishing
     unless current_user_can_publish?
       redirect_to(

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -47,7 +47,6 @@ class ManualsController < ApplicationController
 
   def create
     service = CreateManualService.new(
-      manual_builder: ManualBuilder.create,
       attributes: create_manual_params,
       context: self,
     )

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -102,7 +102,6 @@ class ManualsController < ApplicationController
 
   def update_original_publication_date
     service = UpdateManualOriginalPublicationDateService.new(
-      manual_repository: repository,
       manual_id: manual_id,
       attributes: publication_date_manual_params,
       context: self,

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -77,6 +77,7 @@ class ManualsController < ApplicationController
       manual_repository: repository,
       manual_id: manual_id,
       attributes: update_manual_params,
+      context: self,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -133,7 +133,6 @@ class ManualsController < ApplicationController
 
   def preview
     service = PreviewManualService.new(
-      builder: ManualBuilder.create,
       renderer: ManualRenderer.new,
       manual_id: params[:id],
       attributes: update_manual_params,

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -20,7 +20,6 @@ class ManualsController < ApplicationController
 
   def show
     service = ShowManualService.new(
-      manual_repository: repository,
       manual_id: manual_id,
       context: self,
     )
@@ -66,7 +65,6 @@ class ManualsController < ApplicationController
 
   def edit
     service = ShowManualService.new(
-      manual_repository: repository,
       manual_id: manual_id,
       context: self,
     )
@@ -95,7 +93,6 @@ class ManualsController < ApplicationController
 
   def edit_original_publication_date
     service = ShowManualService.new(
-      manual_repository: repository,
       manual_id: manual_id,
       context: self,
     )

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -29,6 +29,10 @@ class Manual
     ManualRepository.new(collection: user.manual_records).all
   end
 
+  def self.build(attributes)
+    ManualBuilder.create.call(attributes)
+  end
+
   def slug_unique?(user)
     ScopedManualRepository.new(user.manual_records).slug_unique?(self)
   end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -33,6 +33,12 @@ class Manual
     ScopedManualRepository.new(user.manual_records).slug_unique?(self)
   end
 
+  def clashing_sections
+    sections
+      .group_by(&:slug)
+      .select { |_slug, docs| docs.size > 1 }
+  end
+
   def initialize(attributes)
     @id = attributes.fetch(:id)
     @updated_at = attributes.fetch(:updated_at, nil)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -21,6 +21,10 @@ class Manual
 
   attr_accessor :sections, :removed_sections
 
+  def self.find(id, user)
+    ScopedManualRepository.new(user.manual_records).fetch(id)
+  end
+
   def self.all(user)
     ManualRepository.new(collection: user.manual_records).all
   end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -21,6 +21,10 @@ class Manual
 
   attr_accessor :sections, :removed_sections
 
+  def self.all(user)
+    ManualRepository.new(collection: user.manual_records).all
+  end
+
   def initialize(attributes)
     @id = attributes.fetch(:id)
     @updated_at = attributes.fetch(:updated_at, nil)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -29,6 +29,10 @@ class Manual
     ManualRepository.new(collection: user.manual_records).all
   end
 
+  def slug_unique?(user)
+    ScopedManualRepository.new(user.manual_records).slug_unique?(self)
+  end
+
   def initialize(attributes)
     @id = attributes.fetch(:id)
     @updated_at = attributes.fetch(:updated_at, nil)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -43,6 +43,10 @@ class Manual
       .select { |_slug, docs| docs.size > 1 }
   end
 
+  def save(user)
+    ScopedManualRepository.new(user.manual_records).store(self)
+  end
+
   def initialize(attributes)
     @id = attributes.fetch(:id)
     @updated_at = attributes.fetch(:updated_at, nil)

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -23,7 +23,7 @@ private
   )
 
   def manual
-    @manual ||= manual_builder.call(attributes)
+    @manual ||= Manual.build(attributes)
   end
 
   def persist

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -1,6 +1,5 @@
 class CreateManualService
-  def initialize(manual_builder:, attributes:, context:)
-    @manual_builder = manual_builder
+  def initialize(attributes:, context:)
     @attributes = attributes
     @context = context
   end
@@ -17,7 +16,6 @@ class CreateManualService
 private
 
   attr_reader(
-    :manual_builder,
     :attributes,
     :context,
   )

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -33,7 +33,7 @@ private
   end
 
   def export_draft_to_publishing_api
-    reloaded_manual = manual_repository[manual.id]
+    reloaded_manual = Manual.find(manual.id, context.current_user)
     PublishingApiDraftManualWithSectionsExporter.new.call(reloaded_manual)
   end
 end

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -1,6 +1,5 @@
 class CreateManualService
-  def initialize(manual_repository:, manual_builder:, attributes:, context:)
-    @manual_repository = manual_repository
+  def initialize(manual_builder:, attributes:, context:)
     @manual_builder = manual_builder
     @attributes = attributes
     @context = context
@@ -18,7 +17,6 @@ class CreateManualService
 private
 
   attr_reader(
-    :manual_repository,
     :manual_builder,
     :attributes,
     :context,

--- a/app/services/create_manual_service.rb
+++ b/app/services/create_manual_service.rb
@@ -1,8 +1,9 @@
 class CreateManualService
-  def initialize(manual_repository:, manual_builder:, attributes:)
+  def initialize(manual_repository:, manual_builder:, attributes:, context:)
     @manual_repository = manual_repository
     @manual_builder = manual_builder
     @attributes = attributes
+    @context = context
   end
 
   def call
@@ -20,6 +21,7 @@ private
     :manual_repository,
     :manual_builder,
     :attributes,
+    :context,
   )
 
   def manual
@@ -27,7 +29,7 @@ private
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
   end
 
   def export_draft_to_publishing_api

--- a/app/services/list_manuals_service.rb
+++ b/app/services/list_manuals_service.rb
@@ -1,6 +1,5 @@
 class ListManualsService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -10,5 +9,5 @@ class ListManualsService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 end

--- a/app/services/list_manuals_service.rb
+++ b/app/services/list_manuals_service.rb
@@ -5,7 +5,7 @@ class ListManualsService
   end
 
   def call
-    manual_repository.all
+    Manual.all(context.current_user)
   end
 
 private

--- a/app/services/preview_manual_service.rb
+++ b/app/services/preview_manual_service.rb
@@ -1,6 +1,5 @@
 class PreviewManualService
-  def initialize(repository:, builder:, renderer:, manual_id:, attributes:, context:)
-    @repository = repository
+  def initialize(builder:, renderer:, manual_id:, attributes:, context:)
     @builder = builder
     @renderer = renderer
     @manual_id = manual_id
@@ -17,7 +16,6 @@ class PreviewManualService
 private
 
   attr_reader(
-    :repository,
     :builder,
     :renderer,
     :manual_id,

--- a/app/services/preview_manual_service.rb
+++ b/app/services/preview_manual_service.rb
@@ -1,6 +1,5 @@
 class PreviewManualService
-  def initialize(builder:, renderer:, manual_id:, attributes:, context:)
-    @builder = builder
+  def initialize(renderer:, manual_id:, attributes:, context:)
     @renderer = renderer
     @manual_id = manual_id
     @attributes = attributes
@@ -16,7 +15,6 @@ class PreviewManualService
 private
 
   attr_reader(
-    :builder,
     :renderer,
     :manual_id,
     :attributes,

--- a/app/services/preview_manual_service.rb
+++ b/app/services/preview_manual_service.rb
@@ -1,10 +1,11 @@
 class PreviewManualService
-  def initialize(repository:, builder:, renderer:, manual_id:, attributes:)
+  def initialize(repository:, builder:, renderer:, manual_id:, attributes:, context:)
     @repository = repository
     @builder = builder
     @renderer = renderer
     @manual_id = manual_id
     @attributes = attributes
+    @context = context
   end
 
   def call
@@ -21,6 +22,7 @@ private
     :renderer,
     :manual_id,
     :attributes,
+    :context,
   )
 
   def manual

--- a/app/services/preview_manual_service.rb
+++ b/app/services/preview_manual_service.rb
@@ -38,6 +38,6 @@ private
   end
 
   def existing_manual
-    @existing_manual ||= repository.fetch(manual_id)
+    @existing_manual ||= Manual.find(manual_id, context.current_user)
   end
 end

--- a/app/services/preview_manual_service.rb
+++ b/app/services/preview_manual_service.rb
@@ -28,7 +28,7 @@ private
   end
 
   def ephemeral_manual
-    builder.call(
+    Manual.build(
       attributes.reverse_merge(
         title: ""
       )

--- a/app/services/queue_publish_manual_service.rb
+++ b/app/services/queue_publish_manual_service.rb
@@ -1,9 +1,10 @@
 require "manual_publish_task"
 
 class QueuePublishManualService
-  def initialize(repository:, manual_id:)
+  def initialize(repository:, manual_id:, context:)
     @repository = repository
     @manual_id = manual_id
+    @context = context
   end
 
   def call
@@ -23,6 +24,7 @@ private
   attr_reader(
     :repository,
     :manual_id,
+    :context,
   )
 
   def create_publish_task(manual)

--- a/app/services/queue_publish_manual_service.rb
+++ b/app/services/queue_publish_manual_service.rb
@@ -1,7 +1,7 @@
 require "manual_publish_task"
 
 class QueuePublishManualService
-  def initialize(repository, manual_id)
+  def initialize(repository:, manual_id:)
     @repository = repository
     @manual_id = manual_id
   end

--- a/app/services/queue_publish_manual_service.rb
+++ b/app/services/queue_publish_manual_service.rb
@@ -35,7 +35,7 @@ private
   end
 
   def manual
-    @manual ||= repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def govuk_header_params

--- a/app/services/queue_publish_manual_service.rb
+++ b/app/services/queue_publish_manual_service.rb
@@ -1,8 +1,7 @@
 require "manual_publish_task"
 
 class QueuePublishManualService
-  def initialize(repository:, manual_id:, context:)
-    @repository = repository
+  def initialize(manual_id:, context:)
     @manual_id = manual_id
     @context = context
   end
@@ -22,7 +21,6 @@ class QueuePublishManualService
 private
 
   attr_reader(
-    :repository,
     :manual_id,
     :context,
   )

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -5,10 +5,7 @@ class ShowManualService
   end
 
   def call
-    [
-      manual,
-      other_metadata,
-    ]
+    manual
   end
 
 private
@@ -20,12 +17,5 @@ private
 
   def manual
     @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def other_metadata
-    {
-      slug_unique: manual.slug_unique?(context.current_user),
-      clashing_sections: manual.clashing_sections,
-    }
   end
 end

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -26,13 +26,9 @@ private
 
   def other_metadata
     {
-      slug_unique: slug_unique?,
+      slug_unique: manual.slug_unique?(context.current_user),
       clashing_sections: clashing_sections,
     }
-  end
-
-  def slug_unique?
-    manual_repository.slug_unique?(manual)
   end
 
   def clashing_sections

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -1,7 +1,6 @@
 class ShowManualService
-  def initialize(manual_id:, manual_repository:, context:)
+  def initialize(manual_id:, context:)
     @manual_id = manual_id
-    @manual_repository = manual_repository
     @context = context
   end
 
@@ -16,7 +15,6 @@ private
 
   attr_reader(
     :manual_id,
-    :manual_repository,
     :context,
   )
 

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -7,7 +7,7 @@ class ShowManualService
 
   def call
     [
-      Manual.find(manual_id, context.current_user),
+      manual,
       other_metadata,
     ]
   end

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -1,12 +1,13 @@
 class ShowManualService
-  def initialize(manual_id:, manual_repository:)
+  def initialize(manual_id:, manual_repository:, context:)
     @manual_id = manual_id
     @manual_repository = manual_repository
+    @context = context
   end
 
   def call
     [
-      manual_repository.fetch(manual_id),
+      Manual.find(manual_id, context.current_user),
       other_metadata,
     ]
   end
@@ -16,10 +17,11 @@ private
   attr_reader(
     :manual_id,
     :manual_repository,
+    :context,
   )
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def other_metadata

--- a/app/services/show_manual_service.rb
+++ b/app/services/show_manual_service.rb
@@ -27,13 +27,7 @@ private
   def other_metadata
     {
       slug_unique: manual.slug_unique?(context.current_user),
-      clashing_sections: clashing_sections,
+      clashing_sections: manual.clashing_sections,
     }
-  end
-
-  def clashing_sections
-    manual.sections
-      .group_by(&:slug)
-      .select { |_slug, docs| docs.size > 1 }
   end
 end

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -1,8 +1,9 @@
 class UpdateManualOriginalPublicationDateService
-  def initialize(manual_repository:, manual_id:, attributes:)
+  def initialize(manual_repository:, manual_id:, attributes:, context:)
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
+    @context = context
   end
 
   def call
@@ -22,6 +23,7 @@ private
     :manual_id,
     :manual_repository,
     :attributes,
+    :context,
   )
 
   def update
@@ -29,7 +31,7 @@ private
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
     @manual = fetch_manual
   end
 

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -51,6 +51,6 @@ private
   end
 
   def fetch_manual
-    manual_repository.fetch(manual_id)
+    Manual.find(manual_id, context.current_user)
   end
 end

--- a/app/services/update_manual_original_publication_date_service.rb
+++ b/app/services/update_manual_original_publication_date_service.rb
@@ -1,6 +1,5 @@
 class UpdateManualOriginalPublicationDateService
-  def initialize(manual_repository:, manual_id:, attributes:, context:)
-    @manual_repository = manual_repository
+  def initialize(manual_id:, attributes:, context:)
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
     @context = context
@@ -21,7 +20,6 @@ private
 
   attr_reader(
     :manual_id,
-    :manual_repository,
     :attributes,
     :context,
   )

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -33,7 +33,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def export_draft_to_publishing_api

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -37,7 +37,7 @@ private
   end
 
   def export_draft_to_publishing_api
-    reloaded_manual = manual_repository[manual.id]
+    reloaded_manual = Manual.find(manual.id, context.current_user)
     PublishingApiDraftManualWithSectionsExporter.new.call(reloaded_manual)
   end
 end

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -1,6 +1,5 @@
 class UpdateManualService
-  def initialize(manual_repository:, manual_id:, attributes:, context:)
-    @manual_repository = manual_repository
+  def initialize(manual_id:, attributes:, context:)
     @manual_id = manual_id
     @attributes = attributes
     @context = context
@@ -19,7 +18,6 @@ private
 
   attr_reader(
     :manual_id,
-    :manual_repository,
     :attributes,
     :context,
   )

--- a/app/services/update_manual_service.rb
+++ b/app/services/update_manual_service.rb
@@ -1,8 +1,9 @@
 class UpdateManualService
-  def initialize(manual_repository:, manual_id:, attributes:)
+  def initialize(manual_repository:, manual_id:, attributes:, context:)
     @manual_repository = manual_repository
     @manual_id = manual_id
     @attributes = attributes
+    @context = context
   end
 
   def call
@@ -20,6 +21,7 @@ private
     :manual_id,
     :manual_repository,
     :attributes,
+    :context,
   )
 
   def update
@@ -27,7 +29,7 @@ private
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
   end
 
   def manual

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -21,11 +21,9 @@ module ManualHelpers
     stub_organisation_details(organisation_slug)
 
     manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    repository = ScopedManualRepository.new(manual_records)
     user = double(:user, manual_records: manual_records)
 
     service = CreateManualService.new(
-      manual_repository: repository,
       manual_builder: ManualBuilder.create,
       attributes: fields.merge(organisation_slug: organisation_slug),
       context: double(:context, current_user: user)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -24,7 +24,6 @@ module ManualHelpers
     user = double(:user, manual_records: manual_records)
 
     service = CreateManualService.new(
-      manual_builder: ManualBuilder.create,
       attributes: fields.merge(organisation_slug: organisation_slug),
       context: double(:context, current_user: user)
     )

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -20,14 +20,15 @@ module ManualHelpers
   def create_manual_without_ui(fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
 
-    repository = ScopedManualRepository.new(
-      ManualRecord.where(organisation_slug: organisation_slug)
-    )
+    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
+    repository = ScopedManualRepository.new(manual_records)
+    user = double(:user, manual_records: manual_records)
 
     service = CreateManualService.new(
       manual_repository: repository,
       manual_builder: ManualBuilder.create,
       attributes: fields.merge(organisation_slug: organisation_slug),
+      context: double(:context, current_user: user)
     )
     manual = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -76,14 +76,15 @@ module ManualHelpers
   def edit_manual_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
 
-    repository = ScopedManualRepository.new(
-      ManualRecord.where(organisation_slug: organisation_slug)
-    )
+    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
+    repository = ScopedManualRepository.new(manual_records)
+    user = double(:user, manual_records: manual_records)
 
     service = UpdateManualService.new(
       manual_repository: repository,
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
+      context: double(:context, current_user: user)
     )
     manual = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -77,11 +77,9 @@ module ManualHelpers
     stub_organisation_details(organisation_slug)
 
     manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    repository = ScopedManualRepository.new(manual_records)
     user = double(:user, manual_records: manual_records)
 
     service = UpdateManualService.new(
-      manual_repository: repository,
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
       context: double(:context, current_user: user)

--- a/spec/services/queue_publish_manual_service_spec.rb
+++ b/spec/services/queue_publish_manual_service_spec.rb
@@ -4,13 +4,12 @@ require "ostruct"
 
 RSpec.describe QueuePublishManualService do
   let(:manual_id) { double(:manual_id) }
-  let(:repository) { double(:repository) }
   let(:manual) { double(:manual, id: manual_id, version_number: 1, draft?: draft) }
   let(:draft) { true }
   let(:context) { double(:context, current_user: user) }
   let(:user) { double(:user) }
 
-  subject { QueuePublishManualService.new(repository: repository, manual_id: manual_id, context: context) }
+  subject { QueuePublishManualService.new(manual_id: manual_id, context: context) }
 
   before do
     allow(Manual).to receive(:find) { manual }

--- a/spec/services/queue_publish_manual_service_spec.rb
+++ b/spec/services/queue_publish_manual_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe QueuePublishManualService do
   let(:manual) { double(:manual, id: manual_id, version_number: 1, draft?: draft) }
   let(:draft) { true }
 
-  subject { QueuePublishManualService.new(repository, manual_id) }
+  subject { QueuePublishManualService.new(repository: repository, manual_id: manual_id) }
 
   before do
     allow(repository).to receive(:fetch) { manual }

--- a/spec/services/queue_publish_manual_service_spec.rb
+++ b/spec/services/queue_publish_manual_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe QueuePublishManualService do
   let(:repository) { double(:repository) }
   let(:manual) { double(:manual, id: manual_id, version_number: 1, draft?: draft) }
   let(:draft) { true }
+  let(:context) { double(:context) }
 
-  subject { QueuePublishManualService.new(repository: repository, manual_id: manual_id) }
+  subject { QueuePublishManualService.new(repository: repository, manual_id: manual_id, context: context) }
 
   before do
     allow(repository).to receive(:fetch) { manual }

--- a/spec/services/queue_publish_manual_service_spec.rb
+++ b/spec/services/queue_publish_manual_service_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe QueuePublishManualService do
   let(:repository) { double(:repository) }
   let(:manual) { double(:manual, id: manual_id, version_number: 1, draft?: draft) }
   let(:draft) { true }
-  let(:context) { double(:context) }
+  let(:context) { double(:context, current_user: user) }
+  let(:user) { double(:user) }
 
   subject { QueuePublishManualService.new(repository: repository, manual_id: manual_id, context: context) }
 
   before do
-    allow(repository).to receive(:fetch) { manual }
+    allow(Manual).to receive(:find) { manual }
     allow(PublishManualWorker).to receive(:perform_async)
   end
 

--- a/spec/services/update_manual_original_publication_date_service_spec.rb
+++ b/spec/services/update_manual_original_publication_date_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
   }
 
   before do
-    allow(manual_repository).to receive(:fetch) { manual }
+    allow(Manual).to receive(:find).and_return(manual)
     allow(manual).to receive(:draft)
     allow(manual).to receive(:update)
     allow(manual).to receive(:save)

--- a/spec/services/update_manual_original_publication_date_service_spec.rb
+++ b/spec/services/update_manual_original_publication_date_service_spec.rb
@@ -3,7 +3,6 @@ require "update_manual_original_publication_date_service"
 
 RSpec.describe UpdateManualOriginalPublicationDateService do
   let(:manual_id) { double(:manual_id) }
-  let(:manual_repository) { double(:manual_repository) }
   let(:manual) { double(:manual, id: manual_id, sections: sections) }
   let(:section_1) { double(:section, update: nil) }
   let(:section_2) { double(:section, update: nil) }
@@ -16,7 +15,6 @@ RSpec.describe UpdateManualOriginalPublicationDateService do
   subject {
     described_class.new(
       manual_id: manual_id,
-      manual_repository: manual_repository,
       attributes: {
         originally_published_at: originally_published_at,
         use_originally_published_at_for_public_timestamp: "1",


### PR DESCRIPTION
I paired with @chrislo on the beginnings of this PR. It follows on from #940 with the idea of making the app more "standard". The idea here is for the `ManualsController` services to call methods on `Manual` instead of the various manual repository classes. Although for the moment the new methods introduced on `Manual` delegate to instances of the manual repository classes, I'm hoping that by hiding this behind the more Rails-y API of `Manual`, we can more easily convert `Manual` to be a more standard Rails model class.

We found that to do this we had to pass the current user to most of the new methods on `Manual`. However, we're pretty confident that we can deal with this by using [Pundit scopes](https://github.com/elabs/pundit/blob/72c6c1a6060e020d2f8cad999374b6221a27ec4a/README.md#scopes) as suggested by #937.

Furthermore, in hindsight, I wish I had only passed in the current user and not the entire controller context to each service. However, once I'd started, it felt simpler (and not too awful) to keep things consistent.

Also in hindsight it might've been slightly better to extract each new `Manual` method across all services in a single commit, rather than the service-by-service approach which I've taken.

Anyway, I'm pretty happy with the result and I think we ought to be able to apply the same overall approach to the other two controllers and hence eventually get rid of the manual repositories altogether.