### PR TITLE
Rename methods and instance variables calling section uuid

### DIFF
--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -183,16 +183,16 @@ module ManualHelpers
     end
   end
 
-  def check_section_exists(manual_id, section_id)
+  def check_section_exists(manual_id, section_uuid)
     manual = Manual.find(manual_id, FactoryGirl.build(:gds_editor))
 
-    manual.sections.any? { |section| section.uuid == section_id }
+    manual.sections.any? { |section| section.uuid == section_uuid }
   end
 
-  def check_section_was_removed(manual_id, section_id)
+  def check_section_was_removed(manual_id, section_uuid)
     manual = Manual.find(manual_id, FactoryGirl.build(:gds_editor))
 
-    manual.removed_sections.any? { |section| section.uuid == section_id }
+    manual.removed_sections.any? { |section| section.uuid == section_uuid }
   end
 
   def go_to_edit_page_for_manual(manual_title)
@@ -249,8 +249,8 @@ module ManualHelpers
     check_section_is_withdrawn_from_rummager(section)
   end
 
-  def check_section_is_archived_in_db(manual, section_id)
-    expect(Section.find(manual, section_id)).to be_withdrawn
+  def check_section_is_archived_in_db(manual, section_uuid)
+    expect(Section.find(manual, section_uuid)).to be_withdrawn
   end
 
   def check_manual_is_published_to_rummager(slug, attrs)

--- a/lib/attachment_reporting.rb
+++ b/lib/attachment_reporting.rb
@@ -23,8 +23,8 @@ class AttachmentReporting
       # we instead get all unique section ids associated with this manual, then walk through
       # the editions of these sections in version order to find unique PDF attachments and their
       # publication times.
-      all_unique_section_ids_for_manual(manual).each do |section_id|
-        section_editions = SectionEdition.all_for_section(section_id).order_by([:version_number, :asc])
+      all_unique_section_uuids_for_manual(manual).each do |section_uuid|
+        section_editions = SectionEdition.all_for_section(section_uuid).order_by([:version_number, :asc])
 
         section_editions.each do |section_edition|
           next if section_edition_never_published?(section_edition)
@@ -79,7 +79,7 @@ private
     !POST_PUBLICATION_STATES.include?(section_edition.state)
   end
 
-  def all_unique_section_ids_for_manual(manual)
+  def all_unique_section_uuids_for_manual(manual)
     manual.editions.map(&:section_uuids).flatten.uniq
   end
 end

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -46,7 +46,7 @@ private
   end
 
   def user_must_confirm(manual_record)
-    number_of_sections = section_ids_for(manual_record).count
+    number_of_sections = section_uuids_for(manual_record).count
     log "### PLEASE CONFIRM -------------------------------------"
     log "Manual to be deleted: #{manual_record.slug}"
     log "Organisation: #{manual_record.organisation_slug}"
@@ -59,7 +59,7 @@ private
     end
   end
 
-  def section_ids_for(manual_record)
+  def section_uuids_for(manual_record)
     manual_record.editions.flat_map(&:section_uuids).uniq
   end
 
@@ -75,12 +75,12 @@ private
   # I'm loth to do this at this stage, given how specific the requirement
   # driving writing of this script is.
   def complete_removal(manual_record)
-    section_ids = section_ids_for(manual_record)
+    section_uuids = section_uuids_for(manual_record)
 
-    section_ids.each { |id| discard_draft_from_publishing_api(id) }
+    section_uuids.each { |id| discard_draft_from_publishing_api(id) }
     discard_draft_from_publishing_api(manual_record.manual_id)
 
-    section_ids.each do |id|
+    section_uuids.each do |id|
       SectionEdition.all_for_section(id).map(&:destroy)
     end
 

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -201,16 +201,16 @@ private
     end
   end
 
-  def send_gone(section_id, slug)
+  def send_gone(section_uuid, slug)
     # We should be able to use
-    #   publishing_api.unpublish(section_id, type: 'gone')
+    #   publishing_api.unpublish(section_uuid, type: 'gone')
     # here, but that doesn't leave the base_path in a state where
     # publishing_api will let us re-use it.  Sending a draft gone object
     # and then publishing it does though.  Might want to check if we can
     # go back to the unpublish version at some point though.
     gone_item = {
       base_path: "/#{slug}",
-      content_id: section_id,
+      content_id: section_uuid,
       document_type: "gone",
       publishing_app: "manuals-publisher",
       schema_name: "gone",
@@ -221,8 +221,8 @@ private
         }
       ]
     }
