### PR TITLE
Introduce OrganisationsAdapter & inline OrganisationFetcher into it

### DIFF
--- a/app/adapters/organisations_adapter.rb
+++ b/app/adapters/organisations_adapter.rb
@@ -1,0 +1,11 @@
+class OrganisationsAdapter
+  def find(slug)
+    response = OrganisationFetcher.fetch(slug)
+    Organisation.new(
+      title: response["title"],
+      web_url: response["web_url"],
+      abbreviation: response["details"]["abbreviation"],
+      content_id: response["details"]["content_id"]
+    )
+  end
+end

--- a/app/adapters/organisations_adapter.rb
+++ b/app/adapters/organisations_adapter.rb
@@ -1,11 +1,19 @@
 class OrganisationsAdapter
+  def initialize
+    @api = Services.organisations
+    @cache = {}
+  end
+
   def find(slug)
-    response = OrganisationFetcher.fetch(slug)
-    Organisation.new(
-      title: response["title"],
-      web_url: response["web_url"],
-      abbreviation: response["details"]["abbreviation"],
-      content_id: response["details"]["content_id"]
-    )
+    @cache.fetch(slug) do
+      response = @api.organisation(slug)
+      organisation = Organisation.new(
+        title: response["title"],
+        web_url: response["web_url"],
+        abbreviation: response["details"]["abbreviation"],
+        content_id: response["details"]["content_id"]
+      )
+      @cache[slug] = organisation
+    end
   end
 end

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -125,9 +125,9 @@ private
 
   def organisation_info
     {
-      title: organisation["title"],
-      abbreviation: organisation["details"]["abbreviation"],
-      web_url: organisation["web_url"],
+      title: organisation.title,
+      abbreviation: organisation.abbreviation,
+      web_url: organisation.web_url,
     }
   end
 end

--- a/app/exporters/manual_publishing_api_links_exporter.rb
+++ b/app/exporters/manual_publishing_api_links_exporter.rb
@@ -19,7 +19,7 @@ private
   def exportable_attributes
     {
       links: {
-        organisations: [organisation["details"]["content_id"]],
+        organisations: [organisation.content_id],
         sections: manual.sections.map(&:id),
       },
     }

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,13 +1,8 @@
 class PublishingApiDraftManualExporter
   def call(manual)
-    ManualPublishingAPILinksExporter.new(
-      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
-      manual
-    ).call
+    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
 
-    ManualPublishingAPIExporter.new(
-      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
-      manual
-    ).call
+    ManualPublishingAPILinksExporter.new(organisation, manual).call
+    ManualPublishingAPIExporter.new(organisation, manual).call
   end
 end

--- a/app/exporters/publishing_api_draft_manual_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_exporter.rb
@@ -1,6 +1,6 @@
 class PublishingApiDraftManualExporter
   def call(manual)
-    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
+    organisation = OrganisationsAdapter.new.find(manual.organisation_slug)
 
     ManualPublishingAPILinksExporter.new(organisation, manual).call
     ManualPublishingAPIExporter.new(organisation, manual).call

--- a/app/exporters/publishing_api_draft_manual_with_sections_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_with_sections_exporter.rb
@@ -2,7 +2,7 @@ class PublishingApiDraftManualWithSectionsExporter
   def call(manual, action = nil)
     update_type = (action == :republish ? "republish" : nil)
 
