### PR TITLE
Convert rebuild major publication logs for manuals script to rake task

### DIFF
--- a/bin/rebuild_major_publication_logs_for_manuals
+++ b/bin/rebuild_major_publication_logs_for_manuals
@@ -1,21 +1,3 @@
 #!/usr/bin/env ruby
 
-require File.expand_path("../../config/environment", __FILE__)
-require "manual_publication_log_filter"
-require "logger"
-
-logger = Logger.new(STDOUT)
-logger.formatter = Logger::Formatter.new
-
-manual_records = ManualRecord.all
-count = manual_records.count
-
-logger.info "Deleting publication logs and rebuilding for major updates only for #{count} manuals"
-
-manual_records.to_a.each.with_index(1) do |manual, i|
-  manual_publication_log_filter = ManualPublicationLogFilter.new(manual)
-  logger.info("[% 3d/% 3d] id=%s slug=%s" % [i, count, manual.id, manual.slug])
-  manual_publication_log_filter.delete_logs_and_rebuild_for_major_updates_only!
-end
-
-logger.info "Rebuilding of publication logs complete."
+puts "The script is now a rake task: `rake rebuild_major_publication_logs_for_manuals`"

--- a/lib/tasks/rebuild_major_publication_logs_for_manuals.rake
+++ b/lib/tasks/rebuild_major_publication_logs_for_manuals.rake
@@ -1,0 +1,21 @@
+require "manual_publication_log_filter"
+require "logger"
+
+desc "Rebuild major publication logs for manuals"
+task rebuild_major_publication_logs_for_manuals: [:environment] do
+  logger = Logger.new(STDOUT)
+  logger.formatter = Logger::Formatter.new
+
+  manual_records = ManualRecord.all
+  count = manual_records.count
+
+  logger.info "Deleting publication logs and rebuilding for major updates only for #{count} manuals"
+
+  manual_records.to_a.each.with_index(1) do |manual, i|
+    manual_publication_log_filter = ManualPublicationLogFilter.new(manual)
+    logger.info("[% 3d/% 3d] id=%s slug=%s" % [i, count, manual.id, manual.slug])
+    manual_publication_log_filter.delete_logs_and_rebuild_for_major_updates_only!
+  end
+
+  logger.info "Rebuilding of publication logs complete."
+end

--- a/lib/tasks/rebuild_major_publication_logs_for_manuals.rake
+++ b/lib/tasks/rebuild_major_publication_logs_for_manuals.rake
@@ -2,11 +2,16 @@ require "manual_publication_log_filter"
 require "logger"
 
 desc "Rebuild major publication logs for manuals"
-task rebuild_major_publication_logs_for_manuals: [:environment] do
+task :rebuild_major_publication_logs_for_manuals, [:slug] => :environment do |_, args|
   logger = Logger.new(STDOUT)
   logger.formatter = Logger::Formatter.new
 
-  manual_records = ManualRecord.all
+  manual_records = if args.has_key?(:slug)
+                     ManualRecord.where(slug: args[:slug])
+                   else
+                     ManualRecord.all
+                   end
+
   count = manual_records.count
 
   logger.info "Deleting publication logs and rebuilding for major updates only for #{count} manuals"


### PR DESCRIPTION
This PR converts the `bin/rebuild_major_publication_logs_for_manuals` to a rake task so that it can be run by Jenkins. 

We'd like to convert all scripts in `bin` to rake tasks eventually (#858) but in particular we need to run this one against a single manual in order to fix broken data caused by #970. 

0a7cf29 adds an optional parameter to the task so that it can be run against a single manual, e.g.

    rake rebuild_major_publication_logs_for_manuals["guidance/the-highway-code"]

