### PR TITLE
Revert "Merge pull request #929 from alphagov/upgrade-mongoid-to-3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "3.2.22.3"
 
 # Alphabetical order please :)
 gem "airbrake", "~> 4.3"
+gem "bson_ext", "1.12.1"
 gem "faraday", "0.9.0"
 gem "fetchable", "1.0.0"
 gem "gds-sso", "~> 11.0" # can't go higher because govuk_content_models needs this version (also > 12 need rails 4+)
@@ -11,7 +12,7 @@ gem "generic_form_builder", "0.11.0"
 gem "govuk_admin_template", "~> 4.0" # higher versions require rails 4
 gem "kaminari", "0.16.1"
 gem "logstasher", "0.4.8"
-gem "mongoid", "~> 3.0"
+gem "mongoid", "~> 2.5"
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code"
 gem "multi_json", "1.10.0"
 gem "plek", "1.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
+    bson (1.12.5)
+    bson_ext (1.12.1)
+      bson (~> 1.12.1)
     builder (3.0.4)
     byebug (9.0.6)
     capybara (2.12.0)
@@ -187,12 +190,12 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mongoid (3.1.7)
-      activemodel (~> 3.2)
-      moped (~> 1.4)
-      origin (~> 1.0)
-      tzinfo (~> 0.3.29)
-    moped (1.5.3)
+    mongo (1.12.5)
+      bson (= 1.12.5)
+    mongoid (2.8.1)
+      activemodel (~> 3.1)
+      mongo (~> 1.9)
+      tzinfo (~> 0.3.22)
     multi_json (1.10.0)
     multi_test (0.1.2)
     multi_xml (0.6.0)
