### PR TITLE
Remove GovspeakHtmlConverter

### DIFF
--- a/app/lib/govspeak_html_converter.rb
+++ b/app/lib/govspeak_html_converter.rb
@@ -1,5 +1,0 @@
-class GovspeakHtmlConverter
-  def call(string)
-    Govspeak::Document.new(string).to_html
-  end
-end

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -9,6 +9,6 @@ class ManualPresenter
   delegate :errors, to: :@manual
 
   def body
-    GovspeakHtmlConverter.new.call(@manual.body)
+    Govspeak::Document.new(@manual.body).to_html
   end
 end

--- a/app/presenters/section_presenter.rb
+++ b/app/presenters/section_presenter.rb
@@ -24,7 +24,7 @@ private
   end
 
   def render_govspeak(body)
-    GovspeakHtmlConverter.new.call(body)
+    Govspeak::Document.new(body).to_html
   end
 
   def render_footnotes_heading(body)


### PR DESCRIPTION
This class does a very simple delegation to `Govspeak::Document` and I
don't think it adds any value in terms of encapsulation or
readability.