### PR TITLE
Use methods on Manual vs manual repositories from SectionsController services

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -12,7 +12,6 @@ class SectionsController < ApplicationController
 
   def show
     service = ShowSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call
@@ -55,7 +54,6 @@ class SectionsController < ApplicationController
 
   def edit
     service = ShowSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call
@@ -139,7 +137,6 @@ class SectionsController < ApplicationController
 
   def withdraw
     service = ShowSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -12,8 +12,8 @@ class SectionsController < ApplicationController
 
   def show
     service = ShowSectionService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, section = service.call
 
@@ -55,8 +55,8 @@ class SectionsController < ApplicationController
 
   def edit
     service = ShowSectionService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, section = service.call
 
@@ -139,8 +139,8 @@ class SectionsController < ApplicationController
 
   def withdraw
     service = ShowSectionService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -36,7 +36,6 @@ class SectionsController < ApplicationController
 
   def create
     service = CreateSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -104,7 +104,6 @@ class SectionsController < ApplicationController
 
   def reorder
     service = ListSectionsService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, sections = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -80,10 +80,10 @@ class SectionsController < ApplicationController
 
   def preview
     service = PreviewSectionService.new(
-      manual_repository,
-      SectionBuilder.new,
-      SectionRenderer.new,
-      self,
+      manual_repository: manual_repository,
+      section_builder: SectionBuilder.new,
+      section_renderer: SectionRenderer.new,
+      context: self,
     )
     section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -24,7 +24,6 @@ class SectionsController < ApplicationController
 
   def new
     service = NewSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -116,8 +116,8 @@ class SectionsController < ApplicationController
 
   def update_order
     service = ReorderSectionsService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, _sections = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -64,7 +64,6 @@ class SectionsController < ApplicationController
 
   def update
     service = UpdateSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -104,8 +104,8 @@ class SectionsController < ApplicationController
 
   def reorder
     service = ListSectionsService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, sections = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -163,10 +163,6 @@ class SectionsController < ApplicationController
 
 private
 
