### PR TITLE
Remove unnecessary examples from Publishing API exporter specs

### DIFF
--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -289,28 +289,6 @@ describe ManualPublishingAPIExporter do
         )
       end
     end
-
-    context "when update_type is provided as 'minor'" do
-      let(:explicit_update_type) { "minor" }
-      it "exports with the update_type set to minor" do
-        subject.call
-        expect(publishing_api).to have_received(:put_content).with(
-          "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-          hash_including(update_type: "minor")
-        )
-      end
-    end
-
-    context "when update_type is provided as 'major'" do
-      let(:explicit_update_type) { "major" }
-      it "exports with the update_type set to major" do
-        subject.call
-        expect(publishing_api).to have_received(:put_content).with(
-          "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-          hash_including(update_type: "major")
-        )
-      end
-    end
   end
 
   context "when no sections need exporting" do

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -224,17 +224,6 @@ describe SectionPublishingAPIExporter do
           )
         end
       end
-
-      context "when update_type is provided as 'major'" do
-        let(:explicit_update_type) { "major" }
-        it "exports with the update_type set to major" do
-          subject.call
-          expect(publishing_api).to have_received(:put_content).with(
-            "c19ffb7d-448c-4cc8-bece-022662ef9611",
-            hash_including(update_type: "major")
-          )
-        end
-      end
     end
 
     context "the section is a minor update" do


### PR DESCRIPTION
These examples are testing scenarios which do not happen in production, so it's safe to remove them.

The fact that they are shared examples means they are executed multiple times in different contexts exacerbating the problem.