### PR TITLE
Remove SectionValidator

### DIFF
--- a/app/lib/section_factory.rb
+++ b/app/lib/section_factory.rb
@@ -10,13 +10,11 @@ class SectionFactory
     slug_generator = SlugGenerator.new(prefix: @manual.slug)
 
     ChangeNoteValidator.new(
-      SectionValidator.new(
-        Section.new(
-          slug_generator,
-          id,
-          editions,
-        ),
-      )
+      Section.new(
+        slug_generator,
+        id,
+        editions,
+      ),
     )
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -3,7 +3,13 @@ require "active_model/conversion"
 require "active_model/naming"
 
 class Section
+  include ActiveModel::Validations
+
   extend Forwardable
+
+  validates :summary, presence: true
+  validates :title, presence: true
+  validates :body, presence: true, safe_html: true
 
   def self.edition_attributes
     [

--- a/app/models/validators/section_validator.rb
+++ b/app/models/validators/section_validator.rb
@@ -1,9 +1,0 @@
-require "delegate"
-
-class SectionValidator < SimpleDelegator
-  include ActiveModel::Validations
-
-  validates :summary, presence: true
-  validates :title, presence: true
-  validates :body, presence: true, safe_html: true
-end


### PR DESCRIPTION
The SectionValidator class was being used to add validation to the
Section model. Adding the validation to the model directly is more
Rails-like and results in code that's easier to understand.

I temporarily removed these validations and observed the following two
cucumber scenarios in creating-and-editing-a-manual.feature failing:

* Try to create an invalid section
* Previewing a manual with invalid HTML

I'd normally expect unit test coverage around this validation but I'm
not planning to add that at the moment.
