### PR TITLE
Rename SectionEdition#section_id field

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -37,7 +37,7 @@ class Section
 
   def self.find(manual, section_id, published: false)
     editions = SectionEdition
-      .where(section_id: section_id)
+      .all_for_section(section_id)
       .order_by([:version_number, :desc])
       .to_a
       .drop_while { |e| published && !e.published? }

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -35,9 +35,9 @@ class Section
     ]
   end
 
-  def self.find(manual, section_id, published: false)
+  def self.find(manual, section_uuid, published: false)
     editions = SectionEdition
-      .all_for_section(section_id)
+      .all_for_section(section_uuid)
       .order_by([:version_number, :desc])
       .to_a
       .drop_while { |e| published && !e.published? }
@@ -45,9 +45,9 @@ class Section
       .reverse
 
     if editions.empty?
-      raise KeyError.new("key not found #{section_id}")
+      raise KeyError.new("key not found #{section_uuid}")
     else
-      Section.build(manual: manual, id: section_id, editions: editions)
+      Section.build(manual: manual, id: section_uuid, editions: editions)
     end
   end
 
@@ -207,7 +207,7 @@ protected
       state: "draft",
       version_number: 1,
       # TODO: Remove persistence conern
-      section_id: id,
+      section_uuid: id,
     }
   end
 

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -6,7 +6,7 @@ class SectionEdition
 
   store_in collection: "manual_section_editions"
 
-  field :section_id,           type: String
+  field :section_uuid,         type: String, as: :section_id
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -33,6 +33,10 @@ class SectionEdition
     end
   end
 
+  scope :all_for_section, ->(section_id) do
+    where(section_id: section_id)
+  end
+
   scope :draft,               where(state: "draft")
   scope :published,           where(state: "published")
   scope :archived,            where(state: "archived")

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -6,7 +6,7 @@ class SectionEdition
 
   store_in collection: "manual_section_editions"
 
-  field :section_uuid,         type: String, as: :section_id
+  field :section_uuid,         type: String
   field :version_number,       type: Integer, default: 1
   field :title,                type: String
   field :slug,                 type: String

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -37,6 +37,10 @@ class SectionEdition
     where(section_id: section_id)
   end
 
+  scope :all_for_sections, ->(*section_ids) do
+    where(:section_id.in => section_ids)
+  end
+
   scope :draft,               where(state: "draft")
   scope :published,           where(state: "published")
   scope :archived,            where(state: "archived")

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -18,7 +18,7 @@ class SectionEdition
   field :public_updated_at, type: DateTime
   field :exported_at, type: DateTime
 
-  validates :section_id, presence: true
+  validates :section_uuid, presence: true
   validates :slug, presence: true
 
   embeds_many :attachments, cascade_callbacks: true
@@ -33,12 +33,12 @@ class SectionEdition
     end
   end
 
-  scope :all_for_section, ->(section_id) do
-    where(section_id: section_id)
+  scope :all_for_section, ->(section_uuid) do
+    where(section_uuid: section_uuid)
   end
 
-  scope :all_for_sections, ->(*section_ids) do
-    where(:section_id.in => section_ids)
+  scope :all_for_sections, ->(*section_uuids) do
+    where(:section_uuid.in => section_uuids)
   end
 
   scope :draft,               where(state: "draft")
