### PR TITLE
Convert republish manuals script to rake task

### DIFF
--- a/bin/republish_manuals
+++ b/bin/republish_manuals
@@ -1,11 +1,3 @@
 #!/usr/bin/env ruby
 
-require File.expand_path("../../config/environment", __FILE__)
-require "manuals_republisher"
-require "logger"
-
-logger = Logger.new(STDOUT)
-logger.formatter = Logger::Formatter.new
-
-republisher = ManualsRepublisher.new(logger)
-republisher.execute
+puts "This script is now a rake task: `rake republish_manuals`"

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module ManualsPublisher
 
     # These paths are non-standard (they are subdirectories of
     # app/models) so they need to be added to the autoload_paths
+    config.autoload_paths << "#{Rails.root}/app/exporters/formatters"
     config.autoload_paths << "#{Rails.root}/app/models/builders"
     config.autoload_paths << "#{Rails.root}/app/models/validators"
     config.autoload_paths << "#{Rails.root}/app/repositories/marshallers"

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -5,8 +5,7 @@ class ManualsRepublisher
     @logger = logger
   end
 
-  def execute
-    manual_records = ManualRecord.all
+  def execute(manual_records = ManualRecord.all)
     count = manual_records.count
 
     logger.info "Republishing #{count} manuals..."

--- a/lib/tasks/republish_manuals.rake
+++ b/lib/tasks/republish_manuals.rake
@@ -1,0 +1,11 @@
+require "manuals_republisher"
+require "logger"
+
+desc "Republish manuals"
+task republish_manuals: [:environment] do
+  logger = Logger.new(STDOUT)
+  logger.formatter = Logger::Formatter.new
+
+  republisher = ManualsRepublisher.new(logger)
+  republisher.execute
+end

--- a/lib/tasks/republish_manuals.rake
+++ b/lib/tasks/republish_manuals.rake
@@ -2,10 +2,16 @@ require "manuals_republisher"
 require "logger"
 
 desc "Republish manuals"
-task republish_manuals: [:environment] do
+task :republish_manuals, [:slug] => :environment do |_, args|
   logger = Logger.new(STDOUT)
   logger.formatter = Logger::Formatter.new
 
+  manual_records = if args.has_key?(:slug)
+                     ManualRecord.where(slug: args[:slug])
+                   else
+                     ManualRecord.all
+                   end
+
   republisher = ManualsRepublisher.new(logger)
-  republisher.execute
+  republisher.execute(manual_records)
 end


### PR DESCRIPTION
This PR converts the `bin/republish_manuals` to a rake task so that it can be run by Jenkins.

We'd like to convert all scripts in bin to rake tasks eventually (#858) but in particular we need to run this one against a single manual in order to fix broken data caused by #970.

cd3f711 adds an optional parameter to the task so that it can be run against a single manual, e.g.

    rake republish_manuals["guidance/the-highway-code"]