### PR TITLE
Simplify PublishingApiUpdateTypes

### DIFF
--- a/app/exporters/publishing_api_update_types.rb
+++ b/app/exporters/publishing_api_update_types.rb
@@ -1,5 +1,6 @@
 module PublishingAPIUpdateTypes
   UPDATE_TYPES = %w(minor major republish).freeze
+
   def check_update_type!(update_type)
     return if update_type.nil?
     raise ArgumentError, "update_type '#{update_type}' not recognised" unless UPDATE_TYPES.include?(update_type)

--- a/app/exporters/publishing_api_update_types.rb
+++ b/app/exporters/publishing_api_update_types.rb
@@ -1,7 +1,7 @@
 module PublishingAPIUpdateTypes
   UPDATE_TYPES = %w(minor major republish).freeze
-  def check_update_type!(update_type, allow_nil: true)
-    return if update_type.nil? && allow_nil
+  def check_update_type!(update_type)
+    return if update_type.nil?
     raise ArgumentError, "update_type '#{update_type}' not recognised" unless UPDATE_TYPES.include?(update_type)
   end
 end

--- a/app/exporters/publishing_api_update_types.rb
+++ b/app/exporters/publishing_api_update_types.rb
@@ -2,7 +2,8 @@ module PublishingAPIUpdateTypes
   UPDATE_TYPES = %w(minor major republish).freeze
 
   def check_update_type!(update_type)
-    return if update_type.nil?
-    raise ArgumentError, "update_type '#{update_type}' not recognised" unless UPDATE_TYPES.include?(update_type)
+    if update_type.present? && !UPDATE_TYPES.include?(update_type)
+      raise ArgumentError, "update_type '#{update_type}' not recognised"
+    end
   end
 end


### PR DESCRIPTION
A few small improvements to help with the larger goal of [extracting API adapters from exporters][1].

[1]: https://github.com/alphagov/manuals-publisher/issues/996