@@ -47,7 +47,7 @@ class SectionEdition
 
   scope :with_slug_prefix, ->(slug) { where(slug: /^#{slug}.*/) }
 
-  index section_id: 1
+  index section_uuid: 1
   index state: 1
   index updated_at: 1
 

--- a/db/migrate/20170427130832_rename_section_edition_section_id_to_section_uuid.rb
+++ b/db/migrate/20170427130832_rename_section_edition_section_id_to_section_uuid.rb
@@ -1,0 +1,13 @@
+class RenameSectionEditionSectionIdToSectionUuid < Mongoid::Migration
+  def self.up
+    SectionEdition.all.each do |section_edition|
+      section_edition.rename(:section_id, :section_uuid)
+    end
+  end
+
+  def self.down
+    SectionEdition.all.each do |section_edition|
+      section_edition.rename(:section_uuid, :section_id)
+    end
+  end
+end

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -24,7 +24,7 @@ class AttachmentReporting
       # the editions of these sections in version order to find unique PDF attachments and their
       # publication times.
       all_unique_section_ids_for_manual(manual).each do |section_id|
-        section_editions = SectionEdition.where(section_id: section_id).order_by([:version_number, :asc])
+        section_editions = SectionEdition.all_for_section(section_id).order_by([:version_number, :asc])
 
         section_editions.each do |section_edition|
           next if section_edition_never_published?(section_edition)

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -81,7 +81,7 @@ private
     discard_draft_from_publishing_api(manual_record.manual_id)
 
     section_ids.each do |id|
-      SectionEdition.where(section_id: id).map(&:destroy)
+      SectionEdition.all_for_section(id).map(&:destroy)
     end
 
     manual_record.destroy

--- a/lib/duplicate_document_finder.rb
+++ b/lib/duplicate_document_finder.rb
@@ -7,15 +7,15 @@ class DuplicateDocumentFinder
     slug_hash = {}
     SectionEdition.all.each do |edition|
       slug_hash[edition.slug] ||= {}
-      slug_hash[edition.slug][edition.section_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0 }
-      slug_hash[edition.slug][edition.section_id][:editions] += 1
+      slug_hash[edition.slug][edition.section_uuid] ||= { state: edition.state, created_at: edition.created_at, editions: 0 }
+      slug_hash[edition.slug][edition.section_uuid][:editions] += 1
     end
 
-    slug_hash.reject! { |_slug, section_ids| section_ids.size == 1 }
+    slug_hash.reject! { |_slug, section_uuids| section_uuids.size == 1 }
 
     slug_hash.each do |slug, sections|
-      sections.each do |section_id, data|
-        @io.puts [slug, section_id, data[:state], data[:created_at], data[:editions]].join(",")
+      sections.each do |section_uuid, data|
+        @io.puts [slug, section_uuid, data[:state], data[:created_at], data[:editions]].join(",")
       end
     end
   end

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -4,7 +4,7 @@ class DuplicateDraftDeleter
   def call
     duplicated_editions_not_in_publishing_api = duplicated_editions.reject { |data| in_publishing_api?(data[:content_id]) }
     content_ids = duplicated_editions_not_in_publishing_api.map { |data| data[:content_id] }
-    editions_to_delete = SectionEdition.where(:section_id.in => content_ids)
+    editions_to_delete = SectionEdition.all_for_sections(*content_ids)
 
     puts "The following #{editions_to_delete.count} editions are unknown to Publishing API and will be deleted:"
     editions_to_delete.each do |edition|

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -8,7 +8,7 @@ class DuplicateDraftDeleter
 
     puts "The following #{editions_to_delete.count} editions are unknown to Publishing API and will be deleted:"
     editions_to_delete.each do |edition|
-      puts [edition.slug, edition.section_id, edition.state, edition.created_at].join(",")
+      puts [edition.slug, edition.section_uuid, edition.state, edition.created_at].join(",")
       edition.delete
     end
   end
@@ -31,8 +31,8 @@ private
     slug_hash = {}
     SectionEdition.all.each do |edition|
       slug_hash[edition.slug] ||= {}
-      slug_hash[edition.slug][edition.section_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.section_id, slug: edition.slug }
-      slug_hash[edition.slug][edition.section_id][:editions] += 1
+      slug_hash[edition.slug][edition.section_uuid] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.section_uuid, slug: edition.slug }
+      slug_hash[edition.slug][edition.section_uuid][:editions] += 1
     end
 
     slug_hash.reject! { |_slug, documents| documents.size == 1 }

--- a/lib/duplicate_draft_deleter.rb
+++ b/lib/duplicate_draft_deleter.rb
@@ -8,7 +8,7 @@ class DuplicateDraftDeleter
 
     puts "The following #{editions_to_delete.count} editions are unknown to Publishing API and will be deleted:"
     editions_to_delete.each do |edition|
-      puts [edition[:slug], edition[:section_id], edition[:state], edition[:created_at]].join(",")
+      puts [edition.slug, edition.section_id, edition.state, edition.created_at].join(",")
       edition.delete
     end
   end

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -19,7 +19,7 @@ class ManualPublicationLogFilter
 
     def sort_by_section_ids_and_created_at
       editions_not_matching_supplied_sections = @section_editions.where(:section_id.nin => @section_ids)
-      editions_matching_supplied_sections = @section_editions.where(:section_id.in => @section_ids)
+      editions_matching_supplied_sections = @section_editions.all_for_sections(*@section_ids)
 
       order_by_section_ids(editions_matching_supplied_sections).concat(editions_not_matching_supplied_sections.order_by([:created_at, :asc]).to_a)
     end
@@ -69,7 +69,7 @@ private
   end
 
   def section_editions_for_first_manual_edition
-    @section_editions_for_first_manual_edition ||= SectionEdition.where(:section_id.in => first_manual_edition.section_ids, :minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
+    @section_editions_for_first_manual_edition ||= SectionEdition.all_for_sections(*first_manual_edition.section_ids).where(:minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
   end
 
   def first_manual_edition

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -12,24 +12,24 @@ class ManualPublicationLogFilter
   end
 
   class EditionOrdering
-    def initialize(section_editions, section_ids)
+    def initialize(section_editions, section_uuids)
       @section_editions = section_editions
-      @section_ids = section_ids
+      @section_uuids = section_uuids
     end
 
-    def sort_by_section_ids_and_created_at
-      editions_not_matching_supplied_sections = @section_editions.where(:section_id.nin => @section_ids)
-      editions_matching_supplied_sections = @section_editions.all_for_sections(*@section_ids)
+    def sort_by_section_uuids_and_created_at
+      editions_not_matching_supplied_sections = @section_editions.where(:section_uuid.nin => @section_uuids)
+      editions_matching_supplied_sections = @section_editions.all_for_sections(*@section_uuids)
 
-      order_by_section_ids(editions_matching_supplied_sections).concat(editions_not_matching_supplied_sections.order_by([:created_at, :asc]).to_a)
+      order_by_section_uuids(editions_matching_supplied_sections).concat(editions_not_matching_supplied_sections.order_by([:created_at, :asc]).to_a)
     end
 
   private
 
-    def order_by_section_ids(section_editions)
+    def order_by_section_uuids(section_editions)
       section_editions.to_a.sort do |a, b|
-        a_index = @section_ids.index(a.section_id)
-        b_index = @section_ids.index(b.section_id)
+        a_index = @section_uuids.index(a.section_uuid)
+        b_index = @section_uuids.index(b.section_uuid)
 
         a_index <=> b_index
       end
@@ -49,14 +49,14 @@ private
         updated_at: first_manual_edition.updated_at
       )
 
-      section_edition.section_id
+      section_edition.section_uuid
     end
   end
 
   def build_logs_for_all_other_suitable_section_editions
     edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.section_ids)
 
-    edition_ordering.sort_by_section_ids_and_created_at.each do |edition|
+    edition_ordering.sort_by_section_uuids_and_created_at.each do |edition|
       PublicationLog.create!(
         title: edition.title,
         slug: edition.slug,

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -124,7 +124,7 @@ private
   end
 
   def all_editions_of_section(section_id)
-    SectionEdition.where(section_id: section_id).order_by([:version_number, :desc])
+    SectionEdition.all_for_section(section_id).order_by([:version_number, :desc])
   end
 
   def reslug

--- a/lib/marked_section_deleter.rb
+++ b/lib/marked_section_deleter.rb
@@ -14,7 +14,7 @@ class MarkedSectionDeleter
 
     @logger.puts "The following #{duplicated_editions.count} editions have been marked as XX for deletion:"
     duplicated_editions.each do |edition|
-      @logger.puts [edition[:slug], edition[:section_id], edition[:state], edition[:created_at]].join(",")
+      @logger.puts [edition[:slug], edition[:section_uuid], edition[:state], edition[:created_at]].join(",")
     end
 
     known_editions, unknown_editions = duplicated_editions.partition { |edition| in_publishing_api?(edition[:content_id]) }
@@ -53,8 +53,8 @@ class MarkedSectionDeleter
     slug_hash = {}
     marked_editions.all.each do |edition|
       slug_hash[edition.slug] ||= {}
-      slug_hash[edition.slug][edition.section_id] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.section_id, slug: edition.slug }
-      slug_hash[edition.slug][edition.section_id][:editions] += 1
+      slug_hash[edition.slug][edition.section_uuid] ||= { state: edition.state, created_at: edition.created_at, editions: 0, content_id: edition.section_uuid, slug: edition.slug }
+      slug_hash[edition.slug][edition.section_uuid][:editions] += 1
     end
 
     slug_hash.values.map(&:values).flatten(1)

--- a/lib/marked_section_deleter.rb
+++ b/lib/marked_section_deleter.rb
@@ -22,7 +22,7 @@ class MarkedSectionDeleter
     @logger.puts "The following #{unknown_editions.count} are unknown to Publishing API and are safe to delete:"
     unknown_editions.each do |edition|
       @logger.puts [edition[:slug], edition[:content_id], edition[:state], edition[:created_at]].join(",")
-      SectionEdition.where(section_id: edition[:content_id]).delete_all unless dry_run
+      SectionEdition.all_for_section(edition[:content_id]).delete_all unless dry_run
     end
 
     @logger.puts "The following #{known_editions.count} are known to Publishing API and will be deleted after the draft is discarded:"
@@ -30,7 +30,7 @@ class MarkedSectionDeleter
       @logger.puts [edition[:slug], edition[:content_id], edition[:state], edition[:created_at]].join(",")
       unless dry_run
         publishing_api.discard_draft(edition[:content_id])
-        SectionEdition.where(section_id: edition[:content_id]).delete_all
+        SectionEdition.all_for_section(edition[:content_id]).delete_all
       end
     end
   end

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -89,7 +89,7 @@ private
 
   def context_for_section_edition_update(user)
     params_hash = {
-      "id" => current_section_edition.section_id,
+      "id" => current_section_edition.section_uuid,
       "section" => {
         title: current_section_edition.title,
         summary: current_section_edition.summary,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
   end
 
   factory :section_edition do
-    section_id { Moped::BSON::ObjectId.new }
+    section_id { SecureRandom.uuid }
     sequence(:slug) { |n| "test-section-edition-#{n}" }
     sequence(:title) { |n| "Test Section Edition #{n}" }
     summary "My summary"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
   end
 
   factory :section_edition do
-    section_id { SecureRandom.uuid }
+    section_uuid { SecureRandom.uuid }
     sequence(:slug) { |n| "test-section-edition-#{n}" }
     sequence(:title) { |n| "Test Section Edition #{n}" }
     summary "My summary"
@@ -62,7 +62,7 @@ FactoryGirl.define do
       after(:build) do |manual_record|
         manual_record.editions.each do |edition|
           section = FactoryGirl.create(:section_edition)
-          edition.section_ids = [section.section_id]
+          edition.section_ids = [section.section_uuid]
         end
       end
     end
@@ -71,7 +71,7 @@ FactoryGirl.define do
       after(:build) do |manual_record|
         manual_record.editions.each do |edition|
           section = FactoryGirl.create(:section_edition)
-          edition.removed_section_ids = [section.section_id]
+          edition.removed_section_ids = [section.section_uuid]
         end
       end
     end

--- a/spec/lib/attachment_reporting_spec.rb
+++ b/spec/lib/attachment_reporting_spec.rb
@@ -85,11 +85,11 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
       state: "published",
       version_number: 1,
       section_ids: [
-        early_section_edition_with_pdf.section_id,
-        early_section_edition_with_non_pdf.section_id,
-        early_section_edition_draft_with_pdf.section_id,
-        more_recent_section_edition.section_id,
-        very_recent_section_edition.section_id
+        early_section_edition_with_pdf.section_uuid,
+        early_section_edition_with_non_pdf.section_uuid,
+        early_section_edition_draft_with_pdf.section_uuid,
+        more_recent_section_edition.section_uuid,
+        very_recent_section_edition.section_uuid
       ],
     )
   }
@@ -116,7 +116,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
       state: "published",
       version_number: 1,
       section_ids: [
-        very_recent_draft_patent_section_edition.section_id
+        very_recent_draft_patent_section_edition.section_uuid
       ],
     )
   }

