### PR TITLE
Reduce number of references to manual repositories outside Manual class (part 3)

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -47,6 +47,11 @@ class Manual
     ManualRepository.new(user.manual_records).store(self)
   end
 
+  def current_versions
+    repository = VersionedManualRepository.new
+    repository.get_manual(id)
+  end
+
   def initialize(attributes)
     @id = attributes.fetch(:id)
     @updated_at = attributes.fetch(:updated_at, nil)

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -3,10 +3,6 @@ require "manual_repository"
 class VersionedManualRepository
   class NotFoundError < StandardError; include ManualRepository::NotFoundError; end
 
-  def self.get_manual(manual_id)
-    new.get_manual(manual_id)
-  end
-
   def get_manual(manual_id)
     manual_record = ManualRecord.find_by(manual_id: manual_id)
     raise NotFoundError if manual_record.nil?

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -1,6 +1,7 @@
 class RepublishManualService
-  def initialize(manual_id:)
+  def initialize(manual_id:, context:)
     @manual_id = manual_id
+    @context = context
   end
 
   def call
@@ -19,7 +20,7 @@ class RepublishManualService
 
 private
 
-  attr_reader :manual_id
+  attr_reader :manual_id, :context
 
   def published_manual_version
     manual_versions[:published]
@@ -27,10 +28,6 @@ private
 
   def draft_manual_version
     manual_versions[:draft]
-  end
-
-  def manual_repository
-    VersionedManualRepository
   end
 
   def export_published_manual_via_publishing_api
@@ -50,7 +47,7 @@ private
   end
 
   def manual_versions
-    @manual_versions ||= manual_repository.get_manual(manual_id)
+    @manual_versions ||= Manual.find(manual_id, context.current_user).current_versions
   rescue ManualRepository::NotFoundError => error
     raise ManualNotFoundError.new(error)
   end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -168,7 +168,8 @@ private
   end
 
   def redraft_and_republish
-    manual_versions = VersionedManualRepository.get_manual(new_manual.manual_id)
+    manual = Manual.find(new_manual.manual_id, User.gds_editor)
+    manual_versions = manual.current_versions
 
     if manual_versions[:published].present?
       manual_to_publish = manual_versions[:published]

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -18,6 +18,7 @@ class ManualsRepublisher
         logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
         service = RepublishManualService.new(
           manual_id: manual_record.manual_id,
+          context: OpenStruct.new(current_user: User.gds_editor),
         )
         service.call
       rescue SectionAssociationMarshaller::RemovedSectionIdNotFoundError => e

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -9,10 +9,14 @@ RSpec.describe RepublishManualService do
   let(:publishing_api_draft_exporter) { double(:publishing_api_draft_exporter) }
   let(:publishing_api_publisher) { double(:publishing_api_publisher) }
   let(:rummager_exporter) { double(:rummager_exporter) }
+  let(:manual) { double(:manual) }
+  let(:user) { double(:user) }
+  let(:context) { double(:context, current_user: user) }
 
   subject {
     described_class.new(
       manual_id: manual_id,
+      context: context,
     )
   }
 
@@ -23,12 +27,12 @@ RSpec.describe RepublishManualService do
     allow(publishing_api_draft_exporter).to receive(:call)
     allow(publishing_api_publisher).to receive(:call)
     allow(rummager_exporter).to receive(:call)
+    allow(Manual).to receive(:find).with(manual_id, user) { manual }
   end
 
   context "(for a published manual)" do
     before do
-      allow(VersionedManualRepository).to receive(:get_manual)
-        .with(manual_id)
+      allow(manual).to receive(:current_versions)
         .and_return(
           published: published_manual_version,
           draft: nil
@@ -58,8 +62,7 @@ RSpec.describe RepublishManualService do
 
   context "(for a draft manual)" do
     before do
-      allow(VersionedManualRepository).to receive(:get_manual)
-        .with(manual_id)
+      allow(manual).to receive(:current_versions)
         .and_return(
           published: nil,
           draft: draft_manual_version
@@ -81,8 +84,7 @@ RSpec.describe RepublishManualService do
 
   context "(for a published manual with a new draft waiting)" do
     before do
-      allow(VersionedManualRepository).to receive(:get_manual)
-        .with(manual_id)
+      allow(manual).to receive(:current_versions)
         .and_return(
           published: published_manual_version,
           draft: draft_manual_version
@@ -112,8 +114,7 @@ RSpec.describe RepublishManualService do
 
   context "(for a manual that doesn't exist)" do
     before do
-      allow(VersionedManualRepository).to receive(:get_manual)
-        .with(manual_id)
+      allow(manual).to receive(:current_versions)
         .and_raise(VersionedManualRepository::NotFoundError.new("uh-oh!"))
     end
 
@@ -133,8 +134,7 @@ RSpec.describe RepublishManualService do
 
   context "(for a manual that exists, but is neither published, nor draft)" do
     before do
-      allow(VersionedManualRepository).to receive(:get_manual)
-        .with(manual_id)
+      allow(manual).to receive(:current_versions)
         .and_return(
           published: nil,
           draft: nil


### PR DESCRIPTION
This follows on from #953 & #954 and is a further effort at reducing the number of places which depend on the various manual repositories. In this case, I'm specifically dealing with `VersionedManualRepository`. There are still some occurrences left to deal with, e.g. `ManualRepository::NotFoundError`.