### PR TITLE
Explicitly draft new sections with a nil change_note

### DIFF
--- a/app/lib/publication_logger.rb
+++ b/app/lib/publication_logger.rb
@@ -3,6 +3,7 @@ class PublicationLogger
     manual.sections.each do |doc|
       next unless doc.needs_exporting?
       next if doc.minor_update?
+      next if doc.change_note.blank?
 
       PublicationLog.create!(
         title: doc.title,
@@ -15,6 +16,7 @@ class PublicationLogger
     manual.removed_sections.each do |doc|
       next if doc.withdrawn?
       next if doc.minor_update?
+      next if doc.change_note.blank?
 
       PublicationLog.create!(
         title: doc.title,

--- a/app/services/manual/update_original_publication_date_service.rb
+++ b/app/services/manual/update_original_publication_date_service.rb
@@ -39,8 +39,8 @@ private
 
   def update_sections
     manual.sections.each do |section|
-      # a no-op update will force a new draft if we need it
-      section.update({})
+      # a nil change note will omit this update from publication logs
+      section.update(change_note: nil)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,6 +40,7 @@ FactoryGirl.define do
     sequence(:title) { |n| "Test Section Edition #{n}" }
     summary "My summary"
     body "My body"
+    change_note "New section added"
   end
 
   factory :publication_log do

--- a/spec/lib/publication_logger_spec.rb
+++ b/spec/lib/publication_logger_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe PublicationLogger do
+  let(:slug_generator) { SlugGenerator.new(prefix: "manual-slug") }
+  let(:manual) { double(:manual, sections: sections, removed_sections: []) }
+  let(:sections) { [section] }
+  let(:section) { Section.new(slug_generator, "section-id-1", [section_edition]) }
+  let(:section_edition) { FactoryGirl.create(:section_edition) }
+
+  describe "call" do
+    it "creates a PublicationLog for each Section" do
+      expect {
+        subject.call(manual)
+      }.to change(PublicationLog, :count).by(1)
+    end
+
+    # It's possible to pass a nil change_note, this indicates that the section
+    # update is not to be logged by the PublicationLogger
+    context "when a section edition has no change note" do
+      let(:cloned_section) { Section.new(slug_generator, "section-id-2", [cloned_section_edition]) }
+      let(:cloned_section_edition) { FactoryGirl.create(:section_edition, change_note: nil) }
+      let(:sections) { [section, cloned_section] }
+      it "does not create a PublicationLog for a cloned Section" do
+        expect {
+          subject.call(manual)
+        }.to change(PublicationLog, :count).by(1)
+
+        expect {
+          PublicationLog.find_by(change_note: nil)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+      end
+    end
+  end
+end

--- a/spec/services/manual/update_original_publication_date_service_spec.rb
+++ b/spec/services/manual/update_original_publication_date_service_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe Manual::UpdateOriginalPublicationDateService do
       )
   end
 
-  it "forces all the manuals sections to require an export with an empty update message" do
+  it "forces all the manuals sections to require an export with a nil change note" do
     subject.call
 
-    expect(section_1).to have_received(:update).with({})
-    expect(section_2).to have_received(:update).with({})
+    expect(section_1).to have_received(:update).with(change_note: nil)
+    expect(section_2).to have_received(:update).with(change_note: nil)
   end
 
   it "persists the manual after it has been updated" do


### PR DESCRIPTION
https://trello.com/c/WKtK3EIj/920-investigate-underlying-bug-with-setting-publication-date-of-a-manual

2nd attempt, see https://github.com/alphagov/manuals-publisher/pull/1019 for initial go at this.

When updating the `first_published_at` date the change note passed to the
section should be nil, this will then be identified and skipped by the PublicationLogger
and avoid duplicate change notes appearing in the frontend as [documented here](https://github.com/alphagov/manuals-publisher/issues/970)
Previously the section was copied along with the message in the change note
and these could appear several times in the updates page on the frontend.