--- a/spec/lib/duplicate_document_finder_spec.rb
+++ b/spec/lib/duplicate_document_finder_spec.rb
@@ -27,8 +27,8 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with the same slug and same section id' do
     before {
-      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 1)
-      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 1)
     }
 
     it "doesn't report them as duplicates" do
@@ -40,18 +40,18 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with the same slug and different section ids' do
     let!(:edition_1) {
-      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 1)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 1)
     }
     let!(:edition_2) {
-      FactoryGirl.create(:section_edition, slug: 'slug', section_id: 2)
+      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 2)
     }
 
     it "reports them as duplicates" do
       edition_1_data = [
-        edition_1.slug, edition_1.section_id, edition_1.state, edition_1.created_at, 1
+        edition_1.slug, edition_1.section_uuid, edition_1.state, edition_1.created_at, 1
       ]
       edition_2_data = [
-        edition_2.slug, edition_2.section_id, edition_2.state, edition_2.created_at, 1
+        edition_2.slug, edition_2.section_uuid, edition_2.state, edition_2.created_at, 1
       ]
 
       expect(io).to receive(:puts).with(edition_1_data.join(','))

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -9,7 +9,7 @@ describe DuplicateDraftDeleter do
     original_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
-      section_id: original_content_id,
+      section_uuid: original_content_id,
       state: "draft",
     )
     publishing_api_has_item(content_id: original_content_id)
