### PR TITLE
Remove section renderer

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -71,7 +71,6 @@ class SectionsController < ApplicationController
 
   def preview
     service = Section::PreviewService.new(
-      section_renderer: SectionRenderer.new,
       context: self,
     )
     section = service.call

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -112,7 +112,7 @@ private
   end
 
   def rendered_section_attributes
-    @rendered_section_attributes ||= SectionRenderer.new.call(section).attributes
+    @rendered_section_attributes ||= Section::PreviewService.new(context: nil).render(section).attributes
   end
 
   def organisation_info

--- a/app/lib/section_renderer.rb
+++ b/app/lib/section_renderer.rb
@@ -5,15 +5,5 @@ require "footnotes_section_heading_renderer"
 
 class SectionRenderer
   def call(doc)
-    pipeline = [
-      MarkdownAttachmentProcessor.method(:new),
-      SectionHeaderExtractor.create,
-      GovspeakToHTMLRenderer.create,
-      FootnotesSectionHeadingRenderer.create,
-    ]
-
-    pipeline.reduce(doc) { |current_doc, next_renderer|
-      next_renderer.call(current_doc)
-    }
   end
 end

--- a/app/lib/section_renderer.rb
+++ b/app/lib/section_renderer.rb
@@ -1,9 +1,0 @@
-require "markdown_attachment_processor"
-require "section_header_extractor"
-require "govspeak_to_html_renderer"
-require "footnotes_section_heading_renderer"
-
-class SectionRenderer
-  def call(doc)
-  end
-end

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -1,3 +1,8 @@
+require 'markdown_attachment_processor'
+require 'section_header_extractor'
+require 'govspeak_to_html_renderer'
+require 'footnotes_section_heading_renderer'
+
 class Section::PreviewService
   def initialize(context:)
     @section_renderer = SectionRenderer.new
@@ -11,7 +16,16 @@ class Section::PreviewService
   end
 
   def render(section)
-    section_renderer.call(section)
+    pipeline = [
+      MarkdownAttachmentProcessor.method(:new),
+      SectionHeaderExtractor.create,
+      GovspeakToHTMLRenderer.create,
+      FootnotesSectionHeadingRenderer.create,
+    ]
+
+    pipeline.reduce(section) { |current_section, next_renderer|
+      next_renderer.call(current_section)
+    }
   end
 
 private

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -1,6 +1,6 @@
 class Section::PreviewService
-  def initialize(section_renderer:, context:)
-    @section_renderer = section_renderer
+  def initialize(context:)
+    @section_renderer = SectionRenderer.new
     @context = context
   end
 

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -7,6 +7,10 @@ class Section::PreviewService
   def call
     section.update(section_params)
 
+    render(section)
+  end
+
+  def render(section)
     section_renderer.call(section)
   end
 

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -5,7 +5,6 @@ require 'footnotes_section_heading_renderer'
 
 class Section::PreviewService
   def initialize(context:)
-    @section_renderer = SectionRenderer.new
     @context = context
   end
 
@@ -30,10 +29,7 @@ class Section::PreviewService
 
 private
 
-  attr_reader(
-    :section_renderer,
-    :context,
-  )
+  attr_reader(:context)
 
   def section
     section_id ? existing_section : ephemeral_section

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -14,7 +14,8 @@ describe SectionPublishingAPIExporter do
   }
 
   let(:publishing_api) { double(:publishing_api, put_content: nil) }
-  let(:section_renderer) { ->(_) { double(:rendered_section, attributes: rendered_attributes) } }
+  let(:rendered_section) { double(:rendered_section, attributes: rendered_attributes) }
+  let(:section_preview_service) { double(:section_preview_service) }
 
   let(:organisation) {
     {
@@ -81,7 +82,8 @@ describe SectionPublishingAPIExporter do
 
   before {
     allow(Services).to receive(:publishing_api).and_return(publishing_api)
-    allow(SectionRenderer).to receive(:new).and_return(section_renderer)
+    allow(Section::PreviewService).to receive(:new).and_return(section_preview_service)
+    allow(section_preview_service).to receive(:render).with(section).and_return(rendered_section)
   }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do


### PR DESCRIPTION
Fixes #1021 

This PR removes the SectionRenderer class, putting the responsibility instead inside the Section::PreviewService. I think this is an improvement as it moves more of the functionality inside the service objects, but the fact that this service is called "Preview" and is used in the `SectionPublishingAPIExporter` makes me think it is either doing too much, or needs a different name. 