### PR TITLE
Remove load path entries for builders & marshallers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,9 +30,7 @@ module ManualsPublisher
     # These paths are non-standard (they are subdirectories of
     # app/models) so they need to be added to the autoload_paths
     config.autoload_paths << "#{Rails.root}/app/exporters/formatters"
-    config.autoload_paths << "#{Rails.root}/app/models/builders"
     config.autoload_paths << "#{Rails.root}/app/models/validators"
-    config.autoload_paths << "#{Rails.root}/app/repositories/marshallers"
     config.autoload_paths << "#{Rails.root}/app/services/manual"
     config.autoload_paths << "#{Rails.root}/app/services/section"
     config.autoload_paths << "#{Rails.root}/app/services/attachment"


### PR DESCRIPTION
The last builder was removed in [this commit][1].

The last marshaller was removed in [this commit][2].

[1]: https://github.com/alphagov/manuals-publisher/commit/e99a62a5f3f1c449945bae652d77f2433a631a9a
[2]: https://github.com/alphagov/manuals-publisher/commit/7dcebeaeca971c4689c09219b8aea67d6731cbf7