### PR TITLE
Stub Manual#version_type vs #update_type & return symbol vs string

### DIFF
--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -312,7 +312,7 @@ describe ManualPublishingAPIExporter do
 
   context "when Manual#version_type is major" do
     before do
-      allow(manual).to receive(:update_type).and_return("major")
+      allow(manual).to receive(:version_type).and_return(:major)
     end
 
     it "exports with the update_type set to major" do


### PR DESCRIPTION
This should have been changed in [this commit][1]. The relevant examples were passing by accident, because `Manual#version_type` was returning `:new` which coincidentally also maps to an update type of "major".

[1]: github.com/alphagov/manuals-publisher/commit/93115ae3f97997e214e88bca34fdf218a4719efd