### PR TITLE
Reduce number of references to manual repositories outside Manual class (part 4)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  rescue_from("ManualRepository::NotFoundError") do
+  rescue_from("Manual::NotFoundError") do
     redirect_to(manuals_path, flash: { error: "Manual not found" })
   end
 

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -21,8 +21,12 @@ class Manual
 
   attr_accessor :sections, :removed_sections
 
+  NotFoundError = Module.new
+
   def self.find(id, user)
     ManualRepository.new(user.manual_records).fetch(id)
+  rescue KeyError => e
+    raise e.extend(NotFoundError)
   end
 
   def self.all(user)

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -4,20 +4,12 @@ require 'manual'
 class ManualRepository
   include Fetchable
 
-  NotFoundError = Module.new
-
   def initialize(collection)
     @collection = collection
     @association_marshallers = [
       SectionAssociationMarshaller.new,
       ManualPublishTaskAssociationMarshaller.new
     ]
-  end
-
-  def fetch(*args, &block)
-    super
-  rescue KeyError => e
-    raise e.extend(NotFoundError)
   end
 
   def store(manual)

--- a/app/repositories/versioned_manual_repository.rb
+++ b/app/repositories/versioned_manual_repository.rb
@@ -1,7 +1,5 @@
-require "manual_repository"
-
 class VersionedManualRepository
-  class NotFoundError < StandardError; include ManualRepository::NotFoundError; end
+  class NotFoundError < StandardError; include Manual::NotFoundError; end
 
   def get_manual(manual_id)
     manual_record = ManualRecord.find_by(manual_id: manual_id)

--- a/app/services/republish_manual_service.rb
+++ b/app/services/republish_manual_service.rb
@@ -48,9 +48,5 @@ private
 
   def manual_versions
     @manual_versions ||= Manual.find(manual_id, context.current_user).current_versions
-  rescue ManualRepository::NotFoundError => error
-    raise ManualNotFoundError.new(error)
   end
-
-  class ManualNotFoundError < StandardError; end
 end

--- a/spec/repositories/versioned_manual_repository_spec.rb
+++ b/spec/repositories/versioned_manual_repository_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe VersionedManualRepository do
 
   context "when the provided id doesn't refer to a manual" do
     it "raises a Not Found error" do
-      expect { subject.get_manual("i-dont-exist") }.to raise_error(ManualRepository::NotFoundError)
+      expect { subject.get_manual("i-dont-exist") }.to raise_error(Manual::NotFoundError)
     end
   end
 

--- a/spec/services/republish_manual_service_spec.rb
+++ b/spec/services/republish_manual_service_spec.rb
@@ -113,19 +113,15 @@ RSpec.describe RepublishManualService do
   end
 
   context "(for a manual that doesn't exist)" do
+    let(:arbitrary_exception) { Class.new(StandardError) }
+
     before do
       allow(manual).to receive(:current_versions)
-        .and_raise(VersionedManualRepository::NotFoundError.new("uh-oh!"))
-    end
-
-    it "raises an exception" do
-      expect {
-        subject.call
-      }.to raise_error(RepublishManualService::ManualNotFoundError)
+        .and_raise(arbitrary_exception)
     end
 
     it "tells none of the listeners to do anything" do
-      begin; subject.call; rescue(RepublishManualService::ManualNotFoundError); end
+      begin; subject.call; rescue(arbitrary_exception); end
       expect(publishing_api_draft_exporter).not_to have_received(:call)
       expect(publishing_api_publisher).not_to have_received(:call)
       expect(rummager_exporter).not_to have_received(:call)


### PR DESCRIPTION
This follows on from #953, #954 & #956 and is a further effort at reducing the number of places which depend on the various manual repositories.

After these changes, I think the various manual repositories are only referred to from within `Manual` or within the repository classes themselves.