### PR TITLE
Add migration to fix Highway Code change note data

### DIFF
--- a/db/migrate/20170413112512_fix_change_note_data_for_the_highway_code.rb
+++ b/db/migrate/20170413112512_fix_change_note_data_for_the_highway_code.rb
@@ -1,0 +1,62 @@
+class FixChangeNoteDataForTheHighwayCode < Mongoid::Migration
+  def self.reset_change_note(section_slug, created_at)
+    SectionEdition.where(
+      slug: 'guidance/the-highway-code/' + section_slug,
+      created_at: created_at
+    ).each do |section_edition|
+      section_edition.update_attributes!(change_note: nil, minor_update: true)
+      edition_attributes = [
+        section_edition.id,
+        section_edition.title,
+        section_edition.created_at
+      ]
+      puts "Updated SectionEdition with attributes: #{edition_attributes.join(', ')}"
+    end
+  end
+
+  def self.up
+    created_at_0925 = Time.parse('2017-03-01 09:25:48')
+    created_at_1102 = Time.parse('2017-03-01 11:02:33')
+
+    reset_change_note 'road-users-requiring-extra-care-204-to-225',
+                      created_at_0925
+    reset_change_note 'road-users-requiring-extra-care-204-to-225',
+                      created_at_1102
+
+    reset_change_note 'signals-to-other-road-users',
+                      created_at_0925
+    reset_change_note 'signals-to-other-road-users',
+                      created_at_1102
+
+    reset_change_note 'signals-by-authorised-persons',
+                      created_at_0925
+    reset_change_note 'signals-by-authorised-persons',
+                      created_at_1102
+
+    reset_change_note 'road-markings',
+                      created_at_0925
+    reset_change_note 'road-markings',
+                      created_at_1102
+
+    reset_change_note 'vehicle-markings',
+                      created_at_0925
+    reset_change_note 'vehicle-markings',
+                      created_at_1102
+
+    reset_change_note 'annex-8-safety-code-for-new-drivers',
+                      created_at_0925
+    reset_change_note 'annex-8-safety-code-for-new-drivers',
+                      created_at_1102
+
+    # The annex-5-penalties don't have a SectionEdition created at 09:25.
+    # See https://github.com/alphagov/manuals-publisher/issues/861 for
+    # further information
+    reset_change_note 'annex-5-penalties',
+                      created_at_1102
+  end
+
+  def self.down
+    # We've intentionally left this blank.
+    # While feasible to reconstruct the data we've decided against it given the time it'll take and that it's already bad data.
+  end
+end


### PR DESCRIPTION
This is the first part of the fix for the problem described in issue
 #861.

There are unexpected updates listed for The Highway
Code[1] against 1 March 2017.

We expect to see "Annex 5 Penalties" with a single change described as
"Updated the penalty table to increase penalty points for using a
hand-held mobile phone when driving from 3 to 6.".

We're also seeing:

* Road users requiring extra care (204 to 225)
  * Updated Rule 209 to add an image of the school bus road sign.
* Signals to other road users
  * New section added.
* Signals by authorised persons
  * New section added.
* Road markings
  * New section added.
* Vehicle markings
  * New section added.
* Annex 8. Safety code for new drivers
  * Updated the Pass Plus email address to passplus@dvsa.gov.uk

For all the updates on 1 March 2017 we're seeing two identical change
notes, one with a timestamp of 2017-03-01T09:49:18Z and the other with a
timestamp of 2017-03-01T11:03:18Z.

The problem is due to duplicate "major update" `SectionEdition`s and
their change notes. The presence of these SectionEditions result in
"duplicate" `PublicationLog`s which are sent to the Publishing API as
change notes.

This migration updates the affected `SectionEdition`s to make them minor
changes and removes their changes notes.

We still need to rebuild the `PublicationLog`s and update the content in
the Publishing API but they will happen separately.

[1]: https://www.gov.uk/guidance/the-highway-code/updates