### PR TITLE
Reduce number of references to manual repositories outside Manual class (part 1)

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -26,7 +26,7 @@ class Manual
   end
 
   def self.all(user)
-    ManualRepository.new(collection: user.manual_records).all
+    ScopedManualRepository.new(user.manual_records).all
   end
 
   def self.build(attributes)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,12 @@ class User
   attr_accessible :email, :name, :uid
   attr_accessible :email, :name, :uid, :permissions, as: :oauth
 
+  def self.gds_editor
+    User.new.tap do |user|
+      user.permissions = [PermissionChecker::GDS_EDITOR_PERMISSION]
+    end
+  end
+
   def manual_records
     permission_checker = PermissionChecker.new(self)
     if permission_checker.is_gds_editor?

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -1,8 +1,9 @@
 class PublishManualService
-  def initialize(manual_id:, manual_repository:, version_number:)
+  def initialize(manual_id:, manual_repository:, version_number:, context:)
     @manual_id = manual_id
     @manual_repository = manual_repository
     @version_number = version_number
+    @context = context
   end
 
   def call
@@ -29,6 +30,7 @@ private
     :manual_id,
     :manual_repository,
     :version_number,
+    :context,
   )
 
   def versions_match?

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -1,7 +1,6 @@
 class PublishManualService
-  def initialize(manual_id:, manual_repository:, version_number:, context:)
+  def initialize(manual_id:, version_number:, context:)
     @manual_id = manual_id
-    @manual_repository = manual_repository
     @version_number = version_number
     @context = context
   end
@@ -28,7 +27,6 @@ private
 
   attr_reader(
     :manual_id,
-    :manual_repository,
     :version_number,
     :context,
   )

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -42,7 +42,7 @@ private
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
   end
 
   def log_publication

--- a/app/services/publish_manual_service.rb
+++ b/app/services/publish_manual_service.rb
@@ -62,7 +62,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   end
 
   class VersionMismatchError < StandardError

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -15,7 +15,6 @@ class PublishManualWorker
     task.start!
 
     service = PublishManualService.new(
-      manual_repository: repository,
       manual_id: task.manual_id,
       version_number: task.version_number,
       context: context,
@@ -33,10 +32,6 @@ class PublishManualWorker
   end
 
 private
-
-  def repository
-    ScopedManualRepository.new(ManualRecord.all)
-  end
 
   def context
     OpenStruct.new(current_user: User.gds_editor)

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -39,7 +39,7 @@ private
   end
 
   def context
-    OpenStruct.new
+    OpenStruct.new(current_user: User.gds_editor)
   end
 
   def requeue_task(manual_id, error)

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -18,6 +18,7 @@ class PublishManualWorker
       manual_repository: repository,
       manual_id: task.manual_id,
       version_number: task.version_number,
+      context: context,
     )
     service.call
 
@@ -35,6 +36,10 @@ private
 
   def repository
     ScopedManualRepository.new(ManualRecord.all)