@@ -215,7 +218,6 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    origin (1.1.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     phantomjs (2.1.1.0)
@@ -384,6 +386,7 @@ DEPENDENCIES
   awesome_print
   better_errors
   binding_of_caller
+  bson_ext (= 1.12.1)
   cucumber (~> 2.2.0)
   cucumber-rails (~> 1.4.0)
   database_cleaner
@@ -403,7 +406,7 @@ DEPENDENCIES
   kaminari (= 0.16.1)
   launchy
   logstasher (= 0.4.8)
-  mongoid (~> 3.0)
+  mongoid (~> 2.5)
   mongoid_rails_migrations!
   multi_json (= 1.10.0)
   phantomjs (>= 1.9.7.1)

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -12,7 +12,7 @@ class ManualRecord
     autosave: true
 
   def self.find_by(attributes)
-    where(attributes).first
+    first(conditions: attributes)
   end
 
   def self.find_by_organisation(organisation_slug)

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -4,9 +4,9 @@ class SectionEdition
   include Mongoid::Document
   include Mongoid::Timestamps
 
-  store_in collection: "manual_section_editions"
+  store_in "manual_section_editions"
 
-  field :section_id,           type: String
+  field :section_id,          type: String
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String
@@ -39,9 +39,9 @@ class SectionEdition
 
   scope :with_slug_prefix, ->(slug) { where(slug: /^#{slug}.*/) }
 
-  index section_id: 1
-  index state: 1
-  index updated_at: 1
+  index "section_id"
+  index "state"
+  index "updated_at"
 
   def build_attachment(attributes)
     attachments.build(

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,93 +1,19 @@
 development:
-  # Configure available database sessions. (required)
-  sessions:
-    # Defines the default session. (required)
-    default:
-      # Defines the name of the default database that Mongoid can connect to.
-      # (required).
-      # database: manuals_publisher_development
-      # Provides the hosts the default session can connect to. Must be an array
-      # of host:port pairs. (required)
-      # hosts:
-      #  - localhost:27017
-      uri: 'mongodb://localhost/govuk_content_development'
-      options:
-        # Change whether the session persists in safe mode by default.
-        # (default: false)
-        safe: true
+  uri: 'mongodb://localhost'
+  database: govuk_content_development
+  persist_in_safe_mode: true
+  autocreate_indexes: true
 
-        # Change the default consistency model to :eventual or :strong.
-        # :eventual will send reads to secondaries, :strong sends everything
-        # to master. (default: :eventual)
-        # consistency: :eventual
-
-        # How many times Moped should attempt to retry an operation after
-        # failure. (default: 30)
-        # max_retries: 30
-
-        # The time in seconds that Moped should wait before retrying an
-        # operation on failure. (default: 1)
-        # retry_interval: 1
-  # Configure Mongoid specific options. (optional)
-  options:
-    # Configuration for whether or not to allow access to fields that do
-    # not have a field definition on the model. (default: true)
-    # allow_dynamic_fields: true
-
-    # Enable the identity map, needed for eager loading. (default: false)
-    # identity_map_enabled: false
-
-    # Includes the root model name in json serialization. (default: false)
-    # include_root_in_json: false
-
-    # Include the _type field in serializaion. (default: false)
-    # include_type_for_serialization: false
-
-    # Preload all models in development, needed when models use
-    # inheritance. (default: false)
-    # preload_models: false
-
-    # Protect id and type from mass assignment. (default: true)
-    # protect_sensitive_fields: true
-
-    # Raise an error when performing a #find and the document is not found.
-    # (default: true)
-    # raise_not_found_error: true
-
-    # Raise an error when defining a scope with the same name as an
-    # existing method. (default: false)
-    # scope_overwrite_exception: false
-
-    # Skip the database version check, used when connecting to a db without
-    # admin access. (default: false)
-    # skip_version_check: false
-
-    # User Active Support's time zone in conversions. (default: true)
-    # use_activesupport_time_zone: true
-
-    # Ensure all times are UTC in the app side. (default: false)
-    # use_utc: false
 test:
-  sessions:
-    default:
-      # Don't want this interfering with a concurrent publisher/content_api test run
-      # database: manuals_publisher_test
-      # hosts:
-      #   - localhost:27017
-      uri: 'mongodb://localhost/govuk_content_manuals_publisher_test'
-      options:
-        consistency: :strong
-        # In the test environment we lower the retries and retry interval to
-        # low amounts for fast failures.
-        max_retries: 1
-        retry_interval: 0
+  uri: 'mongodb://localhost'
+  # Don't want this interfering with a concurrent publisher/content_api test run
+  database: govuk_content_manuals_publisher_test
+  autocreate_indexes: true
 
 production:
-  sessions:
-    default:
-      uri: <%= ENV['MONGODB_URI'] %>
-      options:
-        logger: false
-        use_activesupport_time_zone: true
-        refresh_interval: 120
-        refresh_mode: :sync
+  uri: <%= ENV['MONGODB_URI'] %>
+  database: govuk_content_production
+  refresh_mode: :sync
+  logger: false
+  refresh_interval: 120
+  use_activesupport_time_zone: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
   end
 
   factory :section_edition do
-    section_id { Moped::BSON::ObjectId.new }
+    section_id { BSON::ObjectId.new }
     sequence(:slug) { |n| "test-section-edition-#{n}" }
     sequence(:title) { |n| "Test Section Edition #{n}" }
     summary "My summary"

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -169,8 +169,8 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       title: log.title,
       version_number: log.version_number,
       change_note: log.change_note,
-      created_at: log.created_at.to_i,
-      updated_at: log.updated_at.to_i,
+      created_at: log.created_at,
+      updated_at: log.updated_at,
     }
   end
 
@@ -180,8 +180,8 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       title: section_edition.title,
       version_number: section_edition.version_number,
       change_note: section_edition.change_note,
-      created_at: expected_time.to_i,
-      updated_at: expected_time.to_i
+      created_at: expected_time,
+      updated_at: expected_time
     }
   end
 end


### PR DESCRIPTION
This reverts commit 5eb24945c170ee9ad12df8e0ce3aaba4727dd191, reversing
changes made to a73ed988c8d9f5087aa4694a7a3bbb0f4a02243f.

I ran `git revert -m1 5eb24945c170ee9ad12df8e0ce3aaba4727dd191` to
reverse the changes that were merged in PR #929.

This is because we've realised that the upgrade to Mongoid 3 is causing
problems with the app in integration: the /manuals index page is now
very slow to load and there seems to be a problem with creating a new
manual in that we see an error saying "Manual not found".

We're reverting while to give us more time to investigate these
problems.