-    publishing_api.put_content(section_id, gone_item)
-    publishing_api.publish(section_id, "major")
+    publishing_api.put_content(section_uuid, gone_item)
+    publishing_api.publish(section_uuid, "major")
   end
 
   def publishing_api

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -36,12 +36,12 @@ private
     manuals.first
   end
 
-  def old_section_ids
-    @old_section_ids ||= old_manual.editions.flat_map(&:section_uuids).uniq
+  def old_section_uuids
+    @old_section_uuids ||= old_manual.editions.flat_map(&:section_uuids).uniq
   end
 
-  def new_section_ids
-    @new_section_ids ||= new_manual.editions.flat_map(&:section_uuids).uniq
+  def new_section_uuids
+    @new_section_uuids ||= new_manual.editions.flat_map(&:section_uuids).uniq
   end
 
   def validate_manuals
@@ -62,23 +62,23 @@ private
     if old_manual.editions.any?
       # Redirect all sections of the manual we're going to remove
       # to prevent dead bookmarked URLs.
-      old_section_ids.each do |section_id|
-        editions = all_editions_of_section(section_id)
+      old_section_uuids.each do |section_uuid|
+        editions = all_editions_of_section(section_uuid)
         section_slug = editions.first.slug
 
         begin
-          if old_sections_reused_in_new_manual.include? section_id
+          if old_sections_reused_in_new_manual.include? section_uuid
             puts "Issuing gone for content item '/#{section_slug}' as it will be reused by a section in '#{new_manual.slug}'"
-            send_gone(section_id, section_slug)
+            send_gone(section_uuid, section_slug)
           else
             puts "Redirecting content item '/#{section_slug}' to '/#{old_manual.slug}'"
