### PR TITLE
Log PublishManualWorker errors to Rails log

### DIFF
--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -50,6 +50,7 @@ private
   end
 
   def log_error(error)
+    Rails.logger.error "#{self.class} error: #{error}"
     Airbrake.notify(error)
   end
 

--- a/spec/workers/publish_manual_worker_spec.rb
+++ b/spec/workers/publish_manual_worker_spec.rb
@@ -25,4 +25,27 @@ RSpec.describe PublishManualWorker do
       expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq("abc123")
     end
   end
+
+  context 'when encountering an HTTP server error connecting to the GDS API' do
+    let(:publish_service) { double(:publish_service) }
+    let(:task) { ManualPublishTask.create! }
+    let(:worker) { PublishManualWorker.new }
+    let(:http_error) { GdsApi::HTTPServerError.new(500) }
+
+    before do
+      allow(Manual::PublishService).to receive(:new).and_return(publish_service)
+      allow(publish_service).to receive(:call).and_raise(http_error)
+    end
+
+    it 'raises a failed to publish error so that Sidekiq can retry the job' do
+      expect { worker.perform(task.id) }
+        .to raise_error(PublishManualWorker::FailedToPublishError)
+    end
+
+    it 'notifies Airbrake of the error' do
+      expect(Airbrake).to receive(:notify).with(http_error)
+
+      worker.perform(task.id) rescue PublishManualWorker::FailedToPublishError
+    end
+  end
 end


### PR DESCRIPTION
Logging exceptions to the Rails log helped me debug a problem I was seeing when trying to publish manuals in development. Prior to this change I wasn't getting any information when `Manual::PublishService.new#call` failed. In my particular case I needed to set `PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk` when running `sidekiq` so that the app could communicate with the Organisations API.
