### PR TITLE
Update Jenkinsfile to use govuk.buildProject() function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = 'manuals-publisher'
-DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 def runTests() {
   echo 'Running tests'
@@ -10,11 +9,6 @@ def runTests() {
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-    govuk.initializeParameters([
-      'IS_SCHEMA_TEST': 'false',
-      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
-    ])
 
     stage('Checkout') {
       checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,10 +17,6 @@ node {
       'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
     ])
 
-    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
-      return
-    }
-
     stage('Checkout') {
       checkout scm
       govuk.cleanupGit()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,8 @@
 #!/usr/bin/env groovy
 
 // TODO: Call govuk.rubyLinter("app bin config features Gemfile lib spec")
-
-def runTests() {
-  echo 'Running tests'
-  sh("TEST_COVERAGE=true bundle exec rake")
-}
+// TODO: RUn tests with TEST_COVERAGE env var set to `true`
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-    stage('Tests') {
-      runTests()
-    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,16 +28,6 @@ node {
     stage('Tests') {
       runTests()
     }
-
-    if (env.BRANCH_NAME == 'master') {
-      stage('Push release tag') {
-        govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
-      }
-
-      stage('Deploy to Integration') {
-        govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
-      }
-    }
   } catch (e) {
     currentBuild.result = 'FAILED'
     step([$class: 'Mailer',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,5 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject()
+  govuk.buildProject(sassLint: false)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 #!/usr/bin/env groovy
 
+// TODO: Call govuk.rubyLinter("app bin config features Gemfile lib spec")
+
 def runTests() {
   echo 'Running tests'
   sh("TEST_COVERAGE=true bundle exec rake")
@@ -7,10 +9,6 @@ def runTests() {
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-    stage("rubylinter") {
-      govuk.rubyLinter("app bin config features Gemfile lib spec")
-    }
 
     stage('Tests') {
       runTests()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ node {
 
     stage('Checkout') {
       checkout scm
-      govuk.cleanupGit()
       govuk.mergeMasterBranch()
       govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,10 +21,6 @@ node {
       checkout scm
     }
 
-    stage('Bundle') {
-      govuk.bundleApp()
-    }
-
     stage("rubylinter") {
       govuk.rubyLinter("app bin config features Gemfile lib spec")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ def runTests() {
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  try {
     govuk.initializeParameters([
       'IS_SCHEMA_TEST': 'false',
       'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
@@ -28,12 +27,4 @@ node {
     stage('Tests') {
       runTests()
     }
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  govuk.buildProject()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,5 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = 'manuals-publisher'
-
 def runTests() {
   echo 'Running tests'
   sh("TEST_COVERAGE=true bundle exec rake")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,6 @@ def runTests() {
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  properties([
-  ])
-
   try {
     govuk.initializeParameters([
       'IS_SCHEMA_TEST': 'false',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,13 +3,6 @@
 REPOSITORY = 'manuals-publisher'
 DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
-// local overrides for govuk methods.
-// because < Rails 5
-def setupDb() {
-  echo 'Setting up database'
-  sh('RAILS_ENV=test bundle exec rake db:drop db:create db:environment:set db:schema:load')
-}
-
 def runTests() {
   echo 'Running tests'
   sh("TEST_COVERAGE=true bundle exec rake")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,6 @@ node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   properties([
-    buildDiscarder(
-      logRotator(numToKeepStr: '10')
-      ),
-    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
     [$class: 'ThrottleJobProperty',
       categories: [],
       limitOneJobWithMatchingParams: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,17 +12,6 @@ node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   properties([
-    [$class: 'ParametersDefinitionProperty',
-      parameterDefinitions: [
-        [$class: 'BooleanParameterDefinition',
-          name: 'IS_SCHEMA_TEST',
-          defaultValue: false,
-          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
-        [$class: 'StringParameterDefinition',
-          name: 'SCHEMA_BRANCH',
-          defaultValue: DEFAULT_SCHEMA_BRANCH,
-          description: 'The branch of govuk-content-schemas to test against']]
-    ],
   ])
 
   try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ node {
 
     stage('Checkout') {
       checkout scm
-      govuk.mergeMasterBranch()
       govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,13 @@
 #!/usr/bin/env groovy
 
 // TODO: Call govuk.rubyLinter("app bin config features Gemfile lib spec")
-// TODO: RUn tests with TEST_COVERAGE env var set to `true`
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(sassLint: false)
+  govuk.buildProject(
+    sassLint: false,
+    beforeTest: {
+      govuk.setEnvar("TEST_COVERAGE", "true")
+    }
+  )
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,10 +10,6 @@ def runTests() {
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-    stage('Checkout') {
-      checkout scm
-    }
-
     stage("rubylinter") {
       govuk.rubyLinter("app bin config features Gemfile lib spec")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,6 @@ node {
 
     stage('Checkout') {
       checkout scm
-      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
-      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 
     stage('Bundle') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,14 +12,6 @@ node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   properties([
-    [$class: 'ThrottleJobProperty',
-      categories: [],
-      limitOneJobWithMatchingParams: true,
-      maxConcurrentPerNode: 1,
-      maxConcurrentTotal: 0,
-      paramsToUseForLimit: 'manuals-publisher',
-      throttleEnabled: true,
-      throttleOption: 'category'],
     [$class: 'ParametersDefinitionProperty',
       parameterDefinitions: [
         [$class: 'BooleanParameterDefinition',


### PR DESCRIPTION
The `Jenkinsfile` contained a lot of custom code that is now available within the [`govuk_jenkinslib.groovy` shared library](https://github.com/alphagov/govuk-puppet/blob/c439fe32a2c0aebf2b0941f3cab4960d2f183ae5/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy). By changing our `Jenkinsfile` to rely on the `govuk.buildProject()` function within this library, we can take advantage of the latest developments and be more consistent with other projects.

I've made the changes to the `Jenkinsfile` in a step-by-step fashion in order to use the commit notes to document why particular bits of code are no longer necessary. Thus the `Jenkinsfile` is not left in a working state until the penultimate commit.

The change in this PR should mean that the "Run tests" stage is locked via the "Lockable Resources" Jenkins plugin so that only one build can run its tests on a given CI agent at one time. See the commit titled "Remove ThrottleJobProperty from Jenkinsfile" and [this PR](https://github.com/alphagov/govuk-puppet/pull/5641) for details. Hopefully this should fix #898.

Note that I haven't resolved the Ruby linting TODO added in the "Remove call to govuk.rubyLinter() from Jenkinsfile" commit, but I'm not sure it's worth delaying getting this PR merged. I think we could address it separately.