### PR TITLE
Extract Manual#all_sections_are_minor? from ManualUpdateType

### DIFF
--- a/app/lib/manual_update_type.rb
+++ b/app/lib/manual_update_type.rb
@@ -26,8 +26,8 @@ private
     manual.
       sections.
       select(&:needs_exporting?).
-      all? { |d|
-        d.minor_update? && d.has_ever_been_published?
+      all? { |s|
+        s.minor_update? && s.has_ever_been_published?
       }
   end
 end

--- a/app/lib/manual_update_type.rb
+++ b/app/lib/manual_update_type.rb
@@ -15,19 +15,10 @@ class ManualUpdateType
     # Otherwise our update type status depends on the update type status
     # of our children if any of them are major we are major (and they
     # have to send a major for their first edition too).
-    all_sections_are_minor? ? "minor" : "major"
+    manual.all_sections_are_minor? ? "minor" : "major"
   end
 
 private
 
   attr_reader :manual
-
-  def all_sections_are_minor?
-    manual.
-      sections.
-      select(&:needs_exporting?).
-      all? { |s|
-        s.minor_update? && s.has_ever_been_published?
-      }
-  end
 end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -209,6 +209,15 @@ class Manual
     !!use_originally_published_at_for_public_timestamp
   end
 
+  def all_sections_are_minor?
+    self.
+      sections.
+      select(&:needs_exporting?).
+      all? { |s|
+        s.minor_update? && s.has_ever_been_published?
+      }
+  end
+
   def build_section(attributes)
     section = Section.build(manual: self, uuid: SecureRandom.uuid, editions: [])
 

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -28,6 +28,7 @@ describe ManualPublishingAPIExporter do
       attributes: manual_attributes,
       sections: sections,
       has_ever_been_published?: manual_attributes[:ever_been_published],
+      all_sections_are_minor?: false,
       originally_published_at: nil,
       use_originally_published_at_for_public_timestamp?: false,
     )
@@ -291,27 +292,10 @@ describe ManualPublishingAPIExporter do
     end
   end
 
-  context "when no sections need exporting" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: false,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: false,
-          has_ever_been_published?: true,
-        )
-      ]
-    }
+  context "when all sections are minor" do
+    before do
+      allow(manual).to receive(:all_sections_are_minor?).and_return(true)
+    end
 
     it "exports with the update_type set to minor" do
       subject.call
@@ -326,62 +310,10 @@ describe ManualPublishingAPIExporter do
     it_behaves_like "obeying the provided update_type"
   end
 
-  context "when one section needs exporting and it is a minor update" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: false,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        )
-      ]
-    }
-
-    it "exports with the update_type set to minor" do
-      subject.call
-
-      expect(publishing_api).to have_received(:put_content).with(
-        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "minor")
-      )
+  context "when all sections are not minor" do
+    before do
+      allow(manual).to receive(:all_sections_are_minor?).and_return(false)
     end
-
-    it_behaves_like "publishing a manual that has never been published"
-    it_behaves_like "obeying the provided update_type"
-  end
-
-  context "when one section needs exporting and it is a minor update that has never been published" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: false,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: false,
-        )
-      ]
-    }
 
     it "exports with the update_type set to major" do
       subject.call
@@ -392,179 +324,6 @@ describe ManualPublishingAPIExporter do
       )
     end
 
