### PR TITLE
Rename ManualRecord::Edition#section_ids to #section_uuids

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -95,7 +95,7 @@ class Manual
     sections.each(&:save)
     removed_sections.each(&:save)
 
-    edition.section_ids = sections.map(&:uuid)
+    edition.section_uuids = sections.map(&:uuid)
     edition.removed_section_ids = removed_sections.map(&:uuid)
 
     manual_record.save!
@@ -273,7 +273,7 @@ class Manual
     end
 
     def add_sections_to_manual(manual, edition, published: false)
-      sections = Array(edition.section_ids).map { |section_uuid|
+      sections = Array(edition.section_uuids).map { |section_uuid|
         Section.find(manual, section_uuid, published: published)
       }
 

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -75,7 +75,7 @@ private
     field :body, type: String
     field :state, type: String
     field :version_number, type: Integer
-    field :section_ids, type: Array
+    field :section_ids, type: Array, as: :section_uuids
     field :removed_section_ids, type: Array
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -75,7 +75,7 @@ private
     field :body, type: String
     field :state, type: String
     field :version_number, type: Integer
-    field :section_ids, type: Array, as: :section_uuids
+    field :section_uuids, type: Array
     field :removed_section_ids, type: Array
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean

--- a/db/migrate/20170505110103_rename_manual_record_edition_section_ids_to_section_uuids.rb
+++ b/db/migrate/20170505110103_rename_manual_record_edition_section_ids_to_section_uuids.rb
@@ -1,0 +1,13 @@
+class RenameManualRecordEditionSectionIdsToSectionUuids < Mongoid::Migration
+  def self.up
+    ManualRecord::Edition.all.each do |manual_record_edition|
+      manual_record_edition.rename(:section_ids, :section_uuids)
+    end
+  end
+
+  def self.down
+    ManualRecord::Edition.all.each do |manual_record_edition|
+      manual_record_edition.rename(:section_uuids, :section_ids)
+    end
+  end
+end

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -80,6 +80,6 @@ private
   end
 
   def all_unique_section_ids_for_manual(manual)
-    manual.editions.map(&:section_ids).flatten.uniq
+    manual.editions.map(&:section_uuids).flatten.uniq
   end
 end

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -60,7 +60,7 @@ private
   end
 
   def section_ids_for(manual_record)
-    manual_record.editions.flat_map(&:section_ids).uniq
+    manual_record.editions.flat_map(&:section_uuids).uniq
   end
 
   # Some of this method violates SRP -- we could move it out to a service if we

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -54,7 +54,7 @@ private
   end
 
   def build_logs_for_all_other_suitable_section_editions
-    edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.section_ids)
+    edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.section_uuids)
 
     edition_ordering.sort_by_section_uuids_and_created_at.each do |edition|
       PublicationLog.create!(
@@ -69,7 +69,7 @@ private
   end
 
   def section_editions_for_first_manual_edition
-    @section_editions_for_first_manual_edition ||= SectionEdition.all_for_sections(*first_manual_edition.section_ids).where(:minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
+    @section_editions_for_first_manual_edition ||= SectionEdition.all_for_sections(*first_manual_edition.section_uuids).where(:minor_update.nin => [true], version_number: 1).any_of({ state: "published" }, state: "archived")
   end
 
   def first_manual_edition

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -37,11 +37,11 @@ private
   end
 
   def old_section_ids
-    @old_section_ids ||= old_manual.editions.flat_map(&:section_ids).uniq
+    @old_section_ids ||= old_manual.editions.flat_map(&:section_uuids).uniq
   end
 
   def new_section_ids
-    @new_section_ids ||= new_manual.editions.flat_map(&:section_ids).uniq
+    @new_section_ids ||= new_manual.editions.flat_map(&:section_uuids).uniq
   end
 
   def validate_manuals

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,7 +63,7 @@ FactoryGirl.define do
       after(:build) do |manual_record|
         manual_record.editions.each do |edition|
           section = FactoryGirl.create(:section_edition)
-          edition.section_ids = [section.section_uuid]
+          edition.section_uuids = [section.section_uuid]
         end
       end
     end

--- a/spec/lib/attachment_reporting_spec.rb
+++ b/spec/lib/attachment_reporting_spec.rb
@@ -84,7 +84,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
     highway_code_manual_record.editions.create!(
       state: "published",
       version_number: 1,
-      section_ids: [
+      section_uuids: [
         early_section_edition_with_pdf.section_uuid,
         early_section_edition_with_non_pdf.section_uuid,
         early_section_edition_draft_with_pdf.section_uuid,
@@ -115,7 +115,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
     patent_manual_record.editions.create!(
       state: "published",
       version_number: 1,
-      section_ids: [
+      section_uuids: [
         very_recent_draft_patent_section_edition.section_uuid
       ],
     )

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -97,7 +97,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     manual_record.editions.create!(
       state: "published",
       version_number: 1,
-      section_ids: [
+      section_uuids: [
         section_a_edition_published_version_1_major_update.section_uuid,
         section_b_edition_published_version_1_major_update.section_uuid,
         section_c_edition_archived_version_1_major_update.section_uuid,
@@ -111,7 +111,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     manual_record.editions.create!(
       state: "published",
       version_number: 2,
-      section_ids: [
+      section_uuids: [
         section_a_edition_published_version_2_major_update.section_uuid,
         section_b_edition_published_version_2_minor_update.section_uuid,
         section_c_edition_archived_version_1_major_update.section_uuid,

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -66,7 +66,7 @@ describe ManualRelocator do
 
     context "validating manuals can be relocated" do
       it "raises an error if the existing manual has never been published" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "draft")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "draft")
 
         expect {
           subject.move!
@@ -74,8 +74,8 @@ describe ManualRelocator do
       end
 
       it "raises an error if the existing manual has been published, but is currently withdrawn" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 2, state: "withdrawn")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 2, state: "withdrawn")
 
         expect {
           subject.move!
@@ -83,8 +83,8 @@ describe ManualRelocator do
       end
 
       it "raises an error if the temporary manual has never been published" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "draft")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "draft")
 
         expect {
           subject.move!
@@ -92,9 +92,9 @@ describe ManualRelocator do
       end
 
       it "raises an error if the temporary manual has been published, but is currently withdrawn" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "withdrawn")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "withdrawn")
 
         expect {
           subject.move!
@@ -102,8 +102,8 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the existing manual is currently published" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
 
         expect {
           subject.move!
@@ -111,10 +111,10 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the existing manual is currently published, regardless of the previous edition state" do
-        previous_edition = ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "withdrawn")
+        previous_edition = ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "withdrawn")
         existing_manual.editions << previous_edition
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 2, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 2, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
 
         expect {
           subject.move!
@@ -132,9 +132,9 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the existing manual has previously been published, but is currently draft" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 2, state: "draft")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 2, state: "draft")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
 
         expect {
           subject.move!
@@ -142,8 +142,8 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the temp manual is currently published" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
 
         expect {
           subject.move!
@@ -151,10 +151,10 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the temp manual is currently published, regardless of the previous edition state" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
-        previous_edition = ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "withdrawn")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+        previous_edition = ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "withdrawn")
         temp_manual.editions << previous_edition
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
 
         expect {
           subject.move!
@@ -172,9 +172,9 @@ describe ManualRelocator do
       end
 
       it "does not raises an error if the temp manual has previously been published, but is currently draft" do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "draft")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "draft")
 
         expect {
           subject.move!
@@ -184,7 +184,7 @@ describe ManualRelocator do
 
     context "with valid manuals" do
       before do
-        existing_manual.editions << ManualRecord::Edition.new(section_ids: %w(12345 23456 34567), version_number: 1, state: "published")
+        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
       end
 
       shared_examples_for "removing the existing manual" do
@@ -265,7 +265,7 @@ describe ManualRelocator do
 
       context "when the temp manual has no draft" do
         before do
-          temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
+          temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "published")
           subject.move!
         end
 
@@ -333,8 +333,8 @@ describe ManualRelocator do
         let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
 
         before do
-          temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
-          temp_manual.editions << ManualRecord::Edition.new(section_ids: %w(abcdef bcdefg cdefgh), state: "draft", version_number: 2, body: "This is in draft")
+          temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")
+          temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), state: "draft", version_number: 2, body: "This is in draft")
           subject.move!
         end
 

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -31,7 +31,7 @@ describe SectionReslugger do
       body: 'section-edition-body'
     )
     manual_record.editions.create!(
-      section_ids: [
+      section_uuids: [
         'section-id'
       ]
     )

--- a/spec/lib/section_slug_synchroniser_spec.rb
+++ b/spec/lib/section_slug_synchroniser_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SectionSlugSynchroniser do
       end
 
       manual_record.editions.create!(
-        section_ids: section_uuids
+        section_uuids: section_uuids
       )
     end
 
@@ -97,7 +97,7 @@ RSpec.describe SectionSlugSynchroniser do
       end
 
       manual_record.editions.create!(
-        section_ids: section_uuids
+        section_uuids: section_uuids
       )
     end
 

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -469,7 +469,7 @@ describe Manual do
           manual_record_id: record.id
         ).first
 
-        expect(edition.section_ids).to eq(['section-uuid'])
+        expect(edition.section_uuids).to eq(['section-uuid'])
       end
     end
 
@@ -505,7 +505,7 @@ describe Manual do
     context "when the provided id refers to the first draft of a manual" do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-      let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "draft") }
+      let(:manual_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "draft") }
       let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "draft") }
       let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "draft") }
 