@@ -17,12 +17,12 @@ describe DuplicateDraftDeleter do
     duplicate_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
-      section_id: duplicate_content_id,
+      section_uuid: duplicate_content_id,
       state: "draft",
     )
     FactoryGirl.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
-      section_id: duplicate_content_id,
+      section_uuid: duplicate_content_id,
       state: "archived",
     )
     publishing_api_does_not_have_item(duplicate_content_id)
@@ -37,12 +37,12 @@ describe DuplicateDraftDeleter do
   it "leaves non-duplicated editions alone" do
     content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
-     section_id: content_id,
+     section_uuid: content_id,
     )
 
     another_content_id = SecureRandom.uuid
     FactoryGirl.create(:section_edition,
-      section_id: another_content_id,
+      section_uuid: another_content_id,
     )
 
     expect { DuplicateDraftDeleter.new.call }.to output.to_stdout

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -30,8 +30,8 @@ describe DuplicateDraftDeleter do
     expected_output = /The following 2 editions are unknown to Publishing API and will be deleted:.*#{duplicate_content_id}/m
     expect { DuplicateDraftDeleter.new.call }.to output(expected_output).to_stdout
 
-    expect(SectionEdition.where(section_id: original_content_id)).to be_present
-    expect(SectionEdition.where(section_id: duplicate_content_id)).to be_empty
+    expect(SectionEdition.all_for_section(original_content_id)).to be_present
+    expect(SectionEdition.all_for_section(duplicate_content_id)).to be_empty
   end
 
   it "leaves non-duplicated editions alone" do
@@ -47,7 +47,7 @@ describe DuplicateDraftDeleter do
 
     expect { DuplicateDraftDeleter.new.call }.to output.to_stdout
 
-    expect(SectionEdition.where(section_id: content_id)).to be_present
-    expect(SectionEdition.where(section_id: another_content_id)).to be_present
+    expect(SectionEdition.all_for_section(content_id)).to be_present
+    expect(SectionEdition.all_for_section(another_content_id)).to be_present
   end
 end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -22,7 +22,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       :section_edition,
       state: "published",
       slug: section_a_edition_published_version_1_major_update.slug,
-      section_id: section_a_edition_published_version_1_major_update.section_id,
+      section_uuid: section_a_edition_published_version_1_major_update.section_uuid,
       exported_at: section_edition_exported_time,
       version_number: 2
     )
@@ -43,7 +43,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       :section_edition,
       state: "published",
       slug: section_b_edition_published_version_1_major_update.slug,
-      section_id: section_b_edition_published_version_1_major_update.section_id,
+      section_uuid: section_b_edition_published_version_1_major_update.section_uuid,
       exported_at: section_edition_exported_time,
       minor_update: true,
       version_number: 2
@@ -98,9 +98,9 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       state: "published",
       version_number: 1,
       section_ids: [
-        section_a_edition_published_version_1_major_update.section_id,
-        section_b_edition_published_version_1_major_update.section_id,
-        section_c_edition_archived_version_1_major_update.section_id,
+        section_a_edition_published_version_1_major_update.section_uuid,
+        section_b_edition_published_version_1_major_update.section_uuid,
+        section_c_edition_archived_version_1_major_update.section_uuid,
       ],
       created_at: first_manual_edition_creation_time,
       updated_at: first_manual_edition_creation_time
