### PR TITLE
Only run CI build on instances with Mongodb 2.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 // TODO: Call govuk.rubyLinter("app bin config features Gemfile lib spec")
 
-node {
+node('mongodb-2.4') {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
   govuk.buildProject(
     sassLint: false,


### PR DESCRIPTION
This commit ensures that the build runs on nodes with Mongodb 2.4
installed which should fix #898.

Some of the CI 'agent' nodes on the Jenkins server run a more recent
version of mongodb. By experimenting with rebuilding on Jenkins we've
noticed that when this application's build runs on `ci-agent-4`, which
is configured[1] to run mongodb 3.2 it fails[2], when it runs on
`ci-agent-1` through `ci-agent-3` it seems to pass.

Fixes: #898

[1] https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml#L639-L654
[2] https://github.com/alphagov/manuals-publisher/issues/898#issuecomment-288057880