### PR TITLE
Use methods on manual instead of repository in attachment services

### DIFF
--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -6,7 +6,6 @@ require "new_section_attachment_service"
 class SectionAttachmentsController < ApplicationController
   def new
     service = NewSectionAttachmentService.new(
-      manual_repository: repository,
       # TODO: This be should be created from the section or just be a form object
       builder: Attachment.method(:new),
       context: self,
@@ -22,7 +21,6 @@ class SectionAttachmentsController < ApplicationController
 
   def create
     service = CreateSectionAttachmentService.new(
-      manual_repository: repository,
       context: self,
     )
     manual, section, _attachment = service.call
@@ -32,7 +30,6 @@ class SectionAttachmentsController < ApplicationController
 
   def edit
     service = ShowSectionAttachmentService.new(
-      manual_repository: repository,
       context: self,
     )
     manual, section, attachment = service.call
@@ -46,7 +43,6 @@ class SectionAttachmentsController < ApplicationController
 
   def update
     service = UpdateSectionAttachmentService.new(
-      manual_repository: repository,
       context: self,
     )
     manual, section, attachment = service.call

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -6,8 +6,6 @@ require "new_section_attachment_service"
 class SectionAttachmentsController < ApplicationController
   def new
     service = NewSectionAttachmentService.new(
-      # TODO: This be should be created from the section or just be a form object
-      builder: Attachment.method(:new),
       context: self,
     )
     manual, section, attachment = service.call

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -6,10 +6,10 @@ require "new_section_attachment_service"
 class SectionAttachmentsController < ApplicationController
   def new
     service = NewSectionAttachmentService.new(
-      repository,
+      manual_repository: repository,
       # TODO: This be should be created from the section or just be a form object
-      Attachment.method(:new),
-      self,
+      builder: Attachment.method(:new),
+      context: self,
     )
     manual, section, attachment = service.call
 
@@ -22,8 +22,8 @@ class SectionAttachmentsController < ApplicationController
 
   def create
     service = CreateSectionAttachmentService.new(
-      repository,
-      self,
+      manual_repository: repository,
+      context: self,
     )
     manual, section, _attachment = service.call
 
@@ -32,8 +32,8 @@ class SectionAttachmentsController < ApplicationController
 
   def edit
     service = ShowSectionAttachmentService.new(
-      repository,
-      self,
+      manual_repository: repository,
+      context: self,
     )
     manual, section, attachment = service.call
 
@@ -46,8 +46,8 @@ class SectionAttachmentsController < ApplicationController
 
   def update
     service = UpdateSectionAttachmentService.new(
-      repository,
-      self,
+      manual_repository: repository,
+      context: self,
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -57,10 +57,4 @@ class SectionAttachmentsController < ApplicationController
       })
     end
   end
-
-private
-
-  def repository
-    ScopedManualRepository.new(current_user.manual_records)
-  end
 end

--- a/app/services/create_section_attachment_service.rb
+++ b/app/services/create_section_attachment_service.rb
@@ -7,7 +7,7 @@ class CreateSectionAttachmentService
   def call
     attachment = section.add_attachment(attachment_params)
 
-    manual_repository.store(manual)
+    manual.save(context.current_user)
 
     [manual, section, attachment]
   end

--- a/app/services/create_section_attachment_service.rb
+++ b/app/services/create_section_attachment_service.rb
@@ -21,7 +21,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def attachment_params

--- a/app/services/create_section_attachment_service.rb
+++ b/app/services/create_section_attachment_service.rb
@@ -1,5 +1,5 @@
 class CreateSectionAttachmentService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/create_section_attachment_service.rb
+++ b/app/services/create_section_attachment_service.rb
@@ -1,6 +1,5 @@
 class CreateSectionAttachmentService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -14,7 +13,7 @@ class CreateSectionAttachmentService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def section
     @section ||= manual.sections.find { |s| s.id == section_id }

--- a/app/services/new_section_attachment_service.rb
+++ b/app/services/new_section_attachment_service.rb
@@ -22,7 +22,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def initial_params

--- a/app/services/new_section_attachment_service.rb
+++ b/app/services/new_section_attachment_service.rb
@@ -1,6 +1,5 @@
 class NewSectionAttachmentService