@@ -112,11 +112,11 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
       state: "published",
       version_number: 2,
       section_ids: [
-        section_a_edition_published_version_2_major_update.section_id,
-        section_b_edition_published_version_2_minor_update.section_id,
-        section_c_edition_archived_version_1_major_update.section_id,
-        section_d_edition_draft_version_1_major_update.section_id,
-        section_e_edition_published_version_1_major_update.section_id
+        section_a_edition_published_version_2_major_update.section_uuid,
+        section_b_edition_published_version_2_minor_update.section_uuid,
+        section_c_edition_archived_version_1_major_update.section_uuid,
+        section_d_edition_draft_version_1_major_update.section_uuid,
+        section_e_edition_published_version_1_major_update.section_uuid
       ],
       created_at: second_manual_edition_creation_time,
       updated_at: first_manual_edition_creation_time
@@ -187,7 +187,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
 end
 
 describe ManualPublicationLogFilter::EditionOrdering do
-  describe ".sort_by_section_ids_and_created_at" do
+  describe ".sort_by_section_uuids_and_created_at" do
     let!(:edition_in_third_position) { FactoryGirl.create :section_edition }
     let!(:edition_in_first_position) { FactoryGirl.create :section_edition }
     let!(:edition_in_second_position) { FactoryGirl.create :section_edition }
@@ -195,24 +195,24 @@ describe ManualPublicationLogFilter::EditionOrdering do
     let!(:other_edition_newer) { FactoryGirl.create :section_edition, created_at: Time.now - 1.day }
     let!(:other_edition_older) { FactoryGirl.create :section_edition, created_at: Time.now - 1.week }
 
-    let!(:section_ids) {
+    let!(:section_uuids) {
       [
-        edition_in_first_position.section_id,
-        edition_in_second_position.section_id,
-        edition_in_third_position.section_id,
+        edition_in_first_position.section_uuid,
+        edition_in_second_position.section_uuid,
+        edition_in_third_position.section_uuid,
       ]
     }
 
     let(:expected_section_order) {
-      section_ids.concat([other_edition_older.section_id, other_edition_newer.section_id])
+      section_uuids.concat([other_edition_older.section_uuid, other_edition_newer.section_uuid])
     }
 
-    let(:subject) { described_class.new(SectionEdition.all, section_ids) }
+    let(:subject) { described_class.new(SectionEdition.all, section_uuids) }
 
-    it "returns editions in the supplied section id and created_at order" do
-      ordered_editions = subject.sort_by_section_ids_and_created_at
+    it "returns editions in the supplied section uuid and created_at order" do
+      ordered_editions = subject.sort_by_section_uuids_and_created_at
 
-      expect(ordered_editions.map(&:section_id)).to eq expected_section_order
+      expect(ordered_editions.map(&:section_uuid)).to eq expected_section_order
     end
   end
 end

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -45,13 +45,13 @@ describe ManualRelocator do
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }
-    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_id: "12345", version_number: 1, state: "published") }
-    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_id: "23456", version_number: 1, state: "published") }
-    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_id: "abcdef", version_number: 1, state: "published") }
-    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_id: "bcdefg", version_number: 1, state: "published") }
+    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published") }
+    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published") }
+    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published") }
+    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published") }
 
