### PR TITLE
Reduce number of references to manual repositories outside Manual class (part 2)

### DIFF
--- a/app/services/withdraw_manual_service.rb
+++ b/app/services/withdraw_manual_service.rb
@@ -1,7 +1,7 @@
 class WithdrawManualService
-  def initialize(manual_repository:, manual_id:)
-    @manual_repository = manual_repository
+  def initialize(manual_id:, context:)
     @manual_id = manual_id
+    @context = context
   end
 
   def call
@@ -18,14 +18,14 @@ class WithdrawManualService
 
 private
 
-  attr_reader :manual_repository, :manual_id
+  attr_reader :manual_id, :context
 
   def withdraw
     manual.withdraw
   end
 
   def persist
-    manual_repository.store(manual)
+    manual.save(context.current_user)
   end
 
   def withdraw_via_publishing_api
@@ -37,7 +37,7 @@ private
   end
 
   def manual
-    @manual ||= manual_repository.fetch(manual_id)
+    @manual ||= Manual.find(manual_id, context.current_user)
   rescue KeyError => error
     raise ManualNotFoundError.new(error)
   end

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -7,8 +7,8 @@ class ManualWithdrawer
 
   def execute(manual_id)
     service = WithdrawManualService.new(
-      manual_repository: ScopedManualRepository.new(ManualRecord.all),
       manual_id: manual_id,
+      context: OpenStruct.new(current_user: User.gds_editor),
     )
     manual = service.call
 

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe "Publishing manuals", type: :feature do
 
   let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
 
-  def manual_repository
-    ScopedManualRepository.new(ManualRecord.all)
-  end
-
   describe "publishing a manual with major and minor updates" do
     let(:publish_time) { DateTime.now }
 
@@ -26,7 +22,7 @@ RSpec.describe "Publishing manuals", type: :feature do
       end
 
       # Re-fetch manual to include sections
-      @manual = manual_repository.fetch(manual.id)
+      @manual = Manual.find(manual.id, User.gds_editor)
 
       Timecop.freeze(publish_time) do
         publish_manual_without_ui(@manual)

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     @sections = create_sections_for_manual_without_ui(manual: manual, count: 2)
 
     # Re-fetch manual to include sections
-    @manual = manual_repository.fetch(manual.id)
+    @manual = Manual.find(manual.id, User.gds_editor)
 
     if published
       Timecop.freeze(original_publish_time) do
@@ -50,10 +50,6 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     WebMock::RequestRegistry.instance.reset!
-  end
-
-  def manual_repository
-    ScopedManualRepository.new(ManualRecord.all)
   end
 
   describe "republishing a published manual with sections" do


### PR DESCRIPTION
This follows on from #953 and is a further effort at reducing the number of places which depend on the various manual repositories. There are still some left to deal with, notably `VersionedManualRepository`.