### PR TITLE
Simplify ManualBuilder

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -39,7 +39,7 @@ class ManualsController < ApplicationController
   end
 
   def new
-    service = ->() { ManualBuilder.create.call(title: "") }
+    service = ->() { ManualBuilder.new.call(title: "") }
     manual = service.call
 
     render(:new, locals: { manual: manual_form(manual) })

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -12,17 +12,7 @@ class ManualBuilder
   end
 
   def call(attrs)
-    @attrs = attrs
-
-    factory.call(defaults.merge(attrs))
-  end
-
-private
-
-  attr_reader :slug_generator, :factory, :attrs
-
-  def defaults
-    {
+    default_attrs = {
       id: SecureRandom.uuid,
       slug: slug_generator.call(attrs.fetch(:title)),
       summary: "",
@@ -33,5 +23,11 @@ private
       originally_published_at: nil,
       use_originally_published_at_for_public_timestamp: true,
     }
+
+    factory.call(default_attrs.merge(attrs))
   end
+
+private
+
+  attr_reader :slug_generator, :factory
 end

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -3,7 +3,6 @@ require "securerandom"
 class ManualBuilder
   def self.create
     ManualBuilder.new(
-      slug_generator: SlugGenerator.new(prefix: "guidance"),
       factory: ->(attrs) {
         manual = Manual.new(attrs)
         manual.sections = attrs.fetch(:sections, [])
@@ -13,8 +12,8 @@ class ManualBuilder
     )
   end
 
-  def initialize(slug_generator:, factory:)
-    @slug_generator = slug_generator
+  def initialize(factory:)
+    @slug_generator = SlugGenerator.new(prefix: "guidance")
     @factory = factory
   end
 

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -2,19 +2,17 @@ require "securerandom"
 
 class ManualBuilder
   def self.create
-    ManualBuilder.new(
-      factory: ->(attrs) {
-        manual = Manual.new(attrs)
-        manual.sections = attrs.fetch(:sections, [])
-        manual.removed_sections = attrs.fetch(:removed_sections, [])
-        manual
-      }
-    )
+    ManualBuilder.new
   end
 
-  def initialize(factory:)
+  def initialize
     @slug_generator = SlugGenerator.new(prefix: "guidance")
-    @factory = factory
+    @factory = ->(attrs) {
+      manual = Manual.new(attrs)
+      manual.sections = attrs.fetch(:sections, [])
+      manual.removed_sections = attrs.fetch(:removed_sections, [])
+      manual
+    }
   end
 
   def call(attrs)

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -24,7 +24,7 @@ private
   def defaults
     {
       id: SecureRandom.uuid,
-      slug: slug,
+      slug: slug_generator.call(attrs.fetch(:title)),
       summary: "",
       body: "",
       state: "draft",
@@ -33,9 +33,5 @@ private
       originally_published_at: nil,
       use_originally_published_at_for_public_timestamp: true,
     }
-  end
-
-  def slug
-    slug_generator.call(attrs.fetch(:title))
   end
 end

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -1,11 +1,9 @@
 require "securerandom"
 
 class ManualBuilder
-  def initialize
-    @slug_generator = SlugGenerator.new(prefix: "guidance")
-  end
-
   def call(attrs)
+    slug_generator = SlugGenerator.new(prefix: "guidance")
+
     default_attrs = {
       id: SecureRandom.uuid,
       slug: slug_generator.call(attrs.fetch(:title)),
@@ -24,8 +22,4 @@ class ManualBuilder
     manual.removed_sections = manual_attrs.fetch(:removed_sections, [])
     manual
   end
-
-private
-
-  attr_reader :slug_generator
 end

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -3,12 +3,6 @@ require "securerandom"
 class ManualBuilder
   def initialize
     @slug_generator = SlugGenerator.new(prefix: "guidance")
-    @factory = ->(attrs) {
-      manual = Manual.new(attrs)
-      manual.sections = attrs.fetch(:sections, [])
-      manual.removed_sections = attrs.fetch(:removed_sections, [])
-      manual
-    }
   end
 
   def call(attrs)
@@ -24,10 +18,14 @@ class ManualBuilder
       use_originally_published_at_for_public_timestamp: true,
     }
 
-    factory.call(default_attrs.merge(attrs))
+    manual_attrs = default_attrs.merge(attrs)
+    manual = Manual.new(manual_attrs)
+    manual.sections = manual_attrs.fetch(:sections, [])
+    manual.removed_sections = manual_attrs.fetch(:removed_sections, [])
+    manual
   end
 
 private
 
-  attr_reader :slug_generator, :factory
+  attr_reader :slug_generator
 end

--- a/app/models/builders/manual_builder.rb
+++ b/app/models/builders/manual_builder.rb
@@ -1,10 +1,6 @@
 require "securerandom"
 
 class ManualBuilder
-  def self.create
-    ManualBuilder.new
-  end
-
   def initialize
     @slug_generator = SlugGenerator.new(prefix: "guidance")
     @factory = ->(attrs) {

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -30,7 +30,7 @@ class Manual
   end
 
   def self.build(attributes)
-    ManualBuilder.create.call(attributes)
+    ManualBuilder.new.call(attributes)
   end
 
   def slug_unique?(user)


### PR DESCRIPTION
I've simplified `ManualBuilder` by removing unnecessary flexibility and indirection and by moving all the behaviour to the `#call` method. I find the resulting class easier to understand.