### PR TITLE
Remove outdated info about removing draft manual section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,3 @@ $ sudo -u deploy govuk_setenv manuals-publisher ./bin/delete_draft_manual slug-t
 ```
 
 This would need to be run on one of the backend boxes.
-
-### Removing a draft manual section
-
-If a manual section (also known as a ‘manual document’) has been created in draft but never been published, it can be removed using the `remove_draft_manual_section script`. On one of the backend boxes, run:
-
-```
-$ cd /var/apps/manuals-publisher
-$ sudo -u deploy govuk_setenv manuals-publisher ./bin/remove_draft_manual_section manual_id section_id
-```
-
-The `manual_id` and `section_id` can easily be found in the URL for the manual section, like so `/manuals/<manual_id>/sections/<section_id>?id=<section_id>&manual_id=<manual_id>`


### PR DESCRIPTION
The script mentioned in this section (`remove_draft_manual_section`) was
removed in 654ca53b35be6c3b547df1be8f3e2e5518e31ec6 after the
functionality had been added to the user interface.

I considered updating the README to explain that this could now be
achieved using the UI but felt that it was somewhat unnecessary.

This addresses issue #946.