### PR TITLE
Rename ManualRecord::Edition#removed_section_ids to #removed_section_uuids

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -96,7 +96,7 @@ class Manual
     removed_sections.each(&:save)
 
     edition.section_uuids = sections.map(&:uuid)
-    edition.removed_section_ids = removed_sections.map(&:uuid)
+    edition.removed_section_uuids = removed_sections.map(&:uuid)
 
     manual_record.save!
   end
@@ -286,7 +286,7 @@ class Manual
         Section.find(manual, section_uuid, published: published)
       }
 
-      removed_sections = Array(edition.removed_section_ids).map { |section_uuid|
+      removed_sections = Array(edition.removed_section_uuids).map { |section_uuid|
         begin
           Section.find(manual, section_uuid)
         rescue KeyError

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -76,7 +76,7 @@ private
     field :state, type: String
     field :version_number, type: Integer
     field :section_uuids, type: Array
-    field :removed_section_ids, type: Array, as: :removed_section_uuids
+    field :removed_section_uuids, type: Array
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean
 

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -76,7 +76,7 @@ private
     field :state, type: String
     field :version_number, type: Integer
     field :section_uuids, type: Array
-    field :removed_section_ids, type: Array
+    field :removed_section_ids, type: Array, as: :removed_section_uuids
     field :originally_published_at, type: DateTime
     field :use_originally_published_at_for_public_timestamp, type: Boolean
 

--- a/db/migrate/20170505112034_rename_manual_record_edition_removed_section_ids_to_removed_section_uuids.rb
+++ b/db/migrate/20170505112034_rename_manual_record_edition_removed_section_ids_to_removed_section_uuids.rb
@@ -1,0 +1,13 @@
+class RenameManualRecordEditionRemovedSectionIdsToRemovedSectionUuids < Mongoid::Migration
+  def self.up
+    ManualRecord::Edition.all.each do |manual_record_edition|
+      manual_record_edition.rename(:removed_section_ids, :removed_section_uuids)
+    end
+  end
+
+  def self.down
+    ManualRecord::Edition.all.each do |manual_record_edition|
+      manual_record_edition.rename(:removed_section_uuids, :removed_section_ids)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,7 +72,7 @@ FactoryGirl.define do
       after(:build) do |manual_record|
         manual_record.editions.each do |edition|
           section = FactoryGirl.create(:section_edition)
-          edition.removed_section_ids = [section.section_uuid]
+          edition.removed_section_uuids = [section.section_uuid]
         end
       end
     end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -494,7 +494,7 @@ describe Manual do
           manual_record_id: record.id
         ).first
 
-        expect(edition.removed_section_ids).to eq(['section-uuid'])
+        expect(edition.removed_section_uuids).to eq(['section-uuid'])
       end
     end
   end


### PR DESCRIPTION
We're planning to introduce a Mongo-backed `Section` class in the near future (see issue #1017). This will have its own internal Mongoid ID field as well as the UUID currently stored on the `SectionEdition` records. Renaming `ManualRecord::Edition#removed_section_ids` to `ManualRecord::Edition#removed_section_uuids` should hopefully help us avoid confusion when we introduce the `Section` class.