-  def manual_repository
-    ScopedManualRepository.new(current_user.manual_records)
-  end
-
   def authorize_user_for_withdrawing
     unless current_user_can_withdraw?
       redirect_to(

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -116,7 +116,6 @@ class SectionsController < ApplicationController
 
   def update_order
     service = ReorderSectionsService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, _sections = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -142,8 +142,8 @@ class SectionsController < ApplicationController
 
   def destroy
     service = RemoveSectionService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -80,7 +80,6 @@ class SectionsController < ApplicationController
 
   def preview
     service = PreviewSectionService.new(
-      manual_repository: manual_repository,
       section_builder: SectionBuilder.new,
       section_renderer: SectionRenderer.new,
       context: self,

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -142,7 +142,6 @@ class SectionsController < ApplicationController
 
   def destroy
     service = RemoveSectionService.new(
-      manual_repository: manual_repository,
       context: self,
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -80,7 +80,6 @@ class SectionsController < ApplicationController
 
   def preview
     service = PreviewSectionService.new(
-      section_builder: SectionBuilder.new,
       section_renderer: SectionRenderer.new,
       context: self,
     )

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -24,8 +24,8 @@ class SectionsController < ApplicationController
 
   def new
     service = NewSectionService.new(
-      manual_repository,
-      self,
+      manual_repository: manual_repository,
+      context: self,
     )
     manual, section = service.call
 

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -24,7 +24,7 @@ private
   attr_reader :new_section
 
   def manual
-    @manual ||= manual_repository.fetch(context.params.fetch("manual_id"))
+    @manual ||= Manual.find(context.params.fetch("manual_id"), context.current_user)
   end
 
   def export_draft_manual_to_publishing_api

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -9,7 +9,7 @@ class CreateSectionService
 
     if new_section.valid?
       manual.draft
-      manual_repository.store(manual)
+      manual.save(context.current_user)
       export_draft_manual_to_publishing_api
       export_draft_section_to_publishing_api
     end

--- a/app/services/create_section_service.rb
+++ b/app/services/create_section_service.rb
@@ -1,6 +1,5 @@
 class CreateSectionService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -19,7 +18,7 @@ class CreateSectionService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   attr_reader :new_section
 

--- a/app/services/list_sections_service.rb
+++ b/app/services/list_sections_service.rb
@@ -17,7 +17,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def manual_id

--- a/app/services/list_sections_service.rb
+++ b/app/services/list_sections_service.rb
@@ -1,6 +1,5 @@
 class ListSectionsService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -10,7 +9,7 @@ class ListSectionsService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def sections
     manual.sections

--- a/app/services/list_sections_service.rb
+++ b/app/services/list_sections_service.rb
@@ -1,5 +1,5 @@
 class ListSectionsService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/new_section_service.rb
+++ b/app/services/new_section_service.rb
@@ -1,5 +1,5 @@
 class NewSectionService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/new_section_service.rb
+++ b/app/services/new_section_service.rb
@@ -16,7 +16,7 @@ private
   )
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def manual_id

--- a/app/services/new_section_service.rb
+++ b/app/services/new_section_service.rb
@@ -1,6 +1,5 @@
 class NewSectionService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -11,7 +10,6 @@ class NewSectionService
 private
 
   attr_reader(
-    :manual_repository,
     :context,
   )
 

--- a/app/services/preview_section_service.rb
+++ b/app/services/preview_section_service.rb
@@ -1,6 +1,5 @@
 class PreviewSectionService
-  def initialize(manual_repository:, section_builder:, section_renderer:, context:)
-    @manual_repository = manual_repository
+  def initialize(section_builder:, section_renderer:, context:)
     @section_builder = section_builder
     @section_renderer = section_renderer
     @context = context
@@ -15,7 +14,6 @@ class PreviewSectionService
 private
 
   attr_reader(
-    :manual_repository,
     :section_builder,
     :section_renderer,
     :context,

--- a/app/services/preview_section_service.rb
+++ b/app/services/preview_section_service.rb
@@ -26,7 +26,7 @@ private
   end
 
   def manual
-    manual_repository.fetch(manual_id)
+    Manual.find(manual_id, context.current_user)
   end
 
   def ephemeral_section

--- a/app/services/preview_section_service.rb
+++ b/app/services/preview_section_service.rb
@@ -28,7 +28,7 @@ private
   end
 
   def ephemeral_section
-    section_builder.call(manual, section_params)
+    manual.build_section(section_params)
   end
 
   def existing_section

--- a/app/services/preview_section_service.rb
+++ b/app/services/preview_section_service.rb
@@ -1,6 +1,5 @@
 class PreviewSectionService
-  def initialize(section_builder:, section_renderer:, context:)
-    @section_builder = section_builder
+  def initialize(section_renderer:, context:)
     @section_renderer = section_renderer
     @context = context
   end
@@ -14,7 +13,6 @@ class PreviewSectionService
 private
 
   attr_reader(
-    :section_builder,
     :section_renderer,
     :context,
   )

--- a/app/services/preview_section_service.rb
+++ b/app/services/preview_section_service.rb
@@ -1,5 +1,5 @@
 class PreviewSectionService
-  def initialize(manual_repository, section_builder, section_renderer, context)
+  def initialize(manual_repository:, section_builder:, section_renderer:, context:)
     @manual_repository = manual_repository
     @section_builder = section_builder
     @section_renderer = section_renderer

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -1,5 +1,5 @@
 class RemoveSectionService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -1,6 +1,5 @@
 class RemoveSectionService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -24,7 +23,7 @@ class RemoveSectionService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def remove
     manual.remove_section(section_id)

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -39,7 +39,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   rescue KeyError
     raise ManualNotFoundError.new(manual_id)
   end

--- a/app/services/remove_section_service.rb
+++ b/app/services/remove_section_service.rb
@@ -31,7 +31,7 @@ private
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
   end
 
   def section

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -30,7 +30,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def manual_id

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -1,6 +1,5 @@
 class ReorderSectionsService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -15,7 +14,7 @@ class ReorderSectionsService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def update
     manual.reorder_sections(section_order)

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -1,5 +1,5 @@
 class ReorderSectionsService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/reorder_sections_service.rb
+++ b/app/services/reorder_sections_service.rb
@@ -22,7 +22,7 @@ private
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
   end
 
   def sections

--- a/app/services/show_section_service.rb
+++ b/app/services/show_section_service.rb
@@ -1,6 +1,5 @@
 class ShowSectionService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -10,7 +9,7 @@ class ShowSectionService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def section
     @section ||= manual.sections.find { |s| s.id == section_id }

--- a/app/services/show_section_service.rb
+++ b/app/services/show_section_service.rb
@@ -1,5 +1,5 @@
 class ShowSectionService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/show_section_service.rb
+++ b/app/services/show_section_service.rb
@@ -17,7 +17,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def section_id

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -1,6 +1,5 @@
 class UpdateSectionService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -19,7 +18,7 @@ class UpdateSectionService
 
 private
 
-  attr_reader :manual_repository, :context, :listeners
+  attr_reader :context, :listeners
 
   def section
     @section ||= manual.sections.find { |s| s.id == section_id }

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -26,7 +26,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def section_id

--- a/app/services/update_section_service.rb
+++ b/app/services/update_section_service.rb
@@ -9,7 +9,7 @@ class UpdateSectionService
 
     if section.valid?
       manual.draft
-      manual_repository.store(manual)
+      manual.save(context.current_user)
       export_draft_manual_to_publishing_api
       export_draft_section_to_publishing_api
     end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -101,9 +101,6 @@ module ManualHelpers
 
   def edit_section_without_ui(manual, section, fields, organisation_slug: "ministry-of-tea")
     manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    organisational_manual_repository = ScopedManualRepository.new(
-      manual_records
-    )
     user = double(:user, manual_records: manual_records)
 
     service_context = OpenStruct.new(
@@ -116,7 +113,6 @@ module ManualHelpers
     )
 
     service = UpdateSectionService.new(
-      manual_repository: organisational_manual_repository,
       context: service_context,
     )
     _, section = service.call

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -100,16 +100,19 @@ module ManualHelpers
   end
 
   def edit_section_without_ui(manual, section, fields, organisation_slug: "ministry-of-tea")
+    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
     organisational_manual_repository = ScopedManualRepository.new(
-      ManualRecord.where(organisation_slug: organisation_slug)
+      manual_records
     )
+    user = double(:user, manual_records: manual_records)
 
     service_context = OpenStruct.new(
       params: {
         "manual_id" => manual.id,
         "id" => section.id,
         "section" => fields,
-      }
+      },
+      current_user: user
     )
 
     service = UpdateSectionService.new(

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -44,15 +44,18 @@ module ManualHelpers
   end
 
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
+    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
     organisational_manual_repository = ScopedManualRepository.new(
-      ManualRecord.where(organisation_slug: organisation_slug)
+      manual_records
     )
+    user = double(:user, manual_records: manual_records)
 
     create_service_context = OpenStruct.new(
       params: {
         "manual_id" => manual.id,
         "section" => fields,
-      }
+      },
+      current_user: user
     )
 
     service = CreateSectionService.new(

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -45,9 +45,6 @@ module ManualHelpers
 
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    organisational_manual_repository = ScopedManualRepository.new(
-      manual_records
-    )
     user = double(:user, manual_records: manual_records)
 
     create_service_context = OpenStruct.new(
@@ -59,7 +56,6 @@ module ManualHelpers
     )
 
     service = CreateSectionService.new(
-      manual_repository: organisational_manual_repository,
       context: create_service_context,
     )
     _, section = service.call

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -77,11 +77,9 @@ private
 
   def new_edition_for_slug_change
     manual_records = ManualRecord.all
-    manual_repository = ScopedManualRepository.new(manual_records)
     user = OpenStruct.new(manual_records: manual_records)
 
     service = UpdateSectionService.new(
-      manual_repository: manual_repository,
       context: context_for_section_edition_update(user),
     )
     _manual, document = service.call

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -76,19 +76,21 @@ private
   end
 
   def new_edition_for_slug_change
-    manual_repository = ScopedManualRepository.new(ManualRecord.all)
+    manual_records = ManualRecord.all
+    manual_repository = ScopedManualRepository.new(manual_records)
+    user = OpenStruct.new(manual_records: manual_records)
 
     service = UpdateSectionService.new(
       manual_repository: manual_repository,
-      context: context_for_section_edition_update,
+      context: context_for_section_edition_update(user),
     )
     _manual, document = service.call
     document.latest_edition
   end
 
-  FakeController = Struct.new(:params)
+  FakeController = Struct.new(:params, :current_user)
 
-  def context_for_section_edition_update
+  def context_for_section_edition_update(user)
     params_hash = {
       "id" => current_section_edition.section_id,
       "section" => {
@@ -98,9 +100,9 @@ private
         minor_update: false,
         change_note: change_note
       },
-      "manual_id" => manual_record.manual_id
+      "manual_id" => manual_record.manual_id,
     }
-    FakeController.new(params_hash)
+    FakeController.new(params_hash, user)
   end
 
   def change_note

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe RemoveSectionService do
   }
 
   let(:repository) {
-    double(
-      store: nil,
-    )
+    double(:repository)
   }
 
   let(:user) { double(:user) }
@@ -44,6 +42,7 @@ RSpec.describe RemoveSectionService do
 
   before do
     allow(Manual).to receive(:find).and_return(manual)
+    allow(manual).to receive(:save)
     allow(PublishingApiDraftManualExporter).to receive(:new).and_return(exporter)
     allow(PublishingApiDraftSectionDiscarder).to receive(:new).and_return(discarder)
   end
@@ -129,7 +128,7 @@ RSpec.describe RemoveSectionService do
     end
 
     it "does not persists the manual" do
-      expect(repository).not_to have_received(:store).with(manual)
+      expect(manual).not_to have_received(:save).with(user)
     end
 
     it "does not export a manual" do
@@ -176,7 +175,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "persists the manual" do
-        expect(repository).to have_received(:store).with(manual)
+        expect(manual).to have_received(:save).with(user)
       end
 
       it "exports a manual" do
@@ -216,7 +215,7 @@ RSpec.describe RemoveSectionService do
       end
 
       it "persists the manual" do
-        expect(repository).to have_received(:store).with(manual)
+        expect(manual).to have_received(:save).with(user)
       end
 
       it "exports a manual" do

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe RemoveSectionService do
 
   let(:service) {
     described_class.new(
-      repository,
-      service_context,
+      manual_repository: repository,
+      context: service_context,
     )
   }
   let(:discarder) { spy(PublishingApiDraftSectionDiscarder) }

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe RemoveSectionService do
 
   let(:repository) {
     double(
-      fetch: manual,
       store: nil,
     )
   }
+
+  let(:user) { double(:user) }
 
   let(:service_context) {
     double(
@@ -28,6 +29,7 @@ RSpec.describe RemoveSectionService do
         "manual_id" => "ABC",
         "section" => change_note_params
       },
+      current_user: user
     )
   }
 
@@ -41,6 +43,7 @@ RSpec.describe RemoveSectionService do
   let(:exporter) { spy(PublishingApiDraftManualExporter) }
 
   before do
+    allow(Manual).to receive(:find).and_return(manual)
     allow(PublishingApiDraftManualExporter).to receive(:new).and_return(exporter)
     allow(PublishingApiDraftSectionDiscarder).to receive(:new).and_return(discarder)
   end

--- a/spec/services/remove_section_service_spec.rb
+++ b/spec/services/remove_section_service_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe RemoveSectionService do
     )
   }
 
-  let(:repository) {
-    double(:repository)
-  }
-
   let(:user) { double(:user) }
 
   let(:service_context) {
@@ -33,7 +29,6 @@ RSpec.describe RemoveSectionService do
 
   let(:service) {
     described_class.new(
-      manual_repository: repository,
       context: service_context,
     )
   }


### PR DESCRIPTION
This follows on from #941, but makes the changes for the `SectionsController` services rather than the `ManualsController` services.

I paired with @chrislo on this.

@chrisroos: I'm afraid it was too late to learn the lessons of #941 and so it uses a similar style, but we can address those concerns if you like.