### PR TITLE
Inline Section#build into Section#new

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -219,7 +219,7 @@ class Manual
   end
 
   def build_section(attributes)
-    section = Section.build(manual: self, uuid: SecureRandom.uuid, editions: [])
+    section = Section.new(manual: self, uuid: SecureRandom.uuid, editions: [])
 
     defaults = {
       minor_update: false,

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -14,9 +14,7 @@ class Section
   validate :change_note_ok
 
   def self.build(manual:, uuid:, editions:)
-    slug_generator = SlugGenerator.new(prefix: manual.slug)
-
-    Section.new(slug_generator, uuid, editions)
+    Section.new(manual, uuid, editions)
   end
 
   def self.edition_attributes
@@ -55,8 +53,8 @@ class Section
 
   attr_reader :uuid, :editions, :latest_edition
 
-  def initialize(slug_generator, uuid, editions)
-    @slug_generator = slug_generator
+  def initialize(manual, uuid, editions)
+    @slug_generator = SlugGenerator.new(prefix: manual.slug)
     @uuid = uuid
     @editions = editions
     @editions.push(create_first_edition) if @editions.empty?

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -14,7 +14,7 @@ class Section
   validate :change_note_ok
 
   def self.build(manual:, uuid:, editions:)
-    Section.new(manual, uuid, editions)
+    Section.new(manual: manual, uuid: uuid, editions: editions)
   end
 
   def self.edition_attributes
@@ -53,7 +53,7 @@ class Section
 
   attr_reader :uuid, :editions, :latest_edition
 
-  def initialize(manual, uuid, editions)
+  def initialize(manual:, uuid:, editions:)
     @slug_generator = SlugGenerator.new(prefix: manual.slug)
     @uuid = uuid
     @editions = editions

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -13,10 +13,6 @@ class Section
   validates :body, presence: true, safe_html: true
   validate :change_note_ok
 
-  def self.build(manual:, uuid:, editions:)
-    Section.new(manual: manual, uuid: uuid, editions: editions)
-  end
-
   def self.edition_attributes
     [
       :title,
@@ -45,7 +41,7 @@ class Section
     if editions.empty?
       raise KeyError.new("key not found #{section_uuid}")
     else
-      Section.build(manual: manual, uuid: section_uuid, editions: editions)
+      Section.new(manual: manual, uuid: section_uuid, editions: editions)
     end
   end
 

--- a/spec/adapters/search_index_adapter_spec.rb
+++ b/spec/adapters/search_index_adapter_spec.rb
@@ -17,7 +17,7 @@ describe SearchIndexAdapter do
   }
 
   let(:section) {
-    Section.build(
+    Section.new(
       manual: manual,
       uuid: "section-id",
       editions: [section_edition],
@@ -34,7 +34,7 @@ describe SearchIndexAdapter do
   }
 
   let(:removed_section) {
-    Section.build(
+    Section.new(
       manual: manual,
       uuid: "removed-section-id",
       editions: [removed_section_edition],

--- a/spec/lib/publication_logger_spec.rb
+++ b/spec/lib/publication_logger_spec.rb
@@ -1,11 +1,14 @@
 require "spec_helper"
 
 RSpec.describe PublicationLogger do
-  let(:slug_generator) { SlugGenerator.new(prefix: "manual-slug") }
-  let(:manual) { double(:manual, sections: sections, removed_sections: []) }
+  let(:manual) { double(:manual, slug: 'manual-slug', removed_sections: []) }
   let(:sections) { [section] }
-  let(:section) { Section.new(slug_generator, "section-id-1", [section_edition]) }
+  let(:section) { Section.new(manual, "section-id-1", [section_edition]) }
   let(:section_edition) { FactoryGirl.create(:section_edition) }
+
+  before do
+    allow(manual).to receive(:sections).and_return(sections)
+  end
 
   describe "call" do
     it "creates a PublicationLog for each Section" do
@@ -17,7 +20,7 @@ RSpec.describe PublicationLogger do
     # It's possible to pass a nil change_note, this indicates that the section
     # update is not to be logged by the PublicationLogger
     context "when a section edition has no change note" do
-      let(:cloned_section) { Section.new(slug_generator, "section-id-2", [cloned_section_edition]) }
+      let(:cloned_section) { Section.new(manual, "section-id-2", [cloned_section_edition]) }
       let(:cloned_section_edition) { FactoryGirl.create(:section_edition, change_note: nil) }
       let(:sections) { [section, cloned_section] }
       it "does not create a PublicationLog for a cloned Section" do

--- a/spec/lib/publication_logger_spec.rb
+++ b/spec/lib/publication_logger_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe PublicationLogger do
   let(:manual) { double(:manual, slug: 'manual-slug', removed_sections: []) }
   let(:sections) { [section] }
-  let(:section) { Section.new(manual, "section-id-1", [section_edition]) }
+  let(:section) { Section.new(manual: manual, uuid: "section-id-1", editions: [section_edition]) }
   let(:section_edition) { FactoryGirl.create(:section_edition) }
 
   before do
@@ -20,7 +20,7 @@ RSpec.describe PublicationLogger do
     # It's possible to pass a nil change_note, this indicates that the section
     # update is not to be logged by the PublicationLogger
     context "when a section edition has no change note" do
-      let(:cloned_section) { Section.new(manual, "section-id-2", [cloned_section_edition]) }
+      let(:cloned_section) { Section.new(manual: manual, uuid: "section-id-2", editions: [cloned_section_edition]) }
       let(:cloned_section_edition) { FactoryGirl.create(:section_edition, change_note: nil) }
       let(:sections) { [section, cloned_section] }
       it "does not create a PublicationLog for a cloned Section" do

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -111,8 +111,6 @@ describe Section do
   end
 
   describe '.find' do
-    let(:manual) { double(:manual, slug: 'manual-slug') }
-
     context 'when there are associated section editions' do
       let(:section_edition) { FactoryGirl.build(:section_edition) }
       let(:editions_proxy) { double(:editions_proxy, to_a: [section_edition]).as_null_object }
@@ -122,17 +120,17 @@ describe Section do
       end
 
       it 'builds a section using the manual' do
-        expect(Section).to receive(:build).with(including(manual: manual))
+        expect(Section).to receive(:new).with(including(manual: manual))
         Section.find(manual, 'section-id')
       end
 
       it 'builds a section using the section id' do
-        expect(Section).to receive(:build).with(including(uuid: 'section-id'))
+        expect(Section).to receive(:new).with(including(uuid: 'section-id'))
         Section.find(manual, 'section-id')
       end
 
       it 'builds a section using the editions' do
-        expect(Section).to receive(:build).with(including(editions: [section_edition]))
+        expect(Section).to receive(:new).with(including(editions: [section_edition]))
         Section.find(manual, 'section-id')
       end
     end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Section do
   subject(:section) {
-    Section.new(manual, section_uuid, editions)
+    Section.new(manual: manual, uuid: section_uuid, editions: editions)
   }
 
   def key_classes_for(hash)
@@ -157,7 +157,7 @@ describe Section do
         edition_2 = double(:edition_2),
         edition_3 = double(:edition_3)
       ]
-      section = Section.new(manual, 'section-id', editions)
+      section = Section.new(manual: manual, uuid: 'section-id', editions: editions)
 
       expect(edition_1).to_not receive(:save!)
       expect(edition_2).to receive(:save!)
@@ -172,12 +172,12 @@ describe Section do
 
     it "is considered the same as another section instance if they have the same uuid" do
       expect(section).to eql(section)
-      expect(section).to eql(Section.new(manual, section.uuid, [draft_edition_v1]))
-      expect(section).not_to eql(Section.new(manual, section.uuid.reverse, [draft_edition_v1]))
+      expect(section).to eql(Section.new(manual: manual, uuid: section.uuid, editions: [draft_edition_v1]))
+      expect(section).not_to eql(Section.new(manual: manual, uuid: section.uuid.reverse, editions: [draft_edition_v1]))
     end
 
     it "is considered the same as another section instance with the same uuid even if they have different version numbers" do
-      expect(section).to eql(Section.new(manual, section.uuid, [draft_edition_v2]))
+      expect(section).to eql(Section.new(manual: manual, uuid: section.uuid, editions: [draft_edition_v2]))
     end
   end
 

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -2,13 +2,15 @@ require "spec_helper"
 
 describe Section do
   subject(:section) {
-    Section.new(slug_generator, section_uuid, editions)
+    Section.new(manual, section_uuid, editions)
   }
 
   def key_classes_for(hash)
     hash.keys.map(&:class).uniq
   end
 
+  let(:manual_slug) { '/guidance/manual-slug' }
+  let(:manual) { double(:manual, slug: manual_slug) }
   let(:section_uuid) { "a-section-uuid" }
   let(:slug) { double(:slug) }
   let(:published_slug) { double(:published_slug) }
@@ -104,6 +106,10 @@ describe Section do
     )
   }
 
+  before do
+    allow(SlugGenerator).to receive(:new).with(prefix: manual_slug).and_return(slug_generator)
+  end
+
   describe '.find' do
     let(:manual) { double(:manual, slug: 'manual-slug') }
 
@@ -146,13 +152,12 @@ describe Section do
 
   describe '#save' do
     it 'saves the last two editions' do
-      slug_generator = double(:slug_generator)
       editions = [
         edition_1 = double(:edition_1),
         edition_2 = double(:edition_2),
         edition_3 = double(:edition_3)
       ]
-      section = Section.new(slug_generator, 'section-id', editions)
+      section = Section.new(manual, 'section-id', editions)
 
       expect(edition_1).to_not receive(:save!)
       expect(edition_2).to receive(:save!)
@@ -167,12 +172,12 @@ describe Section do
 
     it "is considered the same as another section instance if they have the same uuid" do
       expect(section).to eql(section)
-      expect(section).to eql(Section.new(slug_generator, section.uuid, [draft_edition_v1]))
-      expect(section).not_to eql(Section.new(slug_generator, section.uuid.reverse, [draft_edition_v1]))
+      expect(section).to eql(Section.new(manual, section.uuid, [draft_edition_v1]))
+      expect(section).not_to eql(Section.new(manual, section.uuid.reverse, [draft_edition_v1]))
     end
 
     it "is considered the same as another section instance with the same uuid even if they have different version numbers" do
-      expect(section).to eql(Section.new(slug_generator, section.uuid, [draft_edition_v2]))
+      expect(section).to eql(Section.new(manual, section.uuid, [draft_edition_v2]))
     end
   end
 


### PR DESCRIPTION
I _think_ that having a single way of instantiating `Section`s is going to make things easier when we come to store Sections in Mongo.
