### PR TITLE
Use strong consistency in production Mongoid config

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -91,3 +91,4 @@ production:
         use_activesupport_time_zone: true
         refresh_interval: 120
         refresh_mode: :sync
+        consistency: :strong


### PR DESCRIPTION
This appears to solve the problems we've been seeing in integration:

1. Visiting /manuals was occassionally resulting in a 504 Gateway
Timeout error.

2. Creating a new manual would display a "Manual not found" error
message.

I was able to replicate/illustrate these problems in the Rails console
using the following code snippets:

1. `started_at = Time.now; manuals = ListManualsService.new(context:
OpenStruct.new(current_user: User.gds_editor)).call; p manuals.count;
manuals.each { |m| [m.title, m.updated_at] }; finished_at =  Time.now; p
started_at - finished_at`

This would consistently take between 8 and 9 seconds prior to the
upgrade to Mongoid 3 and up to about 15 seconds afterwards.

2. `title = '1608'; manual = Manual.build(:title=>title,
:summary=>title, :body=>title,
:organisation_slug=>"government-digital-service",
:use_originally_published_at_for_public_timestamp=>"1");
manual.save(User.gds_editor); Manual.find(manual.id, User.gds_editor)`

This would succeed prior to the upgrade to Mongoid 3 and fail with a
"Manual not found" error afterwards.

Both of these problems appear to be solved by using strong consistency
in our Mongoid config. I have some confidence that this is a valid
change as it's the consistency model recommended in this blog post[1].

[1]: https://blog.mlab.com/2014/02/mongodb-driver-tips-tricks-mongoid-3/#By_default_Mongoid_reads_from_secondaries