### PR TITLE
Bring "lint" Rake task into line with "Lint Ruby" stage on CI

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --format clang app bin config features Gemfile lib spec"
+  sh "bundle exec govuk-lint-ruby --diff --cached --format clang app lib spec test"
 end


### PR DESCRIPTION
According to the task description this is supposed to mimic the "Lint Ruby" stage run on Jenkins CI (see [these lines][1] & [these lines][2]). I've updated the `govuk-lint-ruby` options and directories in the Rake task to more closely match those used in the CI stage.

Note that this means we are now only checking code that has changed. Ideally we'd be checking all the code every time, but if we want to do that we should change the Jenkins CI build to do the same. It was very confusing that the two did not do the same thing.

Note also that we are no longer checking the following directories: `bin`, `config` & `features`. If we decide we want to do this then we should chage the Jenkins CI build to do the same.

I did contemplate trying to change the Jenkins CI build, but there doesn't seem to be an easy way to do this with the current `govuk_jenkinslib.groovy` code.

I've created the following issues to capture things that have come up while investigating this:

* [Stop using diff option for Rubocop](https://github.com/alphagov/manuals-publisher/issues/1071)
* [Fix auto-correctable Rubocop violations](https://github.com/alphagov/manuals-publisher/issues/1072)
* [Enable remaining disabled Rubocop rules and fix violations](https://github.com/alphagov/manuals-publisher/issues/1073)
* [Consider including Gemfile and bin, config & features directories in Rubocop](https://github.com/alphagov/manuals-publisher/issues/1074)
* [Avoid running govuk-lint-ruby twice in CI builds](https://github.com/alphagov/manuals-publisher/issues/1075)

[1]: https://github.com/alphagov/govuk-puppet/blob/43af3ededf1fc289d63bbac3969176bed76ce147/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy#L138-L140
[2]: https://github.com/alphagov/govuk-puppet/blob/43af3ededf1fc289d63bbac3969176bed76ce147/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy#L378-L396