+  end
+
+  def context
+    OpenStruct.new
   end
 
   def requeue_task(manual_id, error)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -159,7 +159,6 @@ module ManualHelpers
     user = FactoryGirl.build(:gds_editor)
 
     service = PublishManualService.new(
-      manual_repository: ScopedManualRepository.new(ManualRecord.all),
       manual_id: manual.id,
       version_number: manual.version_number,
       context: OpenStruct.new(current_user: user)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -24,7 +24,7 @@ module ManualHelpers
 
     service = CreateManualService.new(
       attributes: fields.merge(organisation_slug: organisation_slug),
-      context: double(:context, current_user: user)
+      context: OpenStruct.new(current_user: user)
     )
     manual = service.call
 
@@ -78,7 +78,7 @@ module ManualHelpers
     service = UpdateManualService.new(
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
-      context: double(:context, current_user: user)
+      context: OpenStruct.new(current_user: user)
     )
     manual = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -531,7 +531,7 @@ module ManualHelpers
   end
 
   def most_recently_created_manual
-    ScopedManualRepository.new(ManualRecord.all).all.first
+    Manual.all(FactoryGirl.build(:gds_editor)).first
   end
 
   def section_fields(section)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -20,8 +20,7 @@ module ManualHelpers
   def create_manual_without_ui(fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
 
-    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    user = double(:user, manual_records: manual_records)
+    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = CreateManualService.new(
       attributes: fields.merge(organisation_slug: organisation_slug),
@@ -44,8 +43,7 @@ module ManualHelpers
   end
 
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
-    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    user = double(:user, manual_records: manual_records)
+    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
     create_service_context = OpenStruct.new(
       params: {
@@ -75,8 +73,7 @@ module ManualHelpers
   def edit_manual_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
 
-    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    user = double(:user, manual_records: manual_records)
+    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = UpdateManualService.new(
       manual_id: manual.id,

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -4,10 +4,6 @@ require "manuals_republisher"
 require "manual_withdrawer"
 
 module ManualHelpers
-  def manual_repository
-    ScopedManualRepository.new(ManualRecord.all)
-  end
-
   def create_manual(fields, save: true)
     visit new_manual_path
     fill_in_fields(fields)
@@ -28,7 +24,7 @@ module ManualHelpers
     )
     manual = service.call
 
-    manual_repository.fetch(manual.id)
+    Manual.find(manual.id, FactoryGirl.build(:gds_editor))
   end
 
   def create_section(manual_title, fields)
@@ -186,13 +182,13 @@ module ManualHelpers
   end
 
   def check_section_exists(manual_id, section_id)
-    manual = manual_repository.fetch(manual_id)
+    manual = Manual.find(manual_id, FactoryGirl.build(:gds_editor))
 
     manual.sections.any? { |section| section.id == section_id }
   end
 
   def check_section_was_removed(manual_id, section_id)
-    manual = manual_repository.fetch(manual_id)
+    manual = Manual.find(manual_id, FactoryGirl.build(:gds_editor))
 
     manual.removed_sections.any? { |section| section.id == section_id }
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -156,11 +156,13 @@ module ManualHelpers
   def publish_manual_without_ui(manual, organisation_slug: "ministry-of-tea")
     stub_manual_publication_observers(organisation_slug)
 
+    user = FactoryGirl.build(:gds_editor)
+
     service = PublishManualService.new(
       manual_repository: ScopedManualRepository.new(ManualRecord.all),
       manual_id: manual.id,
       version_number: manual.version_number,
-      context: OpenStruct.new
+      context: OpenStruct.new(current_user: user)
     )
     service.call
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -97,8 +97,7 @@ module ManualHelpers
   end
 
   def edit_section_without_ui(manual, section, fields, organisation_slug: "ministry-of-tea")
-    manual_records = ManualRecord.where(organisation_slug: organisation_slug)
-    user = double(:user, manual_records: manual_records)
+    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
     service_context = OpenStruct.new(
       params: {
@@ -161,6 +160,7 @@ module ManualHelpers
       manual_repository: ScopedManualRepository.new(ManualRecord.all),
       manual_id: manual.id,
       version_number: manual.version_number,
+      context: OpenStruct.new
     )
     service.call
   end

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -112,8 +112,13 @@ private
       manual_repository: ScopedManualRepository.new(ManualRecord.all),
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,
+      context: context,
     )
     service.call
+  end
+
+  def context
+    OpenStruct.new
   end
 
   def manual_record

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -118,7 +118,7 @@ private
   end
 
   def context
-    OpenStruct.new
+    OpenStruct.new(current_user: User.gds_editor)
   end
 
   def manual_record

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -109,7 +109,6 @@ private
 
   def publish_manual
     service = PublishManualService.new(
-      manual_repository: ScopedManualRepository.new(ManualRecord.all),
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,
       context: context,

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -125,11 +125,8 @@ private
   end
 
   def manual_version_number
-    manual_repository.fetch(manual_record.manual_id).version_number
-  end
-
-  def manual_repository
-    ScopedManualRepository.new(ManualRecord.all)
+    manual = Manual.find(manual_record.manual_id, context.current_user)
+    manual.version_number
   end
 
   def current_section_edition

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,14 +8,12 @@ describe User, type: :model do
     let(:permission_checker) { double(:permission_checker) }
 
     before do
-      allow(PermissionChecker).to receive(:new).and_return(permission_checker)
-      allow(permission_checker).to receive(:is_gds_editor?).and_return(is_gds_editor)
       allow(ManualRecord).to receive(:all).and_return(:all_manual_records)
       allow(ManualRecord).to receive(:where).with(organisation_slug: subject.organisation_slug).and_return(:manual_records_for_organisation)
     end
 
     context 'when user is a GDS editor' do
-      let(:is_gds_editor) { true }
+      subject { User.gds_editor }
 
       it 'returns all manual records' do
         expect(subject.manual_records).to eq(:all_manual_records)
@@ -23,8 +21,6 @@ describe User, type: :model do
     end
 
     context 'when user is not a GDS editor' do
-      let(:is_gds_editor) { false }
-
       it "returns only the manual records for the user's organisation" do
         expect(subject.manual_records).to eq(:manual_records_for_organisation)
       end

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe PublishManualService do
   let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
   let(:new_publishing_api_publisher) { double(:new_publishing_api_publisher) }
   let(:rummager_exporter) { double(:rummager_exporter) }
-  let(:context) { double(:context) }
+  let(:user) { double(:user) }
+  let(:context) { double(:context, current_user: user) }
 
   subject {
     PublishManualService.new(

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe PublishManualService do
   let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
   let(:new_publishing_api_publisher) { double(:new_publishing_api_publisher) }
   let(:rummager_exporter) { double(:rummager_exporter) }
+  let(:context) { double(:context) }
 
   subject {
     PublishManualService.new(
       manual_id: manual_id,
       manual_repository: manual_repository,
       version_number: version_number,
+      context: context,
     )
   }
 

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -4,7 +4,6 @@ require "ostruct"
 
 RSpec.describe PublishManualService do
   let(:manual_id) { double(:manual_id) }
-  let(:manual_repository) { double(:manual_repository) }
   let(:manual) { double(:manual, id: manual_id, version_number: 3) }
   let(:publication_logger) { double(:publication_logger) }
   let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
@@ -16,7 +15,6 @@ RSpec.describe PublishManualService do
   subject {
     PublishManualService.new(
       manual_id: manual_id,
-      manual_repository: manual_repository,
       version_number: version_number,
       context: context,
     )

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PublishManualService do
   }
 
   before do
-    allow(manual_repository).to receive(:fetch) { manual }
+    allow(Manual).to receive(:find) { manual }
     allow(manual_repository).to receive(:store)
     allow(manual).to receive(:publish)
     allow(PublicationLogger).to receive(:new) { publication_logger }

--- a/spec/services/publish_manual_service_spec.rb
+++ b/spec/services/publish_manual_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PublishManualService do
 
   before do
     allow(Manual).to receive(:find) { manual }
-    allow(manual_repository).to receive(:store)
+    allow(manual).to receive(:save)
     allow(manual).to receive(:publish)
     allow(PublicationLogger).to receive(:new) { publication_logger }
     allow(PublishingApiDraftManualWithSectionsExporter).to receive(:new) { publishing_api_draft_exporter }


### PR DESCRIPTION
This continues the work we've done in #941, #944 & #947 in services not used by controllers and some other places. The hope is that by continuing this work, eventually we'll be able to remove the manual repositories.