### PR TITLE
Display new section slug in ManualRelocator

### DIFF
--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -132,9 +132,8 @@ private
     new_section_ids.each do |section_id|
       sections = all_editions_of_section(section_id)
       sections.each do |section|
-        reslug_msg = "Reslugging section '#{section.slug}'"
         new_section_slug = section.slug.gsub(from_slug, to_slug)
-        puts "#{reslug_msg} as '#{section.slug}'"
+        puts "Reslugging section '#{section.slug}' as '#{section.slug}'"
         section.set(:slug, new_section_slug)
       end
     end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -133,7 +133,7 @@ private
       sections = all_editions_of_section(section_id)
       sections.each do |section|
         new_section_slug = section.slug.gsub(from_slug, to_slug)
-        puts "Reslugging section '#{section.slug}' as '#{section.slug}'"
+        puts "Reslugging section '#{section.slug}' as '#{new_section_slug}'"
         section.set(:slug, new_section_slug)
       end
     end


### PR DESCRIPTION
I'm fairly confident that this message should print the old
(`section.slug`) and new (`new_section_slug`) slugs instead of the
printing the old slug twice.

Have run the script I can see that the section slug is indeed updated to
`new_section_slug`.

This appears to have been incorrect since the `ManualRelocator` class
was added in 43b669600d3ddc30fd9fccb7bdbe1e4b4ecf9887.