-    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", section_id: "34567", version_number: 1, state: "published") }
-    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", section_id: "cdefgh", version_number: 1, state: "published") }
+    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published") }
+    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published") }
 
     let!(:existing_publication_log) { FactoryGirl.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
     let!(:temporary_publication_log) { FactoryGirl.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }
@@ -214,12 +214,12 @@ describe ManualRelocator do
         end
 
         it "unpublishes the existing manual's sections with redirects to the existing slug" do
-          assert_publishing_api_unpublish(existing_section_1.section_id,
+          assert_publishing_api_unpublish(existing_section_1.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(existing_section_2.section_id,
+          assert_publishing_api_unpublish(existing_section_2.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}",
                                           discard_drafts: true)
@@ -228,7 +228,7 @@ describe ManualRelocator do
         it "issues a gone for existing manual's sections that would be reused one of the new manual's sections" do
           gone_object = {
             base_path: "/#{existing_section_3.slug}",
-            content_id: existing_section_3.section_id,
+            content_id: existing_section_3.section_uuid,
             document_type: "gone",
             publishing_app: "manuals-publisher",
             schema_name: "gone",
@@ -240,8 +240,8 @@ describe ManualRelocator do
             ]
           }
 
-          assert_publishing_api_put_content(existing_section_3.section_id, request_json_matches(gone_object))
-          assert_publishing_api_publish(existing_section_3.section_id)
+          assert_publishing_api_put_content(existing_section_3.section_uuid, request_json_matches(gone_object))
+          assert_publishing_api_publish(existing_section_3.section_uuid)
         end
 
         it "destroys the existing manual's sections" do
@@ -291,17 +291,17 @@ describe ManualRelocator do
         end
 
         it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
-          assert_publishing_api_unpublish(temporary_section_1.section_id,
+          assert_publishing_api_unpublish(temporary_section_1.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_1",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_2.section_id,
+          assert_publishing_api_unpublish(temporary_section_2.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_2",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_3.section_id,
+          assert_publishing_api_unpublish(temporary_section_3.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/section_3",
                                           discard_drafts: true)
@@ -316,21 +316,21 @@ describe ManualRelocator do
         end
 
         it "sends a new draft of each of the temporary manual's sections with the existing slug version of their path as a route" do
-          assert_publishing_api_put_content(temporary_section_1.section_id, with_route_matcher("/#{existing_slug}/temp_section_1"))
-          assert_publishing_api_put_content(temporary_section_2.section_id, with_route_matcher("/#{existing_slug}/temp_section_2"))
-          assert_publishing_api_put_content(temporary_section_3.section_id, with_route_matcher("/#{existing_slug}/section_3"))
+          assert_publishing_api_put_content(temporary_section_1.section_uuid, with_route_matcher("/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.section_uuid, with_route_matcher("/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_3.section_uuid, with_route_matcher("/#{existing_slug}/section_3"))
         end
 
         it "sends a publish request for each of the temporary manual's sections" do
-          assert_publishing_api_publish(temporary_section_1.section_id)
-          assert_publishing_api_publish(temporary_section_2.section_id)
-          assert_publishing_api_publish(temporary_section_3.section_id)
+          assert_publishing_api_publish(temporary_section_1.section_uuid)
+          assert_publishing_api_publish(temporary_section_2.section_uuid)
+          assert_publishing_api_publish(temporary_section_3.section_uuid)
         end
       end
 
       context "when the temp manual has a draft" do
-        let!(:temporary_section_1_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_id: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
-        let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_id: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
+        let!(:temporary_section_1_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
+        let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
 
         before do
           temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
@@ -360,17 +360,17 @@ describe ManualRelocator do
         end
 
         it "unpublishes the temporary manual's section slugs with redirects to their existing slug version" do
-          assert_publishing_api_unpublish(temporary_section_1.section_id,
+          assert_publishing_api_unpublish(temporary_section_1.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_1",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_2.section_id,
+          assert_publishing_api_unpublish(temporary_section_2.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/temp_section_2",
                                           discard_drafts: true)
 
-          assert_publishing_api_unpublish(temporary_section_3.section_id,
+          assert_publishing_api_unpublish(temporary_section_3.section_uuid,
                                           type: "redirect",
                                           alternative_path: "/#{existing_slug}/section_3",
                                           discard_drafts: true)
@@ -389,23 +389,23 @@ describe ManualRelocator do
         end
 
         it "sends a draft of each of the temporary manual's published sections with the existing slug version of their path as a route" do
-          assert_publishing_api_put_content(temporary_section_1.section_id, with_body_and_route_matcher(temporary_section_1.body, "/#{existing_slug}/temp_section_1"))
-          assert_publishing_api_put_content(temporary_section_2.section_id, with_body_and_route_matcher(temporary_section_2.body, "/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_1.section_uuid, with_body_and_route_matcher(temporary_section_1.body, "/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.section_uuid, with_body_and_route_matcher(temporary_section_2.body, "/#{existing_slug}/temp_section_2"))
         end
 
         it "sends a publish request for each of the temporary manual's published sections" do
-          assert_publishing_api_publish(temporary_section_1.section_id)
-          assert_publishing_api_publish(temporary_section_2.section_id)
+          assert_publishing_api_publish(temporary_section_1.section_uuid)
+          assert_publishing_api_publish(temporary_section_2.section_uuid)
         end
 
         it "does not send a publish request for any section only present in the new draft" do
-          assert_publishing_api_publish(temporary_section_3.section_id, nil, 0)
+          assert_publishing_api_publish(temporary_section_3.section_uuid, nil, 0)
         end
 
         it "sends a draft of each of the temporary manual's draft sections with the existing slug version of their path as a route" do
-          assert_publishing_api_put_content(temporary_section_1.section_id, with_body_and_route_matcher(temporary_section_1_v2.body, "/#{existing_slug}/temp_section_1"))
-          assert_publishing_api_put_content(temporary_section_2.section_id, with_body_and_route_matcher(temporary_section_2_v2.body, "/#{existing_slug}/temp_section_2"))
-          assert_publishing_api_put_content(temporary_section_3.section_id, with_body_and_route_matcher(temporary_section_3.body, "/#{existing_slug}/section_3"))
+          assert_publishing_api_put_content(temporary_section_1.section_uuid, with_body_and_route_matcher(temporary_section_1_v2.body, "/#{existing_slug}/temp_section_1"))
+          assert_publishing_api_put_content(temporary_section_2.section_uuid, with_body_and_route_matcher(temporary_section_2_v2.body, "/#{existing_slug}/temp_section_2"))
+          assert_publishing_api_put_content(temporary_section_3.section_uuid, with_body_and_route_matcher(temporary_section_3.body, "/#{existing_slug}/section_3"))
         end
       end
     end

--- a/spec/lib/marked_section_deleter_spec.rb
+++ b/spec/lib/marked_section_deleter_spec.rb
@@ -20,7 +20,7 @@ describe MarkedSectionDeleter do
     before {
       allow(publishing_api).
         to receive(:get_content).
-        with(edition.section_id).
+        with(edition.section_uuid).
         and_raise(GdsApi::HTTPNotFound.new(nil))
     }
 
@@ -39,11 +39,11 @@ describe MarkedSectionDeleter do
     before {
       allow(publishing_api).
         to receive(:get_content).
-        with(edition.section_id).
+        with(edition.section_uuid).
         and_return(double(:gds_api_response))
       allow(publishing_api).
         to receive(:discard_draft).
-        with(edition.section_id)
+        with(edition.section_uuid)
     }
 
     it "deletes the edition" do
@@ -55,7 +55,7 @@ describe MarkedSectionDeleter do
     it 'discards the draft from the publishing api' do
       expect(publishing_api).
         to receive(:discard_draft).
-        with(edition.section_id)
+        with(edition.section_uuid)
 
       subject.execute(dry_run: false)
     end

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -24,7 +24,7 @@ describe SectionReslugger do
       organisation_slug: 'organisation-slug'
     )
     SectionEdition.create!(
-      section_id: 'section-id',
+      section_uuid: 'section-id',
       slug: 'manual-slug/current-section-slug',
       title: 'section-edition-title',
       summary: 'section-edition-summary',

--- a/spec/lib/section_slug_synchroniser_spec.rb
+++ b/spec/lib/section_slug_synchroniser_spec.rb
@@ -17,18 +17,18 @@ RSpec.describe SectionSlugSynchroniser do
 
   context "when sections are out of sync" do
     before do
-      section_ids = []
+      section_uuids = []
 
       4.times do |n|
         count = n + 1
         section_slug_number = 6 - n
-        section_id = "section-id-#{count}"
-        section_ids << section_id
+        section_uuid = "section-uuid-#{count}"
+        section_uuids << section_uuid
 
         # A common use-case is number-prefixed section titles
         # which get out of sync with their slugs on reordering.
         SectionEdition.create!(
-          section_id: section_id,
+          section_uuid: section_uuid,
           slug: "manual-slug/#{section_slug_number}-section",
           title: "#{count}. Section",
           summary: "Section summary",
@@ -37,7 +37,7 @@ RSpec.describe SectionSlugSynchroniser do
       end
 
       manual_record.editions.create!(
-        section_ids: section_ids
+        section_ids: section_uuids
       )
     end
 
@@ -80,15 +80,15 @@ RSpec.describe SectionSlugSynchroniser do
 
   context "when sections are in sync" do
     before do
-      section_ids = []
+      section_uuids = []
 
       2.times do |n|
         count = n + 1
-        section_id = "section-id-#{count}"
-        section_ids << section_id
+        section_uuid = "section-uuid-#{count}"
+        section_uuids << section_uuid
 
         SectionEdition.create!(
-          section_id: section_id,
+          section_uuid: section_uuid,
           slug: "manual-slug/#{count}-section",
           title: "#{count}. Section",
           summary: "Section summary",
@@ -97,7 +97,7 @@ RSpec.describe SectionSlugSynchroniser do
       end
 
       manual_record.editions.create!(
-        section_ids: section_ids
+        section_ids: section_uuids
       )
     end
 

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -506,8 +506,8 @@ describe Manual do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
       let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "draft") }
-      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 1, state: "draft") }
-      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 1, state: "draft") }
+      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "draft") }
+      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "draft") }
 
       before do
         manual_record.editions << manual_edition
@@ -557,8 +557,8 @@ describe Manual do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
       let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "published") }
-      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
-      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
+      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
 
       before do
         manual_record.editions << manual_edition
@@ -608,8 +608,8 @@ describe Manual do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
       let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "withdrawn") }
