### PR TITLE
Remove scoped manual repository

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -22,11 +22,11 @@ class Manual
   attr_accessor :sections, :removed_sections
 
   def self.find(id, user)
-    ScopedManualRepository.new(user.manual_records).fetch(id)
+    ManualRepository.new(user.manual_records).fetch(id)
   end
 
   def self.all(user)
-    ScopedManualRepository.new(user.manual_records).all
+    ManualRepository.new(user.manual_records).all
   end
 
   def self.build(attributes)
@@ -34,7 +34,7 @@ class Manual
   end
 
   def slug_unique?(user)
-    ScopedManualRepository.new(user.manual_records).slug_unique?(self)
+    ManualRepository.new(user.manual_records).slug_unique?(self)
   end
 
   def clashing_sections
@@ -44,7 +44,7 @@ class Manual
   end
 
   def save(user)
-    ScopedManualRepository.new(user.manual_records).store(self)
+    ManualRepository.new(user.manual_records).store(self)
   end
 
   def initialize(attributes)

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -6,9 +6,12 @@ class ManualRepository
 
   NotFoundError = Module.new
 
-  def initialize(collection:, association_marshallers: [])
+  def initialize(collection:)
     @collection = collection
-    @association_marshallers = association_marshallers
+    @association_marshallers = [
+      SectionAssociationMarshaller.new,
+      ManualPublishTaskAssociationMarshaller.new
+    ]
   end
 
   def fetch(*args, &block)

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -6,7 +6,7 @@ class ManualRepository
 
   NotFoundError = Module.new
 
-  def initialize(collection:)
+  def initialize(collection)
     @collection = collection
     @association_marshallers = [
       SectionAssociationMarshaller.new,

--- a/app/repositories/scoped_manual_repository.rb
+++ b/app/repositories/scoped_manual_repository.rb
@@ -4,8 +4,6 @@ class ScopedManualRepository
   def_delegators :@repository, :all, :store, :[], :fetch, :slug_unique?
 
   def initialize(collection)
-    @repository = ManualRepository.new(
-      collection: collection,
-    )
+    @repository = ManualRepository.new(collection)
   end
 end

--- a/app/repositories/scoped_manual_repository.rb
+++ b/app/repositories/scoped_manual_repository.rb
@@ -1,9 +1,0 @@
-class ScopedManualRepository
-  extend Forwardable
-
-  def_delegators :@repository, :all, :store, :[], :fetch, :slug_unique?
-
-  def initialize(collection)
-    @repository = ManualRepository.new(collection)
-  end
-end

--- a/app/repositories/scoped_manual_repository.rb
+++ b/app/repositories/scoped_manual_repository.rb
@@ -5,10 +5,6 @@ class ScopedManualRepository
 
   def initialize(collection)
     @repository = ManualRepository.new(
-      association_marshallers: [
-        SectionAssociationMarshaller.new,
-        ManualPublishTaskAssociationMarshaller.new
-      ],
       collection: collection,
     )
   end

--- a/spec/repositories/manual_repository_spec.rb
+++ b/spec/repositories/manual_repository_spec.rb
@@ -4,9 +4,7 @@ require "manual_repository"
 
 describe ManualRepository do
   subject(:repo) {
-    ManualRepository.new(
-      collection: record_collection,
-    )
+    ManualRepository.new(record_collection)
   }
 
   let(:record_collection) {

--- a/spec/repositories/manual_repository_spec.rb
+++ b/spec/repositories/manual_repository_spec.rb
@@ -6,7 +6,6 @@ describe ManualRepository do
   subject(:repo) {
     ManualRepository.new(
       collection: record_collection,
-      association_marshallers: association_marshallers,
     )
   }
 
@@ -15,8 +14,6 @@ describe ManualRepository do
       find_or_initialize_by: nil,
     )
   }
-
-  let(:association_marshallers) { [] }
 
   let(:manual_id) { double(:manual_id) }
   let(:manual_slug) { double(:manual_slug) }
@@ -77,6 +74,14 @@ describe ManualRepository do
     }
   }
 
+  let(:section_association_marshaller) { double(:section_association_marshaller, dump: nil, load: manual) }
+  let(:manual_publish_task_association_marshaller) { double(:manual_publish_task_association_marshaller, dump: nil, load: manual) }
+
+  before do
+    allow(SectionAssociationMarshaller).to receive(:new).and_return(section_association_marshaller)
+    allow(ManualPublishTaskAssociationMarshaller).to receive(:new).and_return(manual_publish_task_association_marshaller)
+  end
+
   it "supports the fetch interface" do
     expect(repo).to be_a_kind_of(Fetchable)
   end
@@ -130,18 +135,16 @@ describe ManualRepository do
       expect(manual_record).to have_received(:save!)
     end
 
-    context "with an association_marshaller" do
-      let(:association_marshallers) { [association_marshaller] }
+    it "calls dump on the section association marshaller with the manual domain object and edition" do
+      repo.store(manual)
 
-      let(:association_marshaller) {
-        double(:association_marshaller, dump: nil)
-      }
+      expect(section_association_marshaller).to have_received(:dump).with(manual, edition)
+    end
 
-      it "calls dump on each marshaller with the manual domain object and edition" do
-        repo.store(manual)
+    it "calls dump on the manual publish task association marshaller with the manual domain object and edition" do
+      repo.store(manual)
 
-        expect(association_marshaller).to have_received(:dump).with(manual, edition)
-      end
+      expect(manual_publish_task_association_marshaller).to have_received(:dump).with(manual, edition)
     end
   end
 
@@ -172,24 +175,16 @@ describe ManualRepository do
       expect(repo[manual_id]).to be(manual)
     end
 
-    context "with an association_marshaller" do
-      let(:association_marshallers) { [association_marshaller] }
+    it "calls load on the section association marshaller with the manual domain object and edition" do
+      repo[manual_id]
 
-      let(:association_marshaller) {
-        double(:association_marshaller, load: unmarshalled_manual)
-      }
+      expect(section_association_marshaller).to have_received(:load).with(manual, edition)
+    end
 
-      let(:unmarshalled_manual) { double(:unmarshalled_manual) }
+    it "calls load on the manual publish task association marshaller with the manual domain object and edition" do
+      repo[manual_id]
 
-      it "calls load on each marshaller with the manual domain object and edition" do
-        repo[manual_id]
-
-        expect(association_marshaller).to have_received(:load).with(manual, edition)
-      end
-
-      it "returns the result of the marshaller" do
-        expect(repo[manual_id]).to eq(unmarshalled_manual)
-      end
+      expect(manual_publish_task_association_marshaller).to have_received(:load).with(manual, edition)
     end
   end
 


### PR DESCRIPTION
This PR removes the ScopedManualRepository since it was primarily delegating all of its methods to ManualRepository. The only difference was the addition of the "marshallers" which we have inlined into ManualRepository in ccfac12.