-    it_behaves_like "obeying the provided update_type"
-  end
-
-  context "when one section needs exporting and it is a major update" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: false,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        )
-      ]
-    }
-
-    it "exports with the update_type set to major" do
-      subject.call
-
-      expect(publishing_api).to have_received(:put_content).with(
-        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "major")
-      )
-    end
-
-    it_behaves_like "publishing a manual that has never been published"
-    it_behaves_like "obeying the provided update_type"
-  end
-
-  context "when multiple sections need exporting, but none are major updates" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        )
-      ]
-    }
-
-    it "exports with the update_type set to minor" do
-      subject.call
-
-      expect(publishing_api).to have_received(:put_content).with(
-        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "minor")
-      )
-    end
-
-    it_behaves_like "publishing a manual that has never been published"
-    it_behaves_like "obeying the provided update_type"
-  end
-
-  context "when multiple sections need exporting, but none are major updates, but one has never been published" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: false,
-        )
-      ]
-    }
-
-    it "exports with the update_type set to major" do
-      subject.call
-
-      expect(publishing_api).to have_received(:put_content).with(
-        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "major")
-      )
-    end
-    it_behaves_like "obeying the provided update_type"
-  end
-
-  context "when multiple sections need exporting, and at least one is a major updates" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: true,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        )
-      ]
-    }
-
-    it "exports with the update_type set to major" do
-      subject.call
-
-      expect(publishing_api).to have_received(:put_content).with(
-        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "major")
-      )
-    end
-
-    it_behaves_like "publishing a manual that has never been published"
-    it_behaves_like "obeying the provided update_type"
-  end
-
-  context "when multiple sections need exporting, and all are major updates" do
-    let(:sections) {
-      [
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        ),
-        double(
-          :section,
-          id: "60023f27-0657-4812-9339-264f1c0fd90d",
-          attributes: section_attributes,
-          minor_update?: false,
-          needs_exporting?: true,
-          has_ever_been_published?: true,
-        )
-      ]
-    }
-
-    it "exports with the update_type set to major" do
-      subject.call
-
-      expect(publishing_api).to have_received(:put_content).with(
-        "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "major")
-      )
-    end
-
-    it_behaves_like "publishing a manual that has never been published"
     it_behaves_like "obeying the provided update_type"
   end
 end

--- a/spec/lib/manual_update_type_spec.rb
+++ b/spec/lib/manual_update_type_spec.rb
@@ -15,71 +15,23 @@ RSpec.describe ManualUpdateType do
   describe "for a manual that has been published before" do
     before { allow(manual).to receive(:has_ever_been_published?).and_return true }
 
-    context "and has no sections" do
-      before { allow(manual).to receive(:sections).and_return [] }
+    context "when all sections are minor" do
+      before do
+        allow(manual).to receive(:all_sections_are_minor?).and_return(true)
+      end
 
       it "is 'minor'" do
         expect(subject).to eql "minor"
       end
     end
 
-    context "and has sections" do
-      let(:section_1) { double(:section) }
-      let(:section_2) { double(:section) }
-      let(:section_3) { double(:section) }
-      before { allow(manual).to receive(:sections).and_return [section_1, section_2, section_3] }
-
-      context "none of which need exporting" do
-        before do
-          allow(section_1).to receive(:needs_exporting?).and_return false
-          allow(section_2).to receive(:needs_exporting?).and_return false
-          allow(section_3).to receive(:needs_exporting?).and_return false
-        end
-
-        it "is 'minor'" do
-          expect(subject).to eql "minor"
-        end
+    context "when all sections are not minor" do
+      before do
+        allow(manual).to receive(:all_sections_are_minor?).and_return(false)
       end
 
-      context "some of which need exporting" do
-        before do
-          allow(section_1).to receive(:needs_exporting?).and_return true
-          allow(section_2).to receive(:needs_exporting?).and_return true
-          allow(section_3).to receive(:needs_exporting?).and_return true
-        end
-
-        it "is 'minor' when all sections are minor updates that have been published before" do
-          allow(section_1).to receive(:minor_update?).and_return true
-          allow(section_2).to receive(:minor_update?).and_return true
-          allow(section_3).to receive(:minor_update?).and_return true
-          allow(section_1).to receive(:has_ever_been_published?).and_return true
-          allow(section_2).to receive(:has_ever_been_published?).and_return true
-          allow(section_3).to receive(:has_ever_been_published?).and_return true
-
-          expect(subject).to eql "minor"
-        end
-
-        it "is 'major' when at least one section is a minor update that has never been published before" do
-          allow(section_1).to receive(:minor_update?).and_return true
-          allow(section_2).to receive(:minor_update?).and_return true
-          allow(section_3).to receive(:minor_update?).and_return true
-          allow(section_1).to receive(:has_ever_been_published?).and_return true
-          allow(section_2).to receive(:has_ever_been_published?).and_return true
-          allow(section_3).to receive(:has_ever_been_published?).and_return false
-
-          expect(subject).to eql "major"
-        end
-
-        it "is 'major' when at least one sections is a major update" do
-          allow(section_1).to receive(:minor_update?).and_return false
-          allow(section_2).to receive(:minor_update?).and_return true
-          allow(section_3).to receive(:minor_update?).and_return true
-          allow(section_1).to receive(:has_ever_been_published?).and_return true
-          allow(section_2).to receive(:has_ever_been_published?).and_return true
-          allow(section_3).to receive(:has_ever_been_published?).and_return true
-
-          expect(subject).to eql "major"
-        end
+      it "is 'major'" do
+        expect(subject).to eql "major"
       end
     end
   end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -856,4 +856,74 @@ describe Manual do
       end
     end
   end
