### PR TITLE
Add missing require statement to adapter classes

### DIFF
--- a/app/adapters/organisations_adapter.rb
+++ b/app/adapters/organisations_adapter.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class OrganisationsAdapter
   def initialize
     @api = Services.organisations

--- a/app/adapters/search_index_adapter.rb
+++ b/app/adapters/search_index_adapter.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class SearchIndexAdapter
   RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL = "manual".freeze
   RUMMAGER_DOCUMENT_TYPE_FOR_SECTION = "manual_section".freeze


### PR DESCRIPTION
The `Services` module lives in the `lib` directory and so is not auto-loaded.

Thanks to @chrisroos for [spotting this][1].

[1]: https://github.com/alphagov/manuals-publisher/pull/1053#pullrequestreview-36269656