### PR TITLE
Remove redundant require statement from Services module

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,6 @@
 require "gds_api/asset_manager"
 require "gds_api/content_store"
 require "gds_api/organisations"
-require "gds_api/publishing_api"
 require "gds_api/publishing_api_v2"
 require "gds_api/rummager"
 


### PR DESCRIPTION
This should have been removed as part of [this commit][1].

[1]: https://github.com/alphagov/manuals-publisher/commit/98683b06bb3ea4aadb26d1156fbbc10178ca1b35