-            publishing_api.unpublish(section_id,
+            publishing_api.unpublish(section_uuid,
                                      type: "redirect",
                                      alternative_path: "/#{old_manual.slug}",
                                      discard_drafts: true)
           end
         rescue GdsApi::HTTPNotFound
-          puts "Content item with content_id #{section_id} not present in the publishing API"
+          puts "Content item with section_uuid #{section_uuid} not present in the publishing API"
         end
 
         # Destroy all the editons of this manual as it's going away
@@ -102,35 +102,35 @@ private
   end
 
   def _calculate_old_sections_reused_in_new_manual
-    old_section_ids_and_section_slugs = old_section_ids.map do |section_id|
-      [section_id, most_recent_edition_of_section(section_id).slug.gsub(to_slug, "")]
+    old_section_uuids_and_section_slugs = old_section_uuids.map do |section_uuid|
+      [section_uuid, most_recent_edition_of_section(section_uuid).slug.gsub(to_slug, "")]
     end
 
-    new_section_slugs = new_section_ids.map do |section_id|
-      most_recent_edition_of_section(section_id).slug.gsub(from_slug, "")
+    new_section_slugs = new_section_uuids.map do |section_uuid|
+      most_recent_edition_of_section(section_uuid).slug.gsub(from_slug, "")
     end
 
-    old_section_ids_and_section_slugs.
-      select { |_section_id, slug| new_section_slugs.include? slug }.
-      map { |section_id, _slug| section_id }
+    old_section_uuids_and_section_slugs.
+      select { |_section_uuid, slug| new_section_slugs.include? slug }.
+      map { |section_uuid, _slug| section_uuid }
   end
 
-  def most_recent_published_edition_of_section(section_id)
-    all_editions_of_section(section_id).select { |edition| edition.state == "published" }.first
+  def most_recent_published_edition_of_section(section_uuid)
+    all_editions_of_section(section_uuid).select { |edition| edition.state == "published" }.first
   end
 
-  def most_recent_edition_of_section(section_id)
-    all_editions_of_section(section_id).first
+  def most_recent_edition_of_section(section_uuid)
+    all_editions_of_section(section_uuid).first
   end
 
-  def all_editions_of_section(section_id)
-    SectionEdition.all_for_section(section_id).order_by([:version_number, :desc])
+  def all_editions_of_section(section_uuid)
+    SectionEdition.all_for_section(section_uuid).order_by([:version_number, :desc])
   end
 
   def reslug
     # Reslug the manual sections
-    new_section_ids.each do |section_id|
-      sections = all_editions_of_section(section_id)
+    new_section_uuids.each do |section_uuid|
+      sections = all_editions_of_section(section_uuid)
       sections.each do |section|
         new_section_slug = section.slug.gsub(from_slug, to_slug)
         puts "Reslugging section '#{section.slug}' as '#{new_section_slug}'"
@@ -149,10 +149,10 @@ private
     end
 
     # Clean up manual sections belonging to the temporary manual path
-    new_section_ids.each do |section_id|
-      puts "Redirecting #{section_id} to '/#{to_slug}'"
-      most_recent_edition = most_recent_edition_of_section(section_id)
-      publishing_api.unpublish(section_id,
+    new_section_uuids.each do |section_uuid|
+      puts "Redirecting #{section_uuid} to '/#{to_slug}'"
+      most_recent_edition = most_recent_edition_of_section(section_uuid)
+      publishing_api.unpublish(section_uuid,
                                type: "redirect",
                                alternative_path: "/#{most_recent_edition.slug}",
                                discard_drafts: true)

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -4,11 +4,11 @@ describe SectionsController, type: :controller do
   describe "#withdraw" do
     context "for a user that cannot withdraw" do
       let(:manual_id) { "manual-1" }
-      let(:section_id) { "section-1" }
+      let(:section_uuid) { "section-1" }
       before do
         login_as_stub_user
         allow_any_instance_of(PermissionChecker).to receive(:can_withdraw?).and_return(false)
-        post :withdraw, manual_id: manual_id, id: section_id
+        post :withdraw, manual_id: manual_id, id: section_uuid
       end
 
       after do
@@ -16,7 +16,7 @@ describe SectionsController, type: :controller do
       end
 
       it "redirects to the section's show page" do
-        expect(response).to redirect_to manual_section_path(manual_id: manual_id, id: section_id)
+        expect(response).to redirect_to manual_section_path(manual_id: manual_id, id: section_uuid)
       end
 
       it "sets a flash message" do
@@ -31,13 +31,13 @@ describe SectionsController, type: :controller do
 
   describe "#destroy" do
     let(:manual_id) { "manual-1" }
-    let(:section_id) { "section-1" }
+    let(:section_uuid) { "section-1" }
     let(:service) { spy(Section::RemoveService) }
     before do
       login_as_stub_user
       allow_any_instance_of(PermissionChecker).to receive(:can_withdraw?).and_return(false)
       allow(Section::RemoveService).to receive(:new).and_return(service)
-      delete :destroy, manual_id: manual_id, id: section_id
+      delete :destroy, manual_id: manual_id, id: section_uuid
     end
 
     after do
@@ -45,7 +45,7 @@ describe SectionsController, type: :controller do
     end
 
     it "redirects to the section's show page" do
-      expect(response).to redirect_to manual_section_path(manual_id: manual_id, id: section_id)
+      expect(response).to redirect_to manual_section_path(manual_id: manual_id, id: section_uuid)
     end
 
     it "sets a flash message" do

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -4,8 +4,8 @@ require "publishing_api_publisher"
 
 describe PublishingAPIPublisher do
   let(:publishing_api) { double(:publishing_api, publish: nil) }
-  let(:section_id) { "12345678-9abc-def0-1234-56789abcdef0" }
-  let(:section) { double(:section, id: section_id) }
+  let(:section_uuid) { "12345678-9abc-def0-1234-56789abcdef0" }
+  let(:section) { double(:section, id: section_uuid) }
 
   it "raises an argument error if update_type is supplied, but not a valid choice" do
     expect {
@@ -51,7 +51,7 @@ describe PublishingAPIPublisher do
       it "asks the publishing api to publish the section" do
         subject.call
 
-        expect(publishing_api).to have_received(:publish).with(section_id, nil)
+        expect(publishing_api).to have_received(:publish).with(section_uuid, nil)
       end
     end
 
@@ -66,7 +66,7 @@ describe PublishingAPIPublisher do
       it "asks the publishing api to publish the section with the specific update_type" do
         subject.call
 
-        expect(publishing_api).to have_received(:publish).with(section_id, "republish")
+        expect(publishing_api).to have_received(:publish).with(section_uuid, "republish")
       end
     end
   end


### PR DESCRIPTION
In #1017 we want to store `Section`s in Mongo instead of having an in-memory representation. To make this refactoring easier we are renaming `Section#id` to `Section#uuid`. This PR completes the rename by using `uuid` consistently in method and variable names that previously referred to `id`.

The only places where I haven't renamed are:
- In old migrations
- In the parameters used in the `section` routes (which in turn are passed in the `params` hash to the Service objects). 

@floehopper - what do you think about this last omission? I think I could do something with `routes.rb` to rename this parameter, but I'm not sure it's worth the effort given that we may rename back to `id` from `uuid` once the conversion is complete. 