### PR TITLE
Remove unused `factory` attribute from ManualRepository

### DIFF
--- a/app/repositories/manual_repository.rb
+++ b/app/repositories/manual_repository.rb
@@ -54,7 +54,7 @@ class ManualRepository
 
 private
 
-  attr_reader :collection, :factory
+  attr_reader :collection
 
   def attributes_for(manual)
     {


### PR DESCRIPTION
This should've been removed as part of [this commit][1].

[1]: 90343f30359d2ab0c157b8793e843576a7403473