-    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
+    organisation = OrganisationsAdapter.new.find(manual.organisation_slug)
 
     ManualPublishingAPILinksExporter.new(
       organisation, manual

--- a/app/exporters/publishing_api_draft_manual_with_sections_exporter.rb
+++ b/app/exporters/publishing_api_draft_manual_with_sections_exporter.rb
@@ -2,7 +2,7 @@ class PublishingApiDraftManualWithSectionsExporter
   def call(manual, action = nil)
     update_type = (action == :republish ? "republish" : nil)
 
-    organisation = organisation(manual.attributes.fetch(:organisation_slug))
+    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
 
     ManualPublishingAPILinksExporter.new(
       organisation, manual
@@ -23,9 +23,5 @@ class PublishingApiDraftManualWithSectionsExporter
         organisation, manual, section, update_type: update_type
       ).call
     end
-  end
-
-  def organisation(slug)
-    OrganisationFetcher.fetch(slug)
   end
 end

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -1,6 +1,6 @@
 class PublishingApiDraftSectionExporter
   def call(section, manual)
-    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
+    organisation = OrganisationsAdapter.new.find(manual.organisation_slug)
 
     SectionPublishingAPILinksExporter.new(organisation, manual, section).call
     SectionPublishingAPIExporter.new(organisation, manual, section).call

--- a/app/exporters/publishing_api_draft_section_exporter.rb
+++ b/app/exporters/publishing_api_draft_section_exporter.rb
@@ -1,15 +1,8 @@
 class PublishingApiDraftSectionExporter
   def call(section, manual)
-    SectionPublishingAPILinksExporter.new(
-      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
-      manual,
-      section
-    ).call
+    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
 
-    SectionPublishingAPIExporter.new(
-      OrganisationFetcher.fetch(manual.attributes.fetch(:organisation_slug)),
-      manual,
-      section
-    ).call
+    SectionPublishingAPILinksExporter.new(organisation, manual, section).call
+    SectionPublishingAPIExporter.new(organisation, manual, section).call
   end
 end

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -117,9 +117,9 @@ private
 
   def organisation_info
     {
-      title: organisation["title"],
-      abbreviation: organisation["details"]["abbreviation"],
-      web_url: organisation["web_url"],
+      title: organisation.title,
+      abbreviation: organisation.abbreviation,
+      web_url: organisation.web_url,
     }
   end
 end

--- a/app/exporters/section_publishing_api_links_exporter.rb
+++ b/app/exporters/section_publishing_api_links_exporter.rb
@@ -20,7 +20,7 @@ private
   def exportable_attributes
     {
       links: {
-        organisations: [organisation["details"]["content_id"]],
+        organisations: [organisation.content_id],
         manual: [manual.id],
       },
     }

--- a/app/lib/organisation_fetcher.rb
+++ b/app/lib/organisation_fetcher.rb
@@ -1,8 +1,0 @@
-require "services"
-
-class OrganisationFetcher
-  def self.fetch(organisation_slug)
-    @organisations ||= {}
-    @organisations[organisation_slug] ||= Services.organisations.organisation(organisation_slug)
-  end
-end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,13 @@
+class Organisation
+  attr_reader :title
+  attr_reader :abbreviation
+  attr_reader :content_id
+  attr_reader :web_url
+
+  def initialize(attributes = {})
+    @title = attributes[:title]
+    @abbreviation = attributes[:abbreviation]
+    @content_id = attributes[:content_id]
+    @web_url = attributes[:web_url]
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,8 +1,8 @@
 class Organisation
-  attr_reader :title
-  attr_reader :abbreviation
-  attr_reader :content_id
-  attr_reader :web_url
+  attr_accessor :title
+  attr_accessor :abbreviation
+  attr_accessor :content_id
+  attr_accessor :web_url
 
   def initialize(attributes = {})
     @title = attributes[:title]

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -186,7 +186,7 @@ private
   end
 
   def send_draft(manual)
-    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
+    organisation = OrganisationsAdapter.new.find(manual.organisation_slug)
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -186,7 +186,7 @@ private
   end
 
   def send_draft(manual)
-    organisation = fetch_organisation(manual.organisation_slug)
+    organisation = OrganisationFetcher.fetch(manual.organisation_slug)
 
     puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
     ManualPublishingAPIExporter.new(
@@ -227,9 +227,5 @@ private
 
   def publishing_api
     Services.publishing_api
-  end
-
-  def fetch_organisation(slug)
-    OrganisationFetcher.fetch(slug)
   end
 end

--- a/spec/adapters/organisations_adapter_spec.rb
+++ b/spec/adapters/organisations_adapter_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+describe OrganisationsAdapter do
+  let(:api) { double(:organisations_api) }
+
+  before do
+    allow(Services).to receive(:organisations).and_return(api)
+  end
+
+  describe "#find" do
+    let(:response) {
+      {
+        "title" => "organisation-title",
+        "web_url" => "organisation-web-url",
+        "details" => {
+          "abbreviation" => "organisation-abbreviation",
+          "content_id" => "organisation-content-id"
+        }
+      }
+    }
+
+    before do
+      allow(api).to receive(:organisation).with("slug").and_return(response)
+    end
+
+    it "returns an Organisation populated from the Organisations API" do
+      organisation = subject.find("slug")
+
+      expect(organisation.title).to eq("organisation-title")
+      expect(organisation.abbreviation).to eq("organisation-abbreviation")
+      expect(organisation.web_url).to eq("organisation-web-url")
+      expect(organisation.content_id).to eq("organisation-content-id")
+    end
+
+    it "caches the result for a given slug from the Organisations API" do
+      subject.find("slug")
+      subject.find("slug")
+
+      expect(api).to have_received(:organisation).with("slug").at_most(:once)
+    end
+  end
+end

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -50,11 +50,12 @@ describe ManualPublishingAPIExporter do
   }
 
   let(:organisation) {
-    {
-      "web_url" => "https://www.gov.uk/government/organisations/cabinet-office",
-      "title" => "Cabinet Office",
-      "details" => { "abbreviation" => "CO", "content_id" => "d94d63a5-ce8e-40a1-ab4c-4956eab27259" },
-    }
+    Organisation.new(
+      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
+      title: "Cabinet Office",
+      abbreviation: "CO",
+      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
+    )
   }
 
   let(:manual_attributes) {

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -49,14 +49,7 @@ describe ManualPublishingAPIExporter do
     }
   }
 