-      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 1, state: "archived") }
-      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 1, state: "archived") }
+      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "archived") }
+      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "archived") }
 
       before do
         manual_record.editions << manual_edition
@@ -640,10 +640,10 @@ describe Manual do
       end
 
       context "including new drafts of all sections" do
-        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
-        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
-        let!(:section_1_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 2, state: "draft") }
-        let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 2, state: "draft") }
+        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
+        let!(:section_1_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 2, state: "draft") }
+        let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 2, state: "draft") }
 
         context "the published version returned" do
           it "is the published version as a Manual instance" do
@@ -713,8 +713,8 @@ describe Manual do
       end
 
       context "without new drafts of any sections" do
-        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
-        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
+        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
 
         context "the published version returned" do
           it "is the published version as a Manual instance" do
@@ -784,9 +784,9 @@ describe Manual do
       end
 
       context "including new drafts of some sections" do
-        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_id: "12345", version_number: 1, state: "published") }
-        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 1, state: "published") }
-        let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_id: "67890", version_number: 2, state: "draft") }
+        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
+        let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 2, state: "draft") }
 
         context "the published version returned" do
           it "is the published version as a Manual instance" do

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -29,9 +29,9 @@ describe SectionEdition do
 
   describe '.all_for_section' do
     it 'returns all editions for a section' do
-      section_1_edition_1 = FactoryGirl.create(:section_edition, section_id: 'section-1')
-      section_1_edition_2 = FactoryGirl.create(:section_edition, section_id: 'section-1')
-      section_2_edition = FactoryGirl.create(:section_edition, section_id: 'section-2')
+      section_1_edition_1 = FactoryGirl.create(:section_edition, section_uuid: 'section-1')
+      section_1_edition_2 = FactoryGirl.create(:section_edition, section_uuid: 'section-1')
+      section_2_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-2')
 
       editions = SectionEdition.all_for_section('section-1')
 
@@ -43,9 +43,9 @@ describe SectionEdition do
 
   describe '.all_for_sections' do
     it 'returns all editions for sections' do
