### PR TITLE
Remove unnecessary require statement from sections.rake

### DIFF
--- a/lib/tasks/sections.rake
+++ b/lib/tasks/sections.rake
@@ -1,4 +1,3 @@
-require 'section_reslugger'
 require 'section_slug_synchroniser'
 
 namespace :sections do


### PR DESCRIPTION
This was made redundant in [this recent commit][1].

[1]: https://github.com/alphagov/manuals-publisher/commit/d1ae6f246a9cddb0103ec89a63d2eab64d70128b