### PR TITLE
Remove Publishing API v1 client

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -12,7 +12,7 @@ class ManualPublishingAPIExporter
   end
 
   def call
-    Services.publishing_api_v2.put_content(content_id, exportable_attributes)
+    Services.publishing_api.put_content(content_id, exportable_attributes)
   end
 
 private

--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -5,7 +5,7 @@ class ManualPublishingAPILinksExporter
   end
 
   def call
-    Services.publishing_api_v2.patch_links(content_id, exportable_attributes)
+    Services.publishing_api.patch_links(content_id, exportable_attributes)
   end
 
 private

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,6 +1,6 @@
 class PublishingApiDraftSectionDiscarder
   def call(section, _manual)
-    Services.publishing_api_v2.discard_draft(section.id)
+    Services.publishing_api.discard_draft(section.id)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end
 end

--- a/app/exporters/publishing_api_manual_with_sections_publisher.rb
+++ b/app/exporters/publishing_api_manual_with_sections_publisher.rb
@@ -20,14 +20,10 @@ class PublishingApiManualWithSectionsPublisher
     manual.removed_sections.each do |section|
       next if section.withdrawn? && action != :republish
       begin
-        publishing_api_v2.unpublish(section.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+        Services.publishing_api_v2.unpublish(section.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
       rescue GdsApi::HTTPNotFound # rubocop:disable Lint/HandleExceptions
       end
       section.withdraw_and_mark_as_exported! if action != :republish
     end
-  end
-
-  def publishing_api_v2
-    Services.publishing_api_v2
   end
 end

--- a/app/exporters/publishing_api_manual_with_sections_publisher.rb
+++ b/app/exporters/publishing_api_manual_with_sections_publisher.rb
@@ -20,7 +20,7 @@ class PublishingApiManualWithSectionsPublisher
     manual.removed_sections.each do |section|
       next if section.withdrawn? && action != :republish
       begin
-        Services.publishing_api_v2.unpublish(section.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+        Services.publishing_api.unpublish(section.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
       rescue GdsApi::HTTPNotFound # rubocop:disable Lint/HandleExceptions
       end
       section.withdraw_and_mark_as_exported! if action != :republish

--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -8,7 +8,7 @@ class PublishingAPIPublisher
   end
 
   def call
-    Services.publishing_api_v2.publish(entity.id, update_type)
+    Services.publishing_api.publish(entity.id, update_type)
   end
 
 private

--- a/app/exporters/publishing_api_withdrawer.rb
+++ b/app/exporters/publishing_api_withdrawer.rb
@@ -4,7 +4,7 @@ class PublishingAPIWithdrawer
   end
 
   def call
-    Services.publishing_api_v2.unpublish(content_id, exportable_attributes)
+    Services.publishing_api.unpublish(content_id, exportable_attributes)
   end
 
 private

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -13,7 +13,7 @@ class SectionPublishingAPIExporter
   end
 
   def call
-    Services.publishing_api_v2.put_content(content_id, exportable_attributes)
+    Services.publishing_api.put_content(content_id, exportable_attributes)
   end
 
 private

--- a/app/exporters/section_publishing_api_links_exporter.rb
+++ b/app/exporters/section_publishing_api_links_exporter.rb
@@ -6,7 +6,7 @@ class SectionPublishingAPILinksExporter
   end
 
   def call
-    Services.publishing_api_v2.patch_links(content_id, exportable_attributes)
+    Services.publishing_api.patch_links(content_id, exportable_attributes)
   end
 
 private

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -96,13 +96,9 @@ private
 
   def discard_draft_from_publishing_api(content_id)
     begin
-      publishing_api_v2.discard_draft(content_id)
+      Services.publishing_api_v2.discard_draft(content_id)
     rescue GdsApi::HTTPNotFound
       log "Draft for #{content_id} already discarded."
     end
-  end
-
-  def publishing_api_v2
-    Services.publishing_api_v2
   end
 end

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -96,7 +96,7 @@ private
 
   def discard_draft_from_publishing_api(content_id)
     begin
-      Services.publishing_api_v2.discard_draft(content_id)
+      Services.publishing_api.discard_draft(content_id)
     rescue GdsApi::HTTPNotFound
       log "Draft for #{content_id} already discarded."
     end

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -16,7 +16,7 @@ class DuplicateDraftDeleter
 private
 
   def publishing_api
-    Services.publishing_api_v2
+    Services.publishing_api
   end
 
   def in_publishing_api?(content_id)

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -227,7 +227,7 @@ private
   end
 
   def publishing_api
-    Services.publishing_api_v2
+    Services.publishing_api
   end
 
   def fetch_organisation(slug)

--- a/lib/marked_section_deleter.rb
+++ b/lib/marked_section_deleter.rb
@@ -36,7 +36,7 @@ class MarkedSectionDeleter
   end
 
   def publishing_api
-    Services.publishing_api_v2
+    Services.publishing_api
   end
 
   def in_publishing_api?(content_id)

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -64,7 +64,7 @@ private
 
   def redirect_section
     PublishingAPIRedirecter.new(
-      publishing_api: Services.publishing_api_v2,
+      publishing_api: Services.publishing_api,
       entity: current_section_edition,
       redirect_to_location: "/#{full_new_section_slug}"
     ).call

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -21,14 +21,6 @@ module Services
     @organisations ||= GdsApi::Organisations.new(Plek.find("whitehall-admin"))
   end
 
-  def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(
-      Plek.find("publishing-api"),
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
-      timeout: 30
-    )
-  end
-
   def self.publishing_api_v2
     @publishing_api_v2 ||= GdsApi::PublishingApiV2.new(
       Plek.find("publishing-api"),

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -21,8 +21,8 @@ module Services
     @organisations ||= GdsApi::Organisations.new(Plek.find("whitehall-admin"))
   end
 
-  def self.publishing_api_v2
-    @publishing_api_v2 ||= GdsApi::PublishingApiV2.new(
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
     )

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -100,7 +100,7 @@ describe ManualPublishingAPIExporter do
   }
 
   before {
-    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api).and_return(publishing_api)
     allow(ManualRenderer).to receive(:new).and_return(manual_renderer)
     allow(PublicationLog).to receive(:change_notes_for).and_return(publication_logs)
   }

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -41,7 +41,7 @@ describe ManualPublishingAPILinksExporter do
   }
 
   before {
-    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api).and_return(publishing_api)
   }
 
   it "exports links for the manual" do

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -38,7 +38,7 @@ describe PublishingAPIPublisher do
 
   describe "#call" do
     before {
-      allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+      allow(Services).to receive(:publishing_api).and_return(publishing_api)
     }
 
     context "when no explicit update_type is given" do

--- a/spec/exporters/publishing_api_withdrawer_spec.rb
+++ b/spec/exporters/publishing_api_withdrawer_spec.rb
@@ -5,7 +5,7 @@ describe PublishingAPIWithdrawer do
     publishing_api = double(:publishing_api, unpublish: nil)
     entity = double(:entity, id: 'content-id')
     withdrawer = PublishingAPIWithdrawer.new(entity: entity)
-    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api).and_return(publishing_api)
 
     withdrawer.call
 

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -80,7 +80,7 @@ describe SectionPublishingAPIExporter do
   }
 
   before {
-    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api).and_return(publishing_api)
     allow(SectionRenderer).to receive(:new).and_return(section_renderer)
   }
 

--- a/spec/exporters/section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_links_exporter_spec.rb
@@ -44,7 +44,7 @@ describe SectionPublishingAPILinksExporter do
   }
 
   before {
-    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api).and_return(publishing_api)
   }
 
   it "exports links for the section" do

--- a/spec/lib/marked_section_deleter_spec.rb
+++ b/spec/lib/marked_section_deleter_spec.rb
@@ -9,7 +9,7 @@ describe MarkedSectionDeleter do
   let(:publishing_api) { double(:publishing_api) }
 
   before {
-    allow(Services).to receive(:publishing_api_v2).and_return(publishing_api)
+    allow(Services).to receive(:publishing_api).and_return(publishing_api)
   }
 
   context "when edition is marked for deletion but isn't in publishing api" do


### PR DESCRIPTION
This removes `Services.publishing_api` and renames `Services.publishing_api_v2` to `Services.publishing_api` now that we're only using a single version of the Publishing API.

This address issue #809.