-  def initialize(manual_repository:, builder:, context:)
-    @manual_repository = manual_repository
+  def initialize(builder:, context:)
     @builder = builder
     @context = context
   end
@@ -11,7 +10,7 @@ class NewSectionAttachmentService
 
 private
 
-  attr_reader :manual_repository, :builder, :context
+  attr_reader :builder, :context
 
   def attachment
     builder.call(initial_params)

--- a/app/services/new_section_attachment_service.rb
+++ b/app/services/new_section_attachment_service.rb
@@ -1,6 +1,6 @@
 class NewSectionAttachmentService
-  def initialize(builder:, context:)
-    @builder = builder
+  def initialize(context:)
+    @builder = Attachment.method(:new)
     @context = context
   end
 

--- a/app/services/new_section_attachment_service.rb
+++ b/app/services/new_section_attachment_service.rb
@@ -1,6 +1,5 @@
 class NewSectionAttachmentService
   def initialize(context:)
-    @builder = Attachment.method(:new)
     @context = context
   end
 
@@ -10,10 +9,10 @@ class NewSectionAttachmentService
 
 private
 
-  attr_reader :builder, :context
+  attr_reader :context
 
   def attachment
-    builder.call(initial_params)
+    Attachment.new(initial_params)
   end
 
   def section

--- a/app/services/new_section_attachment_service.rb
+++ b/app/services/new_section_attachment_service.rb
@@ -1,5 +1,5 @@
 class NewSectionAttachmentService
-  def initialize(manual_repository, builder, context)
+  def initialize(manual_repository:, builder:, context:)
     @manual_repository = manual_repository
     @builder = builder
     @context = context

--- a/app/services/show_section_attachment_service.rb
+++ b/app/services/show_section_attachment_service.rb
@@ -1,6 +1,5 @@
 class ShowSectionAttachmentService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -10,7 +9,7 @@ class ShowSectionAttachmentService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)

--- a/app/services/show_section_attachment_service.rb
+++ b/app/services/show_section_attachment_service.rb
@@ -1,5 +1,5 @@
 class ShowSectionAttachmentService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/show_section_attachment_service.rb
+++ b/app/services/show_section_attachment_service.rb
@@ -21,7 +21,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def manual_id

--- a/app/services/update_section_attachment_service.rb
+++ b/app/services/update_section_attachment_service.rb
@@ -7,7 +7,7 @@ class UpdateSectionAttachmentService
   def call
     attachment.update_attributes(attachment_params)
 
-    manual_repository.store(manual)
+    manual.save(context.current_user)
 
     [manual, section, attachment]
   end

--- a/app/services/update_section_attachment_service.rb
+++ b/app/services/update_section_attachment_service.rb
@@ -1,5 +1,5 @@
 class UpdateSectionAttachmentService
-  def initialize(manual_repository, context)
+  def initialize(manual_repository:, context:)
     @manual_repository = manual_repository
     @context = context
   end

--- a/app/services/update_section_attachment_service.rb
+++ b/app/services/update_section_attachment_service.rb
@@ -25,7 +25,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   def attachment_params

--- a/app/services/update_section_attachment_service.rb
+++ b/app/services/update_section_attachment_service.rb
@@ -1,6 +1,5 @@
 class UpdateSectionAttachmentService
-  def initialize(manual_repository:, context:)
-    @manual_repository = manual_repository
+  def initialize(context:)
     @context = context
   end
 
@@ -14,7 +13,7 @@ class UpdateSectionAttachmentService
 
 private
 
-  attr_reader :manual_repository, :context
+  attr_reader :context
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)


### PR DESCRIPTION
This PR removes the dependency on a ManualRepository from the SectionAttachment services (in a similar fashion to #941 and #944. 

I've also added a couple of commits to remove the builder argument from NewSectionAttachmentService.

Note - there are no unit tests for the controller or services modified in this PR. The functionality is covered by a feature spec (in `features/attachments.feature`) that didn't require changing as part of this refactor. I'm reasonably confident that those feature tests show that the behaviour hasn't changed as part of this refactor, and I don't plan to add the missing unit tests at this stage. 