### PR TITLE
Remove ManualRecord.find_by_organisation

### DIFF
--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -15,10 +15,6 @@ class ManualRecord
     where(attributes).first
   end
 
-  def self.find_by_organisation(organisation_slug)
-    where(organisation_slug: organisation_slug)
-  end
-
   def self.all_by_updated_at
     order_by([:updated_at, :desc])
   end

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -79,20 +79,6 @@ describe ManualRecord, hits_db: true do
     end
   end
 
-  describe "#find_by_organisation" do
-    let!(:org_1_manual) {
-      ManualRecord.create!(organisation_slug: "org-1")
-    }
-
-    let!(:org_2_manual) {
-      ManualRecord.create!(organisation_slug: "org-2")
-    }
-
-    it "filters by organisation" do
-      expect(ManualRecord.find_by_organisation("org-1").to_a).to eq([org_1_manual])
-    end
-  end
-
   describe "#all_by_updated_at" do
     let!(:middle_edition) {
       ManualRecord.create!(updated_at: 2.days.ago)


### PR DESCRIPTION
The last call to this method was removed in 8406743 so the method can
be removed.