### PR TITLE
Add Rake task for ManualRelocator

### DIFF
--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -55,3 +55,13 @@ rake reslug_section[manual_slug,old_section_slug,new_section_slug]
 
 This task will update a single section slug, this performs an update within
 the Manual Publisher application database, Rummager and the Publishing API.
+
+## Relocating Manuals
+
+NOTE. The behaviour of this script is a little confusing (essentially overwriting one published manual with another) so it's not entirely obvious that it's still required.
+
+```
+rake relocate_manual[from_slug,to_slug]
+```
+
+Given the published manuals /guidance/manual-1 and /guidance/manual-2, this script will remove /guidance/manual-2 and update the manual and section slugs of /guidance/manual-1 to /guidance/manual-2.

--- a/lib/tasks/relocate_manual.rake
+++ b/lib/tasks/relocate_manual.rake
@@ -1,0 +1,10 @@
+require "manual_relocator"
+require "logger"
+
+desc <<-EndDesc
+Relocate manual from <from-slug> to <to-slug>
+Both <from-slug> and <to-slug> need to be published manuals
+EndDesc
+task :relocate_manual, [:from_slug, :to_slug] => :environment do |_, args|
+  ManualRelocator.move(args[:from_slug], args[:to_slug])
+end


### PR DESCRIPTION
This addresses issue #881. We planned to remove the `ManualRelocator` class in PR #878 but closed it without merging as @h-lame explained that this class is still used. We're hoping that making it a Rake task will make it easier to use in future and prevent someone else from trying to remove it.
