### PR TITLE
Avoid loading manual associations on /manuals index page

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -29,8 +29,8 @@ class Manual
     raise e.extend(NotFoundError)
   end
 
-  def self.all(user)
-    ManualRepository.new(user.manual_records).all
+  def self.all(user, load_associations: true)
+    ManualRepository.new(user.manual_records).all(load_associations: load_associations)
   end
 
   def self.build(attributes)

--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -39,9 +39,9 @@ class ManualRepository
     build_manual_for(manual_record)
   end
 
-  def all
+  def all(load_associations: true)
     collection.all_by_updated_at.lazy.map { |manual_record|
-      build_manual_for(manual_record)
+      build_manual_for(manual_record, load_associations: load_associations)
     }
   end
 
@@ -67,7 +67,7 @@ private
     }
   end
 
-  def build_manual_for(manual_record)
+  def build_manual_for(manual_record, load_associations: true)
     edition = manual_record.latest_edition
 
     base_manual = Manual.new(
@@ -85,8 +85,12 @@ private
       use_originally_published_at_for_public_timestamp: edition.use_originally_published_at_for_public_timestamp,
     )
 
-    manual_with_sections = add_sections_to_manual(base_manual, edition)
-    add_publish_tasks_to_manual(manual_with_sections)
+    if load_associations
+      manual_with_sections = add_sections_to_manual(base_manual, edition)
+      add_publish_tasks_to_manual(manual_with_sections)
+    else
+      base_manual
+    end
   end
 
   def add_sections_to_manual(manual, edition)

--- a/app/services/list_manuals_service.rb
+++ b/app/services/list_manuals_service.rb
@@ -4,7 +4,7 @@ class ListManualsService
   end
 
   def call
-    Manual.all(context.current_user)
+    Manual.all(context.current_user, load_associations: false)
   end
 
 private

--- a/spec/services/list_manuals_service_spec.rb
+++ b/spec/services/list_manuals_service_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "list_manuals_service"
+
+RSpec.describe ListManualsService do
+  let(:user) { double(:user) }
+  let(:context) { double(:context, current_user: user) }
+
+  subject {
+    ListManualsService.new(
+      context: context,
+    )
+  }
+
+  it 'loads all manuals for the user' do
+    expect(Manual).to receive(:all).with(user, anything)
+
+    subject.call
+  end
+
+  it 'avoids loading manual associations' do
+    expect(Manual).to receive(:all).with(anything, load_associations: false)
+
+    subject.call
+  end
+end


### PR DESCRIPTION
This reduces the time taken to render the manuals index page in the
production environment (see below for detail).

The commit essentially reverts part of change introduced in
5ca58c0028e19967ad41d5770318d5017a569620 in that we're no longer loading
all associated objects when we list the manuals on the index page.

I've added a test to ensure that the `ListManualsService` passes the
`load_associations: false` option to `Manual.all`. I haven't added any
other tests as I'm not entirely convinced it's currently worth the
effort given that the code is changing so much.

---

The following information/notes explain why I'm now confident that this
is the change that was causing the timeouts we're seeing in integration.

I'd previously concluded it was the upgrade to Mongoid 3 that caused the
timeout problem but I'm now less convinced about that. I came to this
conclusion by refreshing the /manuals index page in integration and
observing the logs in Kibana. I no longer think that was a reliable test
as I couldn't be sure that my web requests were hitting the recently
deployed versions of the app.

I decided that using the Rails console would give me better results as I
could be sure that I was executing code against the version of the app
I'd just deployed.

I used the following code snippet to act as a proxy for what's happening
when we render the manuals index page:

```
started_at = Time.now; manuals = ListManualsService.new(context:
OpenStruct.new(current_user: User.new.tap { |u| u.permissions =
[PermissionChecker::GDS_EDITOR_PERMISSION] })).call; p manuals.count;
manuals.each { |m| [m.title, m.updated_at] }; finished_at =  Time.now; p
finished_at - started_at
```

I deployed the following branches/tags to production to determine the
change that caused the /manuals index page to start timing out.

== deployed-to-production / release_827

The deployed-to-production branch points at commit
0342ed7ae6ff7a7fe5e870e56b222f5bedda0e55 which corresponds to
release_827.

This is currently deployed to staging and production and appears to be
working as expected.

110, 7.428941204
110, 6.391503865
110, 5.641936134

---

== release_832

This is the release prior to the one containing the change to load the
associated objects of all manuals on the index page.

110, 2.969133477
110, 2.88170978
110, 3.081761473

---

== release_833

This contains the merged PR #953. PR #953 contains commit
5ca58c0028e19967ad41d5770318d5017a569620 which changes the behaviour to
load the associated objects of all the manuals displayed on the index
page.

I ran this 5 times as the first 2 looked out of the ordinary - maybe
something else was going on to affect those times.

Observe that it's now taking a significantly longer time to load the
manuals than it was in release_827 and release_832.

110, 46.9977825
110, 22.854657022
110, 12.166397422
110, 12.723151024
110, 12.077897643

---

== release_840

This contains the upgrade to Mongoid 3.

110, 11.063716662
110, 11.086351544
110, 11.330133596

Observe that the time taken to load the manuals hasn't really changed
since release_833.

---

== release_845

This contains the change to strong consistency. I ran it five times as
the first two results looked out of the ordinary.

Observe that the time taken to load the manuals hasn't really changed
since release_833 or release_840.

110, 15.278262365
110, 28.546912397
110, 11.071549517
110, 10.495581227
110, 10.331643994

---

== avoid-loading-all-manual-associations-on-index-page

Essentially reverts the behaviour introduced in
5ca58c0028e19967ad41d5770318d5017a569620 which meant that we were
loading all associations for all manuals displayed on the index page.

Observe that the time taken to load the manuals has been significantly
reduced and looks similar to the times we see with release_832.

110, 4.282290557
110, 3.541622623
110, 3.939321374