@@ -556,7 +556,7 @@ describe Manual do
     context "when the provided id refers to manual that has been published once" do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-      let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "published") }
+      let(:manual_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "published") }
       let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
       let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
 
@@ -607,7 +607,7 @@ describe Manual do
     context "when the provided id refers to manual that has been withdrawn once" do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-      let(:manual_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "withdrawn") }
+      let(:manual_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "withdrawn") }
       let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "archived") }
       let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "archived") }
 
@@ -631,8 +631,8 @@ describe Manual do
     context "when the provided id refers to manual that has been published once and has a new draft waiting" do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
-      let(:manual_published_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 1, state: "published") }
-      let(:manual_draft_edition) { ManualRecord::Edition.new(section_ids: %w(12345 67890), version_number: 2, state: "draft") }
+      let(:manual_published_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "published") }
+      let(:manual_draft_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 2, state: "draft") }
 
       before do
         manual_record.editions << manual_published_edition


### PR DESCRIPTION
We're planning to introduce a Mongo-backed `Section` class in the near future (see issue #1017). This will have its own internal Mongoid ID field as well as the UUID currently stored on the `SectionEdition` records. Renaming `ManualRecord::Edition#section_ids` to `ManualRecord::Edition#section_uuids` should hopefully help us avoid confusion when we introduce the `Section` class.

I plan to rename `ManualRecord::Edition#removed_section_ids` in a future PR.