-      section_1_edition = FactoryGirl.create(:section_edition, section_id: 'section-1')
-      section_2_edition = FactoryGirl.create(:section_edition, section_id: 'section-2')
-      section_3_edition = FactoryGirl.create(:section_edition, section_id: 'section-3')
+      section_1_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-1')
+      section_2_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-2')
+      section_3_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-3')
 
       editions = SectionEdition.all_for_sections('section-1', 'section-2')
 

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -8,16 +8,16 @@ describe SectionEdition do
   end
 
   describe 'validation' do
-    it 'is valid if section_id and slug are present' do
-      subject.section_id = 'section-id'
+    it 'is valid if section_uuid and slug are present' do
+      subject.section_uuid = 'section-uuid'
       subject.slug = 'section-slug'
       expect(subject).to be_valid
     end
 
-    it 'is invalid if section_id is missing' do
-      subject.section_id = nil
+    it 'is invalid if section_uuid is missing' do
+      subject.section_uuid = nil
       expect(subject).not_to be_valid
-      expect(subject.errors[:section_id]).to include("can't be blank")
+      expect(subject.errors[:section_uuid]).to include("can't be blank")
     end
 
     it 'is invalid if slug is missing' do

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -40,4 +40,18 @@ describe SectionEdition do
       expect(editions).not_to include(section_2_edition)
     end
   end
+
+  describe '.all_for_sections' do
+    it 'returns all editions for sections' do
+      section_1_edition = FactoryGirl.create(:section_edition, section_id: 'section-1')
+      section_2_edition = FactoryGirl.create(:section_edition, section_id: 'section-2')
+      section_3_edition = FactoryGirl.create(:section_edition, section_id: 'section-3')
+
+      editions = SectionEdition.all_for_sections('section-1', 'section-2')
+
+      expect(editions).to include(section_1_edition)
+      expect(editions).to include(section_2_edition)
+      expect(editions).not_to include(section_3_edition)
+    end
+  end
 end

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -6,4 +6,24 @@ describe SectionEdition do
   it 'stores data in the manual_section_editions collection' do
     expect(subject.collection.name).to eq('manual_section_editions')
   end
+
+  describe 'validation' do
+    it 'is valid if section_id and slug are present' do
+      subject.section_id = 'section-id'
+      subject.slug = 'section-slug'
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid if section_id is missing' do
+      subject.section_id = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:section_id]).to include("can't be blank")
+    end
+
+    it 'is invalid if slug is missing' do
+      subject.slug = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:slug]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -26,4 +26,18 @@ describe SectionEdition do
       expect(subject.errors[:slug]).to include("can't be blank")
     end
   end
+
+  describe '.all_for_section' do
+    it 'returns all editions for a section' do
+      section_1_edition_1 = FactoryGirl.create(:section_edition, section_id: 'section-1')
+      section_1_edition_2 = FactoryGirl.create(:section_edition, section_id: 'section-1')
+      section_2_edition = FactoryGirl.create(:section_edition, section_id: 'section-2')
+
+      editions = SectionEdition.all_for_section('section-1')
+
+      expect(editions).to include(section_1_edition_1)
+      expect(editions).to include(section_1_edition_2)
+      expect(editions).not_to include(section_2_edition)
+    end
+  end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -112,7 +112,7 @@ describe Section do
       let(:editions_proxy) { double(:editions_proxy, to_a: [section_edition]).as_null_object }
 
       before do
-        allow(SectionEdition).to receive(:where).with(section_id: 'section-id').and_return(editions_proxy)
+        allow(SectionEdition).to receive(:all_for_section).with('section-id').and_return(editions_proxy)
       end
 
       it 'builds a section using the manual' do
@@ -135,7 +135,7 @@ describe Section do
       let(:editions_proxy) { double(:editions_proxy, to_a: []).as_null_object }
 
       before do
-        allow(SectionEdition).to receive(:where).with(section_id: 'section-id').and_return(editions_proxy)
+        allow(SectionEdition).to receive(:all_for_section).with('section-id').and_return(editions_proxy)
       end
 
       it 'raises a key error exception' do

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe Section do
   subject(:section) {
-    Section.new(slug_generator, section_id, editions)
+    Section.new(slug_generator, section_uuid, editions)
   }
 
   def key_classes_for(hash)
     hash.keys.map(&:class).uniq
   end
 
-  let(:section_id) { "a-section-id" }
+  let(:section_uuid) { "a-section-uuid" }
   let(:slug) { double(:slug) }
   let(:published_slug) { double(:published_slug) }
   let(:slug_generator) { double(:slug_generator, call: slug) }
@@ -312,7 +312,7 @@ describe Section do
         expect(SectionEdition).to have_received(:new).with(
           version_number: 1,
           state: "draft",
-          section_id: section_id,
+          section_uuid: section_uuid,
         )
       end
     end
@@ -608,7 +608,7 @@ describe Section do
 
     it "returns a has including the section's id" do
       expect(section.attributes).to include(
-        id: section_id,
+        id: section_uuid,
       )
     end
   end


### PR DESCRIPTION
We're planning to introduce a Mongo-backed `Section` class in the near future. This will have its own internal Mongoid ID field as well as the UUID currently stored on the `SectionEdition` records. Renaming `SectionEdition#section_id` to `SectionEdition#section_uuid` should hopefully help us avoid confusion when we introduce the `Section` class.

I plan to rename `Section#id`, `ManualRecord::Edition#section_ids` and `ManualRecord::Edition#removed_section_ids` in future PRs.