-  let(:organisation) {
-    Organisation.new(
-      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
-      title: "Cabinet Office",
-      abbreviation: "CO",
-      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
-    )
-  }
+  let(:organisation) { FactoryGirl.build(:organisation) }
 
   let(:manual_attributes) {
     {

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -13,14 +13,7 @@ describe ManualPublishingAPILinksExporter do
 
   let(:publishing_api) { double(:publishing_api, patch_links: nil) }
 
-  let(:organisation) {
-    Organisation.new(
-      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
-      title: "Cabinet Office",
-      abbreviation: "CO",
-      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
-    )
-  }
+  let(:organisation) { FactoryGirl.build(:organisation) }
 
   let(:manual) {
     double(

--- a/spec/exporters/manual_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_links_exporter_spec.rb
@@ -14,11 +14,12 @@ describe ManualPublishingAPILinksExporter do
   let(:publishing_api) { double(:publishing_api, patch_links: nil) }
 
   let(:organisation) {
-    {
-      "web_url" => "https://www.gov.uk/government/organisations/cabinet-office",
-      "title" => "Cabinet Office",
-      "details" => { "abbreviation" => "CO", "content_id" => "d94d63a5-ce8e-40a1-ab4c-4956eab27259" },
-    }
+    Organisation.new(
+      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
+      title: "Cabinet Office",
+      abbreviation: "CO",
+      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
+    )
   }
 
   let(:manual) {
@@ -51,7 +52,7 @@ describe ManualPublishingAPILinksExporter do
       manual.id,
       hash_including(
         links: {
-          organisations: [organisation["details"]["content_id"]],
+          organisations: [organisation.content_id],
           sections: %w[c19ffb7d-448c-4cc8-bece-022662ef9611 f9c91a07-6a41-4b97-94a8-ecdc81997d49],
         }
       )

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -17,11 +17,12 @@ describe SectionPublishingAPIExporter do
   let(:section_renderer) { ->(_) { double(:rendered_section, attributes: rendered_attributes) } }
 
   let(:organisation) {
-    {
-      "web_url" => "https://www.gov.uk/government/organisations/cabinet-office",
-      "title" => "Cabinet Office",
-      "details" => { "abbreviation" => "CO", "content_id" => "d94d63a5-ce8e-40a1-ab4c-4956eab27259" },
-    }
+    Organisation.new(
+      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
+      title: "Cabinet Office",
+      abbreviation: "CO",
+      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
+    )
   }
 
   let(:manual) {

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -16,14 +16,7 @@ describe SectionPublishingAPIExporter do
   let(:publishing_api) { double(:publishing_api, put_content: nil) }
   let(:section_renderer) { ->(_) { double(:rendered_section, attributes: rendered_attributes) } }
 
-  let(:organisation) {
-    Organisation.new(
-      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
-      title: "Cabinet Office",
-      abbreviation: "CO",
-      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
-    )
-  }
+  let(:organisation) { FactoryGirl.build(:organisation) }
 
   let(:manual) {
     double(

--- a/spec/exporters/section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_links_exporter_spec.rb
@@ -14,14 +14,7 @@ describe SectionPublishingAPILinksExporter do
 
   let(:publishing_api) { double(:publishing_api, patch_links: nil) }
 
-  let(:organisation) {
-    Organisation.new(
-      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
-      title: "Cabinet Office",
-      abbreviation: "CO",
-      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
-    )
-  }
+  let(:organisation) { FactoryGirl.build(:organisation) }
 
   let(:manual) {
     double(

--- a/spec/exporters/section_publishing_api_links_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_links_exporter_spec.rb
@@ -15,11 +15,12 @@ describe SectionPublishingAPILinksExporter do
   let(:publishing_api) { double(:publishing_api, patch_links: nil) }
 
   let(:organisation) {
-    {
-      "web_url" => "https://www.gov.uk/government/organisations/cabinet-office",
-      "title" => "Cabinet Office",
-      "details" => { "abbreviation" => "CO", "content_id" => "d94d63a5-ce8e-40a1-ab4c-4956eab27259" },
-    }
+    Organisation.new(
+      web_url: "https://www.gov.uk/government/organisations/cabinet-office",
+      title: "Cabinet Office",
+      abbreviation: "CO",
+      content_id: "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
+    )
   }
 
   let(:manual) {
@@ -54,7 +55,7 @@ describe SectionPublishingAPILinksExporter do
       section.id,
       hash_including(
         links: {
-          organisations: [organisation["details"]["content_id"]],
+          organisations: [organisation.content_id],
           manual: [manual.id],
         }
       )

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -87,4 +87,11 @@ FactoryGirl.define do
     originally_published_at Time.now
     use_originally_published_at_for_public_timestamp true
   end
+
+  factory :organisation do
+    title "Cabinet Office"
+    web_url "https://www.gov.uk/government/organisations/cabinet-office"
+    abbreviation "CO"
+    content_id "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
+  end
 end


### PR DESCRIPTION
The new `OrganisationsAdapter` class is intended to provide the **only** interface that the application code should use to interact with the Organisations API. The intention is that the method signatures, return values and exceptions should all be in terms of the application's own domain model and **not** the classes or concepts specific to the Organisations API, i.e. it should abstract the application away from knowing anything about the underlying external API. To this end, I've introduced a new `Organisation` model. I've also introduced an "organisation" factory to DRY up the exporter specs. As before the choice of the word "Adapter" in the class name is taken from the [Ports and Adapters Pattern][1].

This is a continuation of the work described in #996. It's really all about establishing a consistent level of abstraction.

Closes #1049.

[1]: http://alistair.cockburn.us/Hexagonal+architecture