### PR TITLE
Rename Section#id to Section#uuid

### DIFF
--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -20,7 +20,7 @@ private
     {
       links: {
         organisations: [organisation.content_id],
-        sections: manual.sections.map(&:id),
+        sections: manual.sections.map(&:uuid),
       },
     }
   end

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,6 +1,6 @@
 class PublishingApiDraftSectionDiscarder
   def call(section, _manual)
-    Services.publishing_api.discard_draft(section.id)
+    Services.publishing_api.discard_draft(section.uuid)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end
 end

--- a/app/exporters/publishing_api_manual_with_sections_publisher.rb
+++ b/app/exporters/publishing_api_manual_with_sections_publisher.rb
@@ -20,7 +20,7 @@ class PublishingApiManualWithSectionsPublisher
     manual.removed_sections.each do |section|
       next if section.withdrawn? && action != :republish
       begin
-        Services.publishing_api.unpublish(section.id, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+        Services.publishing_api.unpublish(section.uuid, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
       rescue GdsApi::HTTPNotFound # rubocop:disable Lint/HandleExceptions
       end
       section.withdraw_and_mark_as_exported! if action != :republish

--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -8,10 +8,18 @@ class PublishingAPIPublisher
   end
 
   def call
-    Services.publishing_api.publish(entity.id, update_type)
+    Services.publishing_api.publish(entity_id, update_type)
   end
 
 private
+
+  def entity_id
+    if entity.is_a?(Section)
+      entity.uuid
+    else
+      entity.id
+    end
+  end
 
   attr_reader(
     :entity,

--- a/app/exporters/publishing_api_withdrawer.rb
+++ b/app/exporters/publishing_api_withdrawer.rb
@@ -14,7 +14,11 @@ private
   )
 
   def content_id
-    entity.id
+    if entity.is_a?(Section)
+      entity.uuid
+    else
+      entity.id
+    end
   end
 
   def exportable_attributes

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -21,7 +21,7 @@ private
   attr_reader :organisation, :manual, :section
 
   def content_id
-    section.id
+    section.uuid
   end
 
   def base_path

--- a/app/exporters/section_publishing_api_links_exporter.rb
+++ b/app/exporters/section_publishing_api_links_exporter.rb
@@ -14,7 +14,7 @@ private
   attr_reader :organisation, :manual, :section
 
   def content_id
-    section.id
+    section.uuid
   end
 
   def exportable_attributes

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -210,7 +210,7 @@ class Manual
   end
 
   def build_section(attributes)
-    section = Section.build(manual: self, id: SecureRandom.uuid, editions: [])
+    section = Section.build(manual: self, uuid: SecureRandom.uuid, editions: [])
 
     defaults = {
       minor_update: false,

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -95,8 +95,8 @@ class Manual
     sections.each(&:save)
     removed_sections.each(&:save)
 
-    edition.section_ids = sections.map(&:id)
-    edition.removed_section_ids = removed_sections.map(&:id)
+    edition.section_ids = sections.map(&:uuid)
+    edition.removed_section_ids = removed_sections.map(&:uuid)
 
     manual_record.save!
   end
@@ -224,18 +224,18 @@ class Manual
   end
 
   def reorder_sections(section_order)
-    unless section_order.sort == sections.map(&:id).sort
+    unless section_order.sort == sections.map(&:uuid).sort
       raise(
         ArgumentError,
         "section_order must contain each section_id exactly once",
       )
     end
 
-    sections.sort_by! { |sec| section_order.index(sec.id) }
+    sections.sort_by! { |sec| section_order.index(sec.uuid) }
   end
 
-  def remove_section(section_id)
-    found_section = sections.find { |d| d.id == section_id }
+  def remove_section(section_uuid)
+    found_section = sections.find { |d| d.uuid == section_uuid }
 
     return if found_section.nil?
 
@@ -273,15 +273,15 @@ class Manual
     end
 
     def add_sections_to_manual(manual, edition, published: false)
-      sections = Array(edition.section_ids).map { |section_id|
-        Section.find(manual, section_id, published: published)
+      sections = Array(edition.section_ids).map { |section_uuid|
+        Section.find(manual, section_uuid, published: published)
       }
 
-      removed_sections = Array(edition.removed_section_ids).map { |section_id|
+      removed_sections = Array(edition.removed_section_ids).map { |section_uuid|
         begin
-          Section.find(manual, section_id)
+          Section.find(manual, section_uuid)
         rescue KeyError
-          raise RemovedSectionIdNotFoundError, "No section found for ID #{section_id}"
+          raise RemovedSectionIdNotFoundError, "No section found for UUID #{section_uuid}"
         end
       }
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -88,7 +88,7 @@ class Section
         self.class.edition_attributes.include?(k)
       }
       .merge(
-        id: id,
+        uuid: uuid,
       )
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -13,10 +13,10 @@ class Section
   validates :body, presence: true, safe_html: true
   validate :change_note_ok
 
-  def self.build(manual:, id:, editions:)
+  def self.build(manual:, uuid:, editions:)
     slug_generator = SlugGenerator.new(prefix: manual.slug)
 
-    Section.new(slug_generator, id, editions)
+    Section.new(slug_generator, uuid, editions)
   end
 
   def self.edition_attributes
@@ -47,7 +47,7 @@ class Section
     if editions.empty?
       raise KeyError.new("key not found #{section_uuid}")
     else
-      Section.build(manual: manual, id: section_uuid, editions: editions)
+      Section.build(manual: manual, uuid: section_uuid, editions: editions)
     end
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -77,7 +77,7 @@ class Section
   end
 
   def to_param
-    id
+    uuid
   end
 
   def attributes

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -53,11 +53,12 @@ class Section
 
   def_delegators :latest_edition, *edition_attributes
 
-  attr_reader :id, :editions, :latest_edition
+  attr_reader :uuid, :editions, :latest_edition
+  alias_attribute :id, :uuid
 
-  def initialize(slug_generator, id, editions)
+  def initialize(slug_generator, uuid, editions)
     @slug_generator = slug_generator
-    @id = id
+    @uuid = uuid
     @editions = editions
     @editions.push(create_first_edition) if @editions.empty?
     @latest_edition = @editions.last

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -54,7 +54,6 @@ class Section
   def_delegators :latest_edition, *edition_attributes
 
   attr_reader :uuid, :editions, :latest_edition
-  alias_attribute :id, :uuid
 
   def initialize(slug_generator, uuid, editions)
     @slug_generator = slug_generator

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -208,7 +208,7 @@ protected
       state: "draft",
       version_number: 1,
       # TODO: Remove persistence conern
-      section_uuid: id,
+      section_uuid: uuid,
     }
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -188,7 +188,7 @@ class Section
   end
 
   def eql?(other)
-    id.eql?(other.id)
+    uuid.eql?(other.uuid)
   end
 
   def never_published?

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -16,7 +16,7 @@ private
   attr_reader :context
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
@@ -31,7 +31,7 @@ private
     context.params.fetch("manual_id")
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("section_id")
   end
 end

--- a/app/services/attachment/new_service.rb
+++ b/app/services/attachment/new_service.rb
@@ -16,7 +16,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
@@ -31,7 +31,7 @@ private
     context.params.fetch("manual_id")
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("section_id")
   end
 end

--- a/app/services/attachment/show_service.rb
+++ b/app/services/attachment/show_service.rb
@@ -16,7 +16,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
@@ -27,7 +27,7 @@ private
     context.params.fetch("manual_id")
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("section_id")
   end
 

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -20,7 +20,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
@@ -44,7 +44,7 @@ private
     context.params.fetch("manual_id")
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("section_id")
   end
 

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -16,7 +16,7 @@ private
   )
 
   def section
-    section_id ? existing_section : ephemeral_section
+    section_uuid ? existing_section : ephemeral_section
   end
 
   def manual
@@ -29,7 +29,7 @@ private
 
   def existing_section
     @existing_section ||= manual.sections.find { |section|
-      section.id == section_id
+      section.uuid == section_uuid
     }
   end
 
@@ -37,7 +37,7 @@ private
     context.params.fetch("section")
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("id", nil)
   end
 

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -4,7 +4,7 @@ class Section::RemoveService
   end
 
   def call
-    raise SectionNotFoundError.new(section_id) unless section.present?
+    raise SectionNotFoundError.new(section_uuid) unless section.present?
 
     section.update(change_note_params)
 
@@ -26,7 +26,7 @@ private
   attr_reader :context
 
   def remove
-    manual.remove_section(section_id)
+    manual.remove_section(section_uuid)
   end
 
   def persist
@@ -34,7 +34,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
@@ -43,7 +43,7 @@ private
     raise ManualNotFoundError.new(manual_id)
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("id")
   end
 

--- a/app/services/section/show_service.rb
+++ b/app/services/section/show_service.rb
@@ -12,14 +12,14 @@ private
   attr_reader :context
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
     @manual ||= Manual.find(manual_id, context.current_user)
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("id")
   end
 

--- a/app/services/section/update_service.rb
+++ b/app/services/section/update_service.rb
@@ -21,14 +21,14 @@ private
   attr_reader :context, :listeners
 
   def section
-    @section ||= manual.sections.find { |s| s.id == section_id }
+    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
     @manual ||= Manual.find(manual_id, context.current_user)
   end
 
-  def section_id
+  def section_uuid
     context.params.fetch("id")
   end
 

--- a/app/view_adapters/section_view_adapter.rb
+++ b/app/view_adapters/section_view_adapter.rb
@@ -10,6 +10,10 @@ class SectionViewAdapter < SimpleDelegator
     super(section)
   end
 
+  def id
+    section.uuid
+  end
+
   def persisted?
     section.updated_at || section.published?
   end

--- a/app/view_adapters/section_view_adapter.rb
+++ b/app/view_adapters/section_view_adapter.rb
@@ -23,7 +23,7 @@ class SectionViewAdapter < SimpleDelegator
   end
 
   def to_param
-    section.id
+    section.uuid
   end
 
   def self.model_name

--- a/app/views/sections/reorder.html.erb
+++ b/app/views/sections/reorder.html.erb
@@ -13,7 +13,7 @@
       <ol class="reorderable-document-list">
         <% sections.each do |section| %>
           <li>
-            <input type="hidden" name="section_order[]" value="<%= section.id %>">
+            <input type="hidden" name="section_order[]" value="<%= section.uuid %>">
             <%= section.title %>
           </li>
         <% end %>

--- a/features/step_definitions/deleting_manuals_steps.rb
+++ b/features/step_definitions/deleting_manuals_steps.rb
@@ -24,7 +24,7 @@ end
 Then(/^the manual and its sections are deleted$/) do
   check_manual_does_not_exist_with(@manual_fields)
   check_draft_has_been_discarded_in_publishing_api(@manual.id)
-  check_draft_has_been_discarded_in_publishing_api(@section.id)
+  check_draft_has_been_discarded_in_publishing_api(@section.uuid)
 end
 
 Then(/^the manual and its sections still exist$/) do

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -144,7 +144,7 @@ Then(/^I see the manual has the new section$/) do
 end
 
 Then(/^the section and table of contents will have been sent to the draft publishing api$/) do
-  check_section_is_drafted_to_publishing_api(@section.id)
+  check_section_is_drafted_to_publishing_api(@section.uuid)
   manual_table_of_contents_attributes = {
     details: {
       child_section_groups: [
@@ -168,7 +168,7 @@ Then(/^the section and table of contents will have been sent to the draft publis
 end
 
 Then(/^the updated section at the new slug and updated table of contents will have been sent to the draft publishing api$/) do
-  check_section_is_drafted_to_publishing_api(@section.id)
+  check_section_is_drafted_to_publishing_api(@section.uuid)
   manual_table_of_contents_attributes = {
     details: {
       child_section_groups: [
@@ -277,7 +277,7 @@ Then(/^the manual and the edited section are published$/) do
 end
 
 Then(/^the updated section is available to preview$/) do
-  check_section_is_drafted_to_publishing_api(@updated_section.id)
+  check_section_is_drafted_to_publishing_api(@updated_section.uuid)
   sections = @sections.map do |section|
     {
       title: section == @updated_section ? @updated_fields[:section_title] : section.title,
@@ -302,7 +302,7 @@ Then(/^the updated section is available to preview$/) do
 end
 
 Then(/^the sections that I didn't edit were not republished$/) do
-  @sections.reject { |s| s.id == @updated_section.id }.each do |section|
+  @sections.reject { |s| s.uuid == @updated_section.uuid }.each do |section|
     check_section_was_not_published(section)
   end
 end
@@ -507,19 +507,19 @@ end
 Then(/^the section is published as a major update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @section).id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
 end
 
 Then(/^the section is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @section).id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
 end
 
 Then(/^the section is published as a minor update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @section).id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
 end
 
 Then(/^I can see the change note and update type form when editing existing sections$/) do

--- a/features/step_definitions/removing_manual_section_steps.rb
+++ b/features/step_definitions/removing_manual_section_steps.rb
@@ -29,8 +29,8 @@ When(/^I remove one of the sections from the manual with a minor update$/) do
 end
 
 Then(/^the section is removed from the manual$/) do
-  check_section_was_removed(@manual.id, @removed_section.id)
-  check_draft_has_been_discarded_in_publishing_api(@removed_section.id)
+  check_section_was_removed(@manual.id, @removed_section.uuid)
+  check_draft_has_been_discarded_in_publishing_api(@removed_section.uuid)
 
   # Check that no child section has the removed section's title
   without_removed_section_matcher = ->(request) do
@@ -55,11 +55,11 @@ Then(/^the removed section is withdrawn with a redirect to the manual$/) do
 end
 
 Then(/^the removed section is archived$/) do
-  check_section_is_archived_in_db(@manual, @removed_section.id)
+  check_section_is_archived_in_db(@manual, @removed_section.uuid)
 end
 
 Then(/^the removed section change note is included$/) do
-  @removed_section = Section.find(@manual, @removed_section.id)
+  @removed_section = Section.find(@manual, @removed_section.uuid)
 
   check_manual_is_drafted_to_publishing_api(
     @manual.id,
@@ -69,7 +69,7 @@ Then(/^the removed section change note is included$/) do
 end
 
 Then(/^the removed section change note is not included$/) do
-  @removed_section = Section.find(@manual, @removed_section.id)
+  @removed_section = Section.find(@manual, @removed_section.uuid)
 
   check_manual_is_drafted_to_publishing_api(
     @manual.id,

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -177,8 +177,8 @@ private
       puts "Publishing published edition of manual: #{manual_to_publish.id}"
       publishing_api.publish(manual_to_publish.id, "republish")
       manual_to_publish.sections.each do |section|
-        puts "Publishing published edition of manual section: #{section.id}"
-        publishing_api.publish(section.id, "republish")
+        puts "Publishing published edition of manual section: #{section.uuid}"
+        publishing_api.publish(section.uuid, "republish")
       end
     end
 
@@ -194,7 +194,7 @@ private
     ).call
 
     manual.sections.each do |section|
-      puts "Sending a draft of manual section #{section.id} (version: #{section.version_number})"
+      puts "Sending a draft of manual section #{section.uuid} (version: #{section.version_number})"
       SectionPublishingAPIExporter.new(
         organisation, manual, section
       ).call

--- a/spec/adapters/search_index_adapter_spec.rb
+++ b/spec/adapters/search_index_adapter_spec.rb
@@ -19,7 +19,7 @@ describe SearchIndexAdapter do
   let(:section) {
     Section.build(
       manual: manual,
-      id: "section-id",
+      uuid: "section-id",
       editions: [section_edition],
     )
   }
@@ -36,7 +36,7 @@ describe SearchIndexAdapter do
   let(:removed_section) {
     Section.build(
       manual: manual,
-      id: "removed-section-id",
+      uuid: "removed-section-id",
       editions: [removed_section_edition],
     )
   }

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -29,8 +29,8 @@ describe ManualPublishingAPILinksExporter do
 
   let(:sections) {
     [
-      double(:section, id: "c19ffb7d-448c-4cc8-bece-022662ef9611"),
-      double(:section, id: "f9c91a07-6a41-4b97-94a8-ecdc81997d49"),
+      double(:section, uuid: "c19ffb7d-448c-4cc8-bece-022662ef9611"),
+      double(:section, uuid: "f9c91a07-6a41-4b97-94a8-ecdc81997d49"),
     ]
   }
 

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -62,7 +62,7 @@ describe SectionPublishingAPIExporter do
   let(:section) {
     double(
       :section,
-      id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
+      uuid: "c19ffb7d-448c-4cc8-bece-022662ef9611",
       minor_update?: true,
       attributes: { body: "##Some heading\nmanual section body" },
       attachments: attachments,
@@ -118,7 +118,7 @@ describe SectionPublishingAPIExporter do
     subject.call
 
     expect(publishing_api).to have_received(:put_content).with(
-      section.id,
+      section.uuid,
       all_of(
         hash_including(
           base_path: section_base_path,
@@ -151,7 +151,7 @@ describe SectionPublishingAPIExporter do
       subject.call
 
       expect(publishing_api).to have_received(:put_content).with(
-        section.id,
+        section.uuid,
         hash_including(
           first_published_at: previously_published_date.iso8601,
         )
@@ -163,7 +163,7 @@ describe SectionPublishingAPIExporter do
       subject.call
 
       expect(publishing_api).to have_received(:put_content).with(
-        section.id,
+        section.uuid,
         hash_including(
           public_updated_at: previously_published_date.iso8601,
         )
@@ -175,7 +175,7 @@ describe SectionPublishingAPIExporter do
       subject.call
 
       expect(publishing_api).to have_received(:put_content).with(
-        section.id,
+        section.uuid,
         hash_excluding(:public_updated_at)
       )
     end
@@ -185,7 +185,7 @@ describe SectionPublishingAPIExporter do
     let(:section) {
       double(
         :section,
-        id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
+        uuid: "c19ffb7d-448c-4cc8-bece-022662ef9611",
         minor_update?: update_type_attributes[:minor_update?],
         attributes: { body: "##Some heading\nmanual section body" },
         attachments: attachments,
@@ -302,7 +302,7 @@ describe SectionPublishingAPIExporter do
     subject.call
 
     expect(publishing_api).to have_received(:put_content).with(
-      section.id,
+      section.uuid,
       hash_including(
         details: {
           body:

--- a/spec/exporters/section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_links_exporter_spec.rb
@@ -30,7 +30,7 @@ describe SectionPublishingAPILinksExporter do
   let(:section) {
     double(
       :section,
-      id: "c19ffb7d-448c-4cc8-bece-022662ef9611",
+      uuid: "c19ffb7d-448c-4cc8-bece-022662ef9611",
       minor_update?: true,
       attributes: { body: "##Some heading\nmanual section body" },
       attachments: []
@@ -45,7 +45,7 @@ describe SectionPublishingAPILinksExporter do
     subject.call
 
     expect(publishing_api).to have_received(:patch_links).with(
-      section.id,
+      section.uuid,
       hash_including(
         links: {
           organisations: [organisation.content_id],

--- a/spec/features/manual_urls_spec.rb
+++ b/spec/features/manual_urls_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "manual urls", type: :feature do
     click_on "A manual"
 
     expect(page).to have_link("Edit manual", href: %r{/manuals/#{manual.id}/edit$})
-    expect(page).to have_link("Section 1", href: %r{/manuals/#{manual.id}/sections/#{section.id}$})
+    expect(page).to have_link("Section 1", href: %r{/manuals/#{manual.id}/sections/#{section.uuid}$})
 
     click_on "Section 1"
 
-    expect(page).to have_link("Edit section", href: %r{/manuals/#{manual.id}/sections/#{section.id}/edit$})
+    expect(page).to have_link("Edit section", href: %r{/manuals/#{manual.id}/sections/#{section.uuid}/edit$})
   end
 end

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Publishing manuals", type: :feature do
 
     it "drafts the manual and sections and publishes them to the Publishing API" do
       @sections.each do |section|
-        check_section_is_drafted_to_publishing_api(section.id, number_of_drafts: 2)
+        check_section_is_drafted_to_publishing_api(section.uuid, number_of_drafts: 2)
         check_manual_and_sections_were_published(@manual, section, manual_fields, section_fields(section))
       end
     end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe "Republishing manuals", type: :feature do
       check_manual_is_published_to_publishing_api(@manual.id)
       check_manual_is_published_to_rummager(@manual.slug, manual_fields)
       @sections.each do |section|
-        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+        check_section_is_drafted_to_publishing_api(section.uuid, extra_attributes: {
           title: section.attributes[:title],
           description: section.attributes[:summary],
         })
-        check_section_is_published_to_publishing_api(section.id)
+        check_section_is_published_to_publishing_api(section.uuid)
         check_section_is_published_to_rummager(section.slug, section_fields(section), manual_fields)
       end
     end
@@ -96,11 +96,11 @@ RSpec.describe "Republishing manuals", type: :feature do
       check_manual_is_not_published_to_publishing_api(@manual.id)
       check_manual_is_not_published_to_rummager(@manual.slug)
       @sections.each do |section|
-        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+        check_section_is_drafted_to_publishing_api(section.uuid, extra_attributes: {
           title: section.attributes[:title],
           description: section.attributes[:summary],
         })
-        check_section_is_not_published_to_publishing_api(section.id)
+        check_section_is_not_published_to_publishing_api(section.uuid)
         check_section_is_not_published_to_rummager(section.slug)
       end
     end
@@ -128,11 +128,11 @@ RSpec.describe "Republishing manuals", type: :feature do
       check_manual_is_published_to_rummager(@manual.slug, manual_fields)
       @sections.each do |section|
         edited_fields = edited_section_fields(section)
-        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+        check_section_is_drafted_to_publishing_api(section.uuid, extra_attributes: {
           title: edited_fields[:title],
           description: edited_fields[:summary],
         })
-        check_section_is_published_to_publishing_api(section.id)
+        check_section_is_published_to_publishing_api(section.uuid)
         check_section_is_published_to_rummager(section.slug, section_fields(section), manual_fields)
       end
     end
@@ -147,13 +147,13 @@ RSpec.describe "Republishing manuals", type: :feature do
       check_manual_is_published_to_publishing_api(@manual.id, times: 1)
       check_manual_is_not_published_to_rummager_with_attrs(@manual.slug, edited_manual_fields)
       @edited_sections.each do |section|
-        check_section_is_drafted_to_publishing_api(section.id, extra_attributes: {
+        check_section_is_drafted_to_publishing_api(section.uuid, extra_attributes: {
           title: section.title,
           description: section.summary,
         })
         # we can't check that it's not published (because one version will be)
         # all we can check is that it was only published once
-        check_section_is_published_to_publishing_api(section.id, times: 1)
+        check_section_is_published_to_publishing_api(section.uuid, times: 1)
         check_section_is_not_published_to_rummager_with_attrs(section.slug, section_fields(section), edited_manual_fields)
       end
     end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -226,9 +226,9 @@ describe Manual do
       ]
     }
 
-    let(:alpha_section) { double(:section, id: "alpha") }
-    let(:beta_section) { double(:section, id: "beta") }
-    let(:gamma_section) { double(:section, id: "gamma") }
+    let(:alpha_section) { double(:section, uuid: "alpha") }
+    let(:beta_section) { double(:section, uuid: "beta") }
+    let(:gamma_section) { double(:section, uuid: "gamma") }
 
     let(:section_order) { %w(gamma alpha beta) }
 
@@ -289,11 +289,11 @@ describe Manual do
         section_b,
       ]
     }
-    let(:section_a) { double(:section, id: "a") }
-    let(:section_b) { double(:section, id: "b") }
+    let(:section_a) { double(:section, uuid: "a") }
+    let(:section_b) { double(:section, uuid: "b") }
 
     let(:removed_sections) { [section_c] }
-    let(:section_c) { double(:section, id: "c") }
+    let(:section_c) { double(:section, uuid: "c") }
 
     before do
       manual.sections = sections
@@ -301,13 +301,13 @@ describe Manual do
     end
 
     it "removes the section from #sections" do
-      manual.remove_section(section_a.id)
+      manual.remove_section(section_a.uuid)
 
       expect(manual.sections.to_a).to eq([section_b])
     end
 
     it "adds the section to #removed_sections" do
-      manual.remove_section(section_a.id)
+      manual.remove_section(section_a.uuid)
 
       expect(manual.removed_sections.to_a).to eq(
         [
@@ -449,7 +449,7 @@ describe Manual do
     end
 
     context 'with sections' do
-      let(:section) { double(:section, id: 'section-id', save: nil) }
+      let(:section) { double(:section, uuid: 'section-uuid', save: nil) }
 
       before do
         manual.sections = [section]
@@ -469,12 +469,12 @@ describe Manual do
           manual_record_id: record.id
         ).first
 
-        expect(edition.section_ids).to eq(['section-id'])
+        expect(edition.section_ids).to eq(['section-uuid'])
       end
     end
 
     context 'with removed sections' do
-      let(:section) { double(:section, id: 'section-id', save: nil) }
+      let(:section) { double(:section, uuid: 'section-uuid', save: nil) }
 
       before do
         manual.removed_sections = [section]
@@ -494,7 +494,7 @@ describe Manual do
           manual_record_id: record.id
         ).first
 
-        expect(edition.removed_section_ids).to eq(['section-id'])
+        expect(edition.removed_section_ids).to eq(['section-uuid'])
       end
     end
   end
@@ -538,14 +538,14 @@ describe Manual do
 
           section_1 = sections[0]
           expect(section_1).to be_a ::Section
-          expect(section_1.id).to eq "12345"
+          expect(section_1.uuid).to eq "12345"
           expect(section_1).to be_draft
           expect(section_1.version_number).to eq 1
           expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
           section_2 = sections[1]
           expect(section_2).to be_a ::Section
-          expect(section_2.id).to eq "67890"
+          expect(section_2.uuid).to eq "67890"
           expect(section_2).to be_draft
           expect(section_2.version_number).to eq 1
           expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -583,14 +583,14 @@ describe Manual do
 
           section_1 = sections[0]
           expect(section_1).to be_a ::Section
-          expect(section_1.id).to eq "12345"
+          expect(section_1.uuid).to eq "12345"
           expect(section_1).to be_published
           expect(section_1.version_number).to eq 1
           expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
           section_2 = sections[1]
           expect(section_2).to be_a ::Section
-          expect(section_2.id).to eq "67890"
+          expect(section_2.uuid).to eq "67890"
           expect(section_2).to be_published
           expect(section_2.version_number).to eq 1
           expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -664,14 +664,14 @@ describe Manual do
 
             section_1 = sections[0]
             expect(section_1).to be_a ::Section
-            expect(section_1.id).to eq "12345"
+            expect(section_1.uuid).to eq "12345"
             expect(section_1).to be_published
             expect(section_1.version_number).to eq 1
             expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
             section_2 = sections[1]
             expect(section_2).to be_a ::Section
-            expect(section_2.id).to eq "67890"
+            expect(section_2.uuid).to eq "67890"
             expect(section_2).to be_published
             expect(section_2.version_number).to eq 1
             expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -697,14 +697,14 @@ describe Manual do
 
             section_1 = sections[0]
             expect(section_1).to be_a ::Section
-            expect(section_1.id).to eq "12345"
+            expect(section_1.uuid).to eq "12345"
             expect(section_1).to be_draft
             expect(section_1.version_number).to eq 2
             expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
             section_2 = sections[1]
             expect(section_2).to be_a ::Section
-            expect(section_2.id).to eq "67890"
+            expect(section_2.uuid).to eq "67890"
             expect(section_2).to be_draft
             expect(section_2.version_number).to eq 2
             expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -735,14 +735,14 @@ describe Manual do
 
             section_1 = sections[0]
             expect(section_1).to be_a ::Section
-            expect(section_1.id).to eq "12345"
+            expect(section_1.uuid).to eq "12345"
             expect(section_1).to be_published
             expect(section_1.version_number).to eq 1
             expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
             section_2 = sections[1]
             expect(section_2).to be_a ::Section
-            expect(section_2.id).to eq "67890"
+            expect(section_2.uuid).to eq "67890"
             expect(section_2).to be_published
             expect(section_2.version_number).to eq 1
             expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -768,14 +768,14 @@ describe Manual do
 
             section_1 = sections[0]
             expect(section_1).to be_a ::Section
-            expect(section_1.id).to eq "12345"
+            expect(section_1.uuid).to eq "12345"
             expect(section_1).to be_published
             expect(section_1.version_number).to eq 1
             expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
             section_2 = sections[1]
             expect(section_2).to be_a ::Section
-            expect(section_2.id).to eq "67890"
+            expect(section_2.uuid).to eq "67890"
             expect(section_2).to be_published
             expect(section_2.version_number).to eq 1
             expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -807,14 +807,14 @@ describe Manual do
 
             section_1 = sections[0]
             expect(section_1).to be_a ::Section
-            expect(section_1.id).to eq "12345"
+            expect(section_1.uuid).to eq "12345"
             expect(section_1).to be_published
             expect(section_1.version_number).to eq 1
             expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
             section_2 = sections[1]
             expect(section_2).to be_a ::Section
-            expect(section_2.id).to eq "67890"
+            expect(section_2.uuid).to eq "67890"
             expect(section_2).to be_published
             expect(section_2.version_number).to eq 1
             expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"
@@ -840,14 +840,14 @@ describe Manual do
 
             section_1 = sections[0]
             expect(section_1).to be_a ::Section
-            expect(section_1.id).to eq "12345"
+            expect(section_1.uuid).to eq "12345"
             expect(section_1).to be_published
             expect(section_1.version_number).to eq 1
             expect(section_1.slug).to eq "guidance/my-amazing-manual/section-1"
 
             section_2 = sections[1]
             expect(section_2).to be_a ::Section
-            expect(section_2.id).to eq "67890"
+            expect(section_2.uuid).to eq "67890"
             expect(section_2).to be_draft
             expect(section_2.version_number).to eq 2
             expect(section_2.slug).to eq "guidance/my-amazing-manual/section-2"

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -121,7 +121,7 @@ describe Section do
       end
 
       it 'builds a section using the section id' do
-        expect(Section).to receive(:build).with(including(id: 'section-id'))
+        expect(Section).to receive(:build).with(including(uuid: 'section-id'))
         Section.find(manual, 'section-id')
       end
 

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -606,9 +606,9 @@ describe Section do
       )
     end
 
-    it "returns a has including the section's id" do
+    it "returns a has including the section's uuid" do
       expect(section.attributes).to include(
-        id: section_uuid,
+        uuid: section_uuid,
       )
     end
   end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -165,14 +165,14 @@ describe Section do
   describe "#eql?" do
     let(:editions) { [draft_edition_v1] }
 
-    it "is considered the same as another section instance if they have the same id" do
+    it "is considered the same as another section instance if they have the same uuid" do
       expect(section).to eql(section)
-      expect(section).to eql(Section.new(slug_generator, section.id, [draft_edition_v1]))
-      expect(section).not_to eql(Section.new(slug_generator, section.id.reverse, [draft_edition_v1]))
+      expect(section).to eql(Section.new(slug_generator, section.uuid, [draft_edition_v1]))
+      expect(section).not_to eql(Section.new(slug_generator, section.uuid.reverse, [draft_edition_v1]))
     end
 
-    it "is considered the same as another section instance with the same id even if they have different version numbers" do
-      expect(section).to eql(Section.new(slug_generator, section.id, [draft_edition_v2]))
+    it "is considered the same as another section instance with the same uuid even if they have different version numbers" do
+      expect(section).to eql(Section.new(slug_generator, section.uuid, [draft_edition_v2]))
     end
   end
 

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Section::RemoveService do
-  let(:section_id) { "123" }
+  let(:section_uuid) { "123" }
 
   let(:manual) {
     double(
@@ -18,7 +18,7 @@ RSpec.describe Section::RemoveService do
   let(:service_context) {
     double(
       params: {
-        "id" => section_id,
+        "id" => section_uuid,
         "manual_id" => "ABC",
         "section" => change_note_params
       },
@@ -43,7 +43,7 @@ RSpec.describe Section::RemoveService do
 
   context "with a section id that doesn't belong to the manual" do
     let(:section) {
-      double(id: section_id)
+      double(uuid: section_uuid)
     }
     let(:manual) {
       double(
@@ -62,7 +62,7 @@ RSpec.describe Section::RemoveService do
     it "raises a SectionNotFoundError" do
       expect {
         service.call
-      }.to raise_error(described_class::SectionNotFoundError, section_id)
+      }.to raise_error(described_class::SectionNotFoundError, section_uuid)
     end
 
     context "when SectionNotFoundError is raised" do
@@ -92,7 +92,7 @@ RSpec.describe Section::RemoveService do
   context "with invalid change_note params" do
     let(:section) {
       double(
-        id: section_id,
+        uuid: section_uuid,
         published?: true,
         update: nil,
         valid?: false,
@@ -114,7 +114,7 @@ RSpec.describe Section::RemoveService do
     end
 
     it "does not removes the section" do
-      expect(manual).not_to have_received(:remove_section).with(section.id)
+      expect(manual).not_to have_received(:remove_section).with(section.uuid)
     end
 
     it "does not mark the manual as a draft" do
@@ -145,7 +145,7 @@ RSpec.describe Section::RemoveService do
     context "with a section that's previously been published" do
       let(:section) {
         double(
-          id: section_id,
+          uuid: section_uuid,
           published?: true,
           update: nil,
           valid?: true,
@@ -161,7 +161,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "removes the section" do
-        expect(manual).to have_received(:remove_section).with(section.id)
+        expect(manual).to have_received(:remove_section).with(section.uuid)
       end
 
       it "marks the manual as a draft" do
@@ -184,7 +184,7 @@ RSpec.describe Section::RemoveService do
     context "with a section that's never been published" do
       let(:section) {
         double(
-          id: section_id,
+          uuid: section_uuid,
           published?: false,
           update: nil,
           valid?: true,
@@ -200,7 +200,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "removes the section" do
-        expect(manual).to have_received(:remove_section).with(section_id)
+        expect(manual).to have_received(:remove_section).with(section_uuid)
       end
 
       it "marks the manual as a draft" do
@@ -224,7 +224,7 @@ RSpec.describe Section::RemoveService do
     context "with extra section params" do
       let(:section) {
         double(
-          id: section_id,
+          uuid: section_uuid,
           published?: true,
           update: nil,
           valid?: true,


### PR DESCRIPTION
We're planning to introduce a Mongo-backed `Section` class in the near future. This will have its own internal Mongoid ID field as well as the UUID currently stored on the `SectionEdition` records. Renaming `Section#id` to `Section#uuid` should hopefully help us avoid confusion when we introduce the `Section` class.

I plan to rename `ManualRecord::Edition#section_ids` and `ManualRecord::Edition#removed_section_ids` in future PRs.

This follows on from PR #1035 which renamed `SectionEdition#section_id` to `#section_uuid`.