+
+  describe "#all_sections_are_minor?" do
+    context "when manual has no sections" do
+      before { allow(manual).to receive(:sections).and_return [] }
+
+      it "returns truthy" do
+        expect(manual.all_sections_are_minor?).to be_truthy
+      end
+    end
+
+    context "when manual has sections" do
+      let(:section_1) { double(:section) }
+      let(:section_2) { double(:section) }
+      let(:section_3) { double(:section) }
+      before { allow(manual).to receive(:sections).and_return [section_1, section_2, section_3] }
+
+      context "none of which need exporting" do
+        before do
+          allow(section_1).to receive(:needs_exporting?).and_return false
+          allow(section_2).to receive(:needs_exporting?).and_return false
+          allow(section_3).to receive(:needs_exporting?).and_return false
+        end
+
+        it "returns truthy" do
+          expect(manual.all_sections_are_minor?).to be_truthy
+        end
+      end
+
+      context "some of which need exporting" do
+        before do
+          allow(section_1).to receive(:needs_exporting?).and_return true
+          allow(section_2).to receive(:needs_exporting?).and_return true
+          allow(section_3).to receive(:needs_exporting?).and_return true
+        end
+
+        it "returns truthy when all sections are minor updates that have been published before" do
+          allow(section_1).to receive(:minor_update?).and_return true
+          allow(section_2).to receive(:minor_update?).and_return true
+          allow(section_3).to receive(:minor_update?).and_return true
+          allow(section_1).to receive(:has_ever_been_published?).and_return true
+          allow(section_2).to receive(:has_ever_been_published?).and_return true
+          allow(section_3).to receive(:has_ever_been_published?).and_return true
+
+          expect(manual.all_sections_are_minor?).to be_truthy
+        end
+
+        it "returns falsey when at least one section is a minor update that has never been published before" do
+          allow(section_1).to receive(:minor_update?).and_return true
+          allow(section_2).to receive(:minor_update?).and_return true
+          allow(section_3).to receive(:minor_update?).and_return true
+          allow(section_1).to receive(:has_ever_been_published?).and_return true
+          allow(section_2).to receive(:has_ever_been_published?).and_return true
+          allow(section_3).to receive(:has_ever_been_published?).and_return false
+
+          expect(manual.all_sections_are_minor?).to be_falsey
+        end
+
+        it "returns falsey when at least one sections is a major update" do
+          allow(section_1).to receive(:minor_update?).and_return false
+          allow(section_2).to receive(:minor_update?).and_return true
+          allow(section_3).to receive(:minor_update?).and_return true
+          allow(section_1).to receive(:has_ever_been_published?).and_return true
+          allow(section_2).to receive(:has_ever_been_published?).and_return true
+          allow(section_3).to receive(:has_ever_been_published?).and_return true
+
+          expect(manual.all_sections_are_minor?).to be_falsey
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Although this behaviour is somewhat related to the way the Publishing API works, it feels pretty specific to this application and so I think it's legitimate to move this method onto the `Manual` domain model.

Making this change has allowed me to substantially simplify the spec for `ManualPublishingAPIExporter` which was suffering from combinatorial explosion. This in turn should make it easier to [refactor the exporters towards a `PublishingAdapter`](https://github.com/alphagov/manuals-publisher/issues/1048).

Note that this probably have some conflicts with #1064.