### PR TITLE
Move and extract GdsApi constants for Rummager and Publishing Api

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -28,7 +28,7 @@ class PublishingAdapter
       SecureRandom.uuid,
       document_type: 'redirect',
       schema_name: 'redirect',
-      publishing_app: "manuals-publisher",
+      publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
       base_path: "/#{section.slug}",
       redirects: [
         {

--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -33,7 +33,7 @@ class PublishingAdapter
       redirects: [
         {
           path: "/#{section.slug}",
-          type: "exact",
+          type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
           destination: to
         }
       ],

--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -1,9 +1,10 @@
 require "adapters"
 require "securerandom"
+require "gds_api_constants"
 
 class PublishingAdapter
   def save(manual, republish: false, include_sections: true, include_links: true)
-    update_type = (republish ? "republish" : nil)
+    update_type = (republish ? GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE : nil)
 
     save_manual_links(manual) if include_links
     save_manual_content(manual, update_type: update_type)

--- a/app/adapters/search_index_adapter.rb
+++ b/app/adapters/search_index_adapter.rb
@@ -1,31 +1,29 @@
 require "services"
+require "gds_api_constants"
 
 class SearchIndexAdapter
-  RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL = "manual".freeze
-  RUMMAGER_DOCUMENT_TYPE_FOR_SECTION = "manual_section".freeze
-
   def add(manual)
     rummager.add_document(
-      RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL,
+      GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE,
       path_for(manual),
       title: manual.title,
       description: manual.summary,
       link: path_for(manual),
       indexable_content: manual.summary,
       public_timestamp: manual.updated_at,
-      content_store_document_type: RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL
+      content_store_document_type: GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE
     )
 
     manual.sections.each do |section|
       rummager.add_document(
-        RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+        GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
         path_for(section),
         title: "#{manual.title}: #{section.title}",
         description: section.summary,
         link: path_for(section),
         indexable_content: MarkdownAttachmentProcessor.new(section).body,
         public_timestamp: nil,
-        content_store_document_type: RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+        content_store_document_type: GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
         manual: path_for(manual)
       )
     end
@@ -37,7 +35,7 @@ class SearchIndexAdapter
 
   def remove(manual)
     rummager.delete_document(
-      RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL,
+      GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE,
       path_for(manual)
     )
 
@@ -48,7 +46,7 @@ class SearchIndexAdapter
 
   def remove_section(section)
     rummager.delete_document(
-      RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+      GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
       path_for(section)
     )
   end

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -41,7 +41,7 @@ private
       title: presented_manual.title,
       description: presented_manual.summary,
       update_type: update_type,
-      publishing_app: "manuals-publisher",
+      publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
       rendering_app: "manuals-frontend",
       routes: [
         {

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -71,9 +71,9 @@ private
     return @update_type if @update_type.present?
     case manual.version_type
     when :new, :major
-      "major"
+      GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE
     when :minor
-      "minor"
+      GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE
     else
       raise "Uknown version type: #{manual.version_type}"
     end

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -42,7 +42,7 @@ private
       description: presented_manual.summary,
       update_type: update_type,
       publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
-      rendering_app: "manuals-frontend",
+      rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
       routes: [
         {
           path: base_path,

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -46,11 +46,11 @@ private
       routes: [
         {
           path: base_path,
-          type: "exact",
+          type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
         },
         {
           path: updates_path,
-          type: "exact",
+          type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
         }
       ],
       details: details_data,

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -30,7 +30,7 @@ private
   end
 
   def updates_path
-    [base_path, "updates"].join("/")
+    [base_path, GdsApiConstants::PublishingApiV2::UPDATES_PATH_SUFFIX].join("/")
   end
 
   def exportable_attributes

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,8 +1,7 @@
+require "gds_api_constants"
+
 class ManualPublishingAPIExporter
   include PublishingAPIUpdateTypes
-
-  PUBLISHING_API_SCHEMA_NAME = "manual".freeze
-  PUBLISHING_API_DOCUMENT_TYPE = "manual".freeze
 
   def initialize(organisation, manual, update_type: nil)
     @organisation = organisation
@@ -37,8 +36,8 @@ private
   def exportable_attributes
     {
       base_path: base_path,
-      schema_name: PUBLISHING_API_SCHEMA_NAME,
-      document_type: PUBLISHING_API_DOCUMENT_TYPE,
+      schema_name: GdsApiConstants::PublishingApiV2::MANUAL_SCHEMA_NAME,
+      document_type: GdsApiConstants::PublishingApiV2::MANUAL_DOCUMENT_TYPE,
       title: presented_manual.title,
       description: presented_manual.summary,
       update_type: update_type,

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -54,7 +54,7 @@ private
         }
       ],
       details: details_data,
-      locale: "en",
+      locale: GdsApiConstants::PublishingApiV2::EDITION_LOCALE,
     }.merge(optional_exportable_attributes)
   end
 

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -97,7 +97,7 @@ private
       ],
       child_section_groups: [
         {
-          title: "Contents",
+          title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
           child_sections: sections,
         }
       ],

--- a/app/exporters/publishing_api_manual_with_sections_publisher.rb
+++ b/app/exporters/publishing_api_manual_with_sections_publisher.rb
@@ -1,6 +1,8 @@
+require "gds_api_constants"
+
 class PublishingApiManualWithSectionsPublisher
   def call(manual, action = nil)
-    update_type = (action == :republish ? "republish" : nil)
+    update_type = (action == :republish ? GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE : nil)
     PublishingAPIPublisher.new(
       entity: manual,
       update_type: update_type,

--- a/app/exporters/publishing_api_update_types.rb
+++ b/app/exporters/publishing_api_update_types.rb
@@ -1,5 +1,11 @@
+require "gds_api_constants"
+
 module PublishingAPIUpdateTypes
-  UPDATE_TYPES = %w(minor major republish).freeze
+  UPDATE_TYPES = [
+    GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE,
+    GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
+    GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE
+  ].freeze
 
   def check_update_type!(update_type)
     if update_type.present? && !UPDATE_TYPES.include?(update_type)

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -44,7 +44,7 @@ private
         }
       ],
       details: details,
-      locale: "en",
+      locale: GdsApiConstants::PublishingApiV2::EDITION_LOCALE,
     }.merge(optional_exportable_attributes)
   end
 

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -105,9 +105,9 @@ private
     return @update_type if @update_type.present?
     case section.version_type
     when :new, :major
-      "major"
+      GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE
     when :minor
-      "minor"
+      GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE
     else
       raise "Unknown version type: #{section.version_type}"
     end

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -1,8 +1,7 @@
+require "gds_api_constants"
+
 class SectionPublishingAPIExporter
   include PublishingAPIUpdateTypes
-
-  PUBLISHING_API_SCHEMA_NAME = "manual_section".freeze
-  PUBLISHING_API_DOCUMENT_TYPE = "manual_section".freeze
 
   def initialize(organisation, manual, section, update_type: nil)
     @organisation = organisation
@@ -31,8 +30,8 @@ private
   def exportable_attributes
     {
       base_path: base_path,
-      schema_name: PUBLISHING_API_SCHEMA_NAME,
-      document_type: PUBLISHING_API_DOCUMENT_TYPE,
+      schema_name: GdsApiConstants::PublishingApiV2::SECTION_SCHEMA_NAME,
+      document_type: GdsApiConstants::PublishingApiV2::SECTION_DOCUMENT_TYPE,
       title: section_presenter.title,
       description: section_presenter.summary,
       update_type: update_type,

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -40,7 +40,7 @@ private
       routes: [
         {
           path: base_path,
-          type: "exact",
+          type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
         }
       ],
       details: details,

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -35,7 +35,7 @@ private
       title: section_presenter.title,
       description: section_presenter.summary,
       update_type: update_type,
-      publishing_app: "manuals-publisher",
+      publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
       rendering_app: "manuals-frontend",
       routes: [
         {

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -36,7 +36,7 @@ private
       description: section_presenter.summary,
       update_type: update_type,
       publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
-      rendering_app: "manuals-frontend",
+      rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
       routes: [
         {
           path: base_path,

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -1,3 +1,5 @@
+require "gds_api_constants"
+
 When(/^I create a manual$/) do
   @manual_fields = {
     title: "Example Manual Title",
@@ -489,37 +491,37 @@ end
 Then(/^the manual is published as a major update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE }, number_of_drafts: 2)
 end
 
 Then(/^the manual is published as a minor update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE }, number_of_drafts: 2)
 end
 
 Then(/^the manual is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
+  check_manual_is_drafted_to_publishing_api(@manual.id, extra_attributes: { update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE }, number_of_drafts: 1)
 end
 
 Then(/^the section is published as a major update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: "major" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE }, number_of_drafts: 2)
 end
 
 Then(/^the section is published as a major update$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: "major" }, number_of_drafts: 1)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE }, number_of_drafts: 1)
 end
 
 Then(/^the section is published as a minor update including a change note draft$/) do
   # We don't use the update_type on the publish API, we fallback to what we set
   # when drafting the content
-  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: "minor" }, number_of_drafts: 2)
+  check_section_is_drafted_to_publishing_api((@updated_section || @section).uuid, extra_attributes: { update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE }, number_of_drafts: 2)
 end
 
 Then(/^I can see the change note and update type form when editing existing sections$/) do

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -151,7 +151,7 @@ Then(/^the section and table of contents will have been sent to the draft publis
     details: {
       child_section_groups: [
         {
-          title: "Contents",
+          title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
           child_sections: [
             {
               title: @section_title,
@@ -175,7 +175,7 @@ Then(/^the updated section at the new slug and updated table of contents will ha
     details: {
       child_section_groups: [
         {
-          title: "Contents",
+          title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
           child_sections: [
             {
               title: @new_title,
@@ -291,7 +291,7 @@ Then(/^the updated section is available to preview$/) do
     details: {
       child_section_groups: [
         {
-          title: "Contents",
+          title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
           child_sections: sections,
         }
       ]
@@ -703,7 +703,7 @@ Then(/^the new order should be visible in the preview environment$/) do
     details: {
       child_section_groups: [
         {
-          title: "Contents",
+          title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
           child_sections: @reordered_section_attributes.map do |sec|
             {
               title: sec[:fields][:section_title],

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -1,5 +1,6 @@
 require "manuals_republisher"
 require "manual_withdrawer"
+require "gds_api_constants"
 
 module ManualHelpers
   def entity_id_for(entity)
@@ -256,7 +257,7 @@ module ManualHelpers
   def check_manual_is_published_to_rummager(slug, attrs)
     expect(fake_rummager).to have_received(:add_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL,
+        GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: attrs.fetch(:title),
@@ -269,7 +270,7 @@ module ManualHelpers
   def check_manual_is_not_published_to_rummager(slug)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL,
+        GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE,
         "/#{slug}",
         anything
       )
@@ -278,7 +279,7 @@ module ManualHelpers
   def check_manual_is_not_published_to_rummager_with_attrs(slug, attrs)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL,
+        GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: attrs.fetch(:title),
@@ -345,7 +346,7 @@ module ManualHelpers
   def check_section_is_published_to_rummager(slug, attrs, manual_attrs)
     expect(fake_rummager).to have_received(:add_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+        GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: "#{manual_attrs.fetch(:title)}: #{attrs.fetch(:section_title)}",
@@ -358,7 +359,7 @@ module ManualHelpers
   def check_section_is_not_published_to_rummager(slug)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+        GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
         "/#{slug}",
         anything
       )
@@ -367,7 +368,7 @@ module ManualHelpers
   def check_section_is_not_published_to_rummager_with_attrs(slug, attrs, manual_attrs)
     expect(fake_rummager).not_to have_received(:add_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+        GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
         "/#{slug}",
         hash_including(
           title: "#{manual_attrs.fetch(:title)}: #{attrs.fetch(:section_title)}",
@@ -468,14 +469,14 @@ module ManualHelpers
   def check_manual_is_withdrawn_from_rummager(manual, sections)
     expect(fake_rummager).to have_received(:delete_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL,
+        GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE,
         "/#{manual.slug}",
       )
 
     sections.each do |section|
       expect(fake_rummager).to have_received(:delete_document)
         .with(
-          SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+          GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
           "/#{section.slug}",
         )
     end
@@ -484,7 +485,7 @@ module ManualHelpers
   def check_section_is_withdrawn_from_rummager(section)
     expect(fake_rummager).to have_received(:delete_document)
       .with(
-        SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_SECTION,
+        GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE,
         "/#{section.slug}",
       )
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -294,8 +294,8 @@ module ManualHelpers
 
     if with_matcher.nil?
       attributes = {
-        "schema_name" => ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
-        "document_type" => ManualPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
+        "schema_name" => GdsApiConstants::PublishingApiV2::MANUAL_SCHEMA_NAME,
+        "document_type" => GdsApiConstants::PublishingApiV2::MANUAL_DOCUMENT_TYPE,
         "rendering_app" => "manuals-frontend",
         "publishing_app" => "manuals-publisher",
       }.merge(extra_attributes)
@@ -321,8 +321,8 @@ module ManualHelpers
 
     if with_matcher.nil?
       attributes = {
-        "schema_name" => SectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
-        "document_type" => SectionPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
+        "schema_name" => GdsApiConstants::PublishingApiV2::SECTION_SCHEMA_NAME,
+        "document_type" => GdsApiConstants::PublishingApiV2::SECTION_DOCUMENT_TYPE,
         "rendering_app" => "manuals-frontend",
         "publishing_app" => "manuals-publisher",
       }.merge(extra_attributes)

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -17,5 +17,7 @@ module GdsApiConstants
     MINOR_UPDATE_TYPE = "minor".freeze
     MAJOR_UPDATE_TYPE = "major".freeze
     REPUBLISH_UPDATE_TYPE = "republish".freeze
+
+    EXACT_ROUTE_TYPE = "exact".freeze
   end
 end

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -5,6 +5,8 @@ module GdsApiConstants
   end
 
   module PublishingApiV2
+    PUBLISHING_APP = "manuals-publisher".freeze
+
     MANUAL_SCHEMA_NAME = "manual".freeze
     MANUAL_DOCUMENT_TYPE = "manual".freeze
 

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -10,5 +10,9 @@ module GdsApiConstants
 
     SECTION_SCHEMA_NAME = "manual_section".freeze
     SECTION_DOCUMENT_TYPE = "manual_section".freeze
+
+    MINOR_UPDATE_TYPE = "minor".freeze
+    MAJOR_UPDATE_TYPE = "major".freeze
+    REPUBLISH_UPDATE_TYPE = "republish".freeze
   end
 end

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -6,6 +6,7 @@ module GdsApiConstants
 
   module PublishingApiV2
     PUBLISHING_APP = "manuals-publisher".freeze
+    RENDERING_APP = "manuals-frontend".freeze
 
     MANUAL_SCHEMA_NAME = "manual".freeze
     MANUAL_DOCUMENT_TYPE = "manual".freeze

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -21,5 +21,7 @@ module GdsApiConstants
     EXACT_ROUTE_TYPE = "exact".freeze
 
     CHILD_SECTION_GROUP_TITLE = "Contents".freeze
+
+    EDITION_LOCALE = "en".freeze
   end
 end

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -1,0 +1,6 @@
+module GdsApiConstants
+  module Rummager
+    MANUAL_DOCUMENT_TYPE = "manual".freeze
+    SECTION_DOCUMENT_TYPE = "manual_section".freeze
+  end
+end

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -18,6 +18,7 @@ module GdsApiConstants
     MAJOR_UPDATE_TYPE = "major".freeze
     REPUBLISH_UPDATE_TYPE = "republish".freeze
 
+    UPDATES_PATH_SUFFIX = "updates".freeze
     EXACT_ROUTE_TYPE = "exact".freeze
 
     CHILD_SECTION_GROUP_TITLE = "Contents".freeze

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -3,4 +3,12 @@ module GdsApiConstants
     MANUAL_DOCUMENT_TYPE = "manual".freeze
     SECTION_DOCUMENT_TYPE = "manual_section".freeze
   end
+
+  module PublishingApiV2
+    MANUAL_SCHEMA_NAME = "manual".freeze
+    MANUAL_DOCUMENT_TYPE = "manual".freeze
+
+    SECTION_SCHEMA_NAME = "manual_section".freeze
+    SECTION_DOCUMENT_TYPE = "manual_section".freeze
+  end
 end

--- a/lib/gds_api_constants.rb
+++ b/lib/gds_api_constants.rb
@@ -19,5 +19,7 @@ module GdsApiConstants
     REPUBLISH_UPDATE_TYPE = "republish".freeze
 
     EXACT_ROUTE_TYPE = "exact".freeze
+
+    CHILD_SECTION_GROUP_TITLE = "Contents".freeze
   end
 end

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -211,7 +211,7 @@ private
       routes: [
         {
           path: "/#{slug}",
-          type: "exact"
+          type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE
         }
       ]
     }

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -1,5 +1,6 @@
 require "services"
 require "adapters"
+require "gds_api_constants"
 
 class ManualRelocator
   attr_reader :from_slug, :to_slug
@@ -176,10 +177,10 @@ private
       send_draft(manual_to_publish)
 
       puts "Publishing published edition of manual: #{manual_to_publish.id}"
-      publishing_api.publish(manual_to_publish.id, "republish")
+      publishing_api.publish(manual_to_publish.id, GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
       manual_to_publish.sections.each do |section|
         puts "Publishing published edition of manual section: #{section.uuid}"
-        publishing_api.publish(section.uuid, "republish")
+        publishing_api.publish(section.uuid, GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
       end
     end
 
@@ -215,7 +216,7 @@ private
       ]
     }
     publishing_api.put_content(section_uuid, gone_item)
-    publishing_api.publish(section_uuid, "major")
+    publishing_api.publish(section_uuid, GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
   end
 
   def publishing_api

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -206,7 +206,7 @@ private
       base_path: "/#{slug}",
       content_id: section_uuid,
       document_type: "gone",
-      publishing_app: "manuals-publisher",
+      publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
       schema_name: "gone",
       routes: [
         {

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -119,7 +119,7 @@ describe PublishingAdapter do
         document_type: publishing_api_document_type_for_manual,
         title: "manual-title",
         description: "manual-summary",
-        update_type: "major",
+        update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
         publishing_app: "manuals-publisher",
         rendering_app: "manuals-frontend",
         routes: [
@@ -201,7 +201,7 @@ describe PublishingAdapter do
         document_type: publishing_api_document_type_for_section,
         title: "section-title",
         description: "section-summary",
-        update_type: "major",
+        update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
         publishing_app: "manuals-publisher",
         rendering_app: "manuals-frontend",
         routes: [
@@ -345,7 +345,7 @@ describe PublishingAdapter do
         it "saves content for manual to Publishing API with republish update_type" do
           expect(publishing_api).to receive(:put_content).with(
             manual_id,
-            including(update_type: "republish")
+            including(update_type: GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
           )
 
           subject.save(manual, republish: true)
@@ -354,7 +354,7 @@ describe PublishingAdapter do
         it "saves content for section to Publishing API with republish update_type" do
           expect(publishing_api).to receive(:put_content).with(
             section_uuid,
-            including(update_type: "republish")
+            including(update_type: GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
           )
 
           subject.save(manual, republish: true)
@@ -371,7 +371,7 @@ describe PublishingAdapter do
       it "saves content for manual to Publishing API with major update_type" do
         expect(publishing_api).to receive(:put_content).with(
           manual_id,
-          including(update_type: "major")
+          including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
         )
 
         subject.save(manual)
@@ -380,7 +380,7 @@ describe PublishingAdapter do
       it "saves content for section to Publishing API with major update_type" do
         expect(publishing_api).to receive(:put_content).with(
           section_uuid,
-          including(update_type: "major")
+          including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
         )
 
         subject.save(manual)
@@ -398,7 +398,7 @@ describe PublishingAdapter do
       it "saves content for manual to Publishing API with minor update_type" do
         expect(publishing_api).to receive(:put_content).with(
           manual_id,
-          including(update_type: "minor")
+          including(update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE)
         )
 
         subject.save(manual)
@@ -407,7 +407,7 @@ describe PublishingAdapter do
       it "saves content for section to Publishing API with minor update_type" do
         expect(publishing_api).to receive(:put_content).with(
           section_uuid,
-          including(update_type: "minor")
+          including(update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE)
         )
 
         subject.save(manual)
@@ -425,7 +425,7 @@ describe PublishingAdapter do
       it "saves content for manual to Publishing API with major update_type" do
         expect(publishing_api).to receive(:put_content).with(
           manual_id,
-          including(update_type: "major")
+          including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
         )
 
         subject.save(manual)
@@ -434,7 +434,7 @@ describe PublishingAdapter do
       it "saves content for section to Publishing API with major update_type" do
         expect(publishing_api).to receive(:put_content).with(
           section_uuid,
-          including(update_type: "major")
+          including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
         )
 
         subject.save(manual)

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -125,11 +125,11 @@ describe PublishingAdapter do
         routes: [
           {
             path: "/manual-slug",
-            type: "exact",
+            type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
           },
           {
             path: "/manual-slug/updates",
-            type: "exact",
+            type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
           }
         ],
         details: {
@@ -207,7 +207,7 @@ describe PublishingAdapter do
         routes: [
           {
             path: "/manual-slug/section-slug",
-            type: "exact"
+            type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE
           },
         ],
         details: {
@@ -530,7 +530,7 @@ describe PublishingAdapter do
         redirects: [
           {
             path: "/manual-slug/section-slug",
-            type: "exact",
+            type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             destination: "/new-location"
           }
         ],

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -121,7 +121,7 @@ describe PublishingAdapter do
         description: "manual-summary",
         update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
         publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
-        rendering_app: "manuals-frontend",
+        rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
         routes: [
           {
             path: "/manual-slug",
@@ -203,7 +203,7 @@ describe PublishingAdapter do
         description: "section-summary",
         update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
         publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
-        rendering_app: "manuals-frontend",
+        rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
         routes: [
           {
             path: "/manual-slug/section-slug",

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -103,7 +103,7 @@ describe PublishingAdapter do
       expect(publishing_api).to receive(:patch_links).with(
         manual_id,
         be_valid_against_links_schema(
-          ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME
+          publishing_api_schema_name_for_manual
         )
       )
 
@@ -185,7 +185,7 @@ describe PublishingAdapter do
       expect(publishing_api).to receive(:patch_links).with(
         section_uuid,
         be_valid_against_links_schema(
-          SectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME
+          publishing_api_schema_name_for_section
         )
       )
 

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -1,20 +1,21 @@
 require "spec_helper"
+require "gds_api_constants"
 
 describe PublishingAdapter do
   let(:publishing_api_schema_name_for_manual) {
-    ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME
+    GdsApiConstants::PublishingApiV2::MANUAL_SCHEMA_NAME
   }
 
   let(:publishing_api_document_type_for_manual) {
-    ManualPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE
+    GdsApiConstants::PublishingApiV2::MANUAL_DOCUMENT_TYPE
   }
 
   let(:publishing_api_schema_name_for_section) {
-    SectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME
+    GdsApiConstants::PublishingApiV2::SECTION_SCHEMA_NAME
   }
 
   let(:publishing_api_document_type_for_section) {
-    SectionPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE
+    GdsApiConstants::PublishingApiV2::SECTION_DOCUMENT_TYPE
   }
 
   let(:timestamp) { Time.zone.parse("2017-01-01 00:00:00") }

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -120,7 +120,7 @@ describe PublishingAdapter do
         title: "manual-title",
         description: "manual-summary",
         update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
-        publishing_app: "manuals-publisher",
+        publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
         rendering_app: "manuals-frontend",
         routes: [
           {
@@ -202,7 +202,7 @@ describe PublishingAdapter do
         title: "section-title",
         description: "section-summary",
         update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
-        publishing_app: "manuals-publisher",
+        publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
         rendering_app: "manuals-frontend",
         routes: [
           {
@@ -526,7 +526,7 @@ describe PublishingAdapter do
         base_path: "/manual-slug/section-slug",
         schema_name: "redirect",
         document_type: "redirect",
-        publishing_app: "manuals-publisher",
+        publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
         redirects: [
           {
             path: "/manual-slug/section-slug",

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -164,7 +164,7 @@ describe PublishingAdapter do
             }
           ]
         },
-        locale: "en",
+        locale: GdsApiConstants::PublishingApiV2::EDITION_LOCALE,
       )
 
       subject.save(manual)
@@ -232,7 +232,7 @@ describe PublishingAdapter do
             }
           ]
         },
-        locale: "en",
+        locale: GdsApiConstants::PublishingApiV2::EDITION_LOCALE,
       )
 
       subject.save(manual)

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -128,7 +128,7 @@ describe PublishingAdapter do
             type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
           },
           {
-            path: "/manual-slug/updates",
+            path: "/manual-slug/#{GdsApiConstants::PublishingApiV2::UPDATES_PATH_SUFFIX}",
             type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
           }
         ],

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -145,7 +145,7 @@ describe PublishingAdapter do
           ],
           child_section_groups:  [
             {
-              title: "Contents",
+              title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
               child_sections: [
                 {
                   title: "section-title",

--- a/spec/adapters/search_index_adapter_spec.rb
+++ b/spec/adapters/search_index_adapter_spec.rb
@@ -1,10 +1,11 @@
 require "spec_helper"
+require "gds_api_constants"
 
 describe SearchIndexAdapter do
   let(:rummager) { double(:rummager) }
 
-  let(:rummager_document_type_for_manual) { SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_MANUAL }
-  let(:rummager_document_type_for_section) { SearchIndexAdapter::RUMMAGER_DOCUMENT_TYPE_FOR_SECTION }
+  let(:rummager_document_type_for_manual) { GdsApiConstants::Rummager::MANUAL_DOCUMENT_TYPE }
+  let(:rummager_document_type_for_section) { GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE }
 
   let(:manual) {
     Manual.build(

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -152,7 +152,7 @@ describe ManualPublishingAPIExporter do
               type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             },
             {
-              path: "/guidance/my-first-manual/updates",
+              path: "/guidance/my-first-manual/#{GdsApiConstants::PublishingApiV2::UPDATES_PATH_SUFFIX}",
               type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             }
           ],

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -145,7 +145,7 @@ describe ManualPublishingAPIExporter do
           description: "This is my first manual",
           update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
           publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
-          rendering_app: "manuals-frontend",
+          rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
           routes: [
             {
               path: "/guidance/my-first-manual",

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -3,6 +3,7 @@ require "support/all_of_matcher"
 require "support/govuk_content_schema_helpers"
 
 require "manual_publishing_api_exporter"
+require "gds_api_constants"
 
 describe ManualPublishingAPIExporter do
   subject {
@@ -127,7 +128,7 @@ describe ManualPublishingAPIExporter do
   end
 
   it "exports a manual valid against the schema" do
-    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema(ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME)
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema(GdsApiConstants::PublishingApiV2::MANUAL_SCHEMA_NAME)
   end
 
   it "exports the serialized section attributes" do
@@ -138,8 +139,8 @@ describe ManualPublishingAPIExporter do
       all_of(
         hash_including(
           base_path: "/guidance/my-first-manual",
-          schema_name: ManualPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
-          document_type: ManualPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
+          schema_name: GdsApiConstants::PublishingApiV2::MANUAL_SCHEMA_NAME,
+          document_type: GdsApiConstants::PublishingApiV2::MANUAL_DOCUMENT_TYPE,
           title: "My first manual",
           description: "This is my first manual",
           update_type: "major",

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -144,7 +144,7 @@ describe ManualPublishingAPIExporter do
           title: "My first manual",
           description: "This is my first manual",
           update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
-          publishing_app: "manuals-publisher",
+          publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
           rendering_app: "manuals-frontend",
           routes: [
             {

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -106,7 +106,7 @@ describe ManualPublishingAPIExporter do
   end
 
   it "accepts major, minor, and republish as options for update_type" do
-    %w(major minor republish).each do |update_type|
+    PublishingAPIUpdateTypes::UPDATE_TYPES.each do |update_type|
       expect {
         described_class.new(
           organisation,
@@ -143,7 +143,7 @@ describe ManualPublishingAPIExporter do
           document_type: GdsApiConstants::PublishingApiV2::MANUAL_DOCUMENT_TYPE,
           title: "My first manual",
           description: "This is my first manual",
-          update_type: "major",
+          update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
           publishing_app: "manuals-publisher",
           rendering_app: "manuals-frontend",
           routes: [
@@ -266,12 +266,12 @@ describe ManualPublishingAPIExporter do
     }
 
     context "when update_type is provided as 'republish'" do
-      let(:explicit_update_type) { "republish" }
+      let(:explicit_update_type) { GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE }
       it "exports with the update_type set to republish" do
         subject.call
         expect(publishing_api).to have_received(:put_content).with(
           "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-          hash_including(update_type: "republish")
+          hash_including(update_type: GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
         )
       end
     end
@@ -287,7 +287,7 @@ describe ManualPublishingAPIExporter do
 
       expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "minor")
+        hash_including(update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE)
       )
     end
 
@@ -304,7 +304,7 @@ describe ManualPublishingAPIExporter do
 
       expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "major")
+        hash_including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
       )
     end
 
@@ -321,7 +321,7 @@ describe ManualPublishingAPIExporter do
 
       expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
-        hash_including(update_type: "major")
+        hash_including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
       )
     end
 

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -222,7 +222,7 @@ describe ManualPublishingAPIExporter do
           ],
           child_section_groups: [
             {
-              title: "Contents",
+              title: GdsApiConstants::PublishingApiV2::CHILD_SECTION_GROUP_TITLE,
               child_sections: [
                 base_path: "/guidance/my-first-manual/first-section",
                 title: "Document title",

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -156,7 +156,7 @@ describe ManualPublishingAPIExporter do
               type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             }
           ],
-          locale: "en",
+          locale: GdsApiConstants::PublishingApiV2::EDITION_LOCALE,
         ),
         hash_excluding(:first_published_at, :public_updated_at)
       )

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -149,11 +149,11 @@ describe ManualPublishingAPIExporter do
           routes: [
             {
               path: "/guidance/my-first-manual",
-              type: "exact",
+              type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             },
             {
               path: "/guidance/my-first-manual/updates",
-              type: "exact",
+              type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             }
           ],
           locale: "en",

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 require "publishing_api_publisher"
+require "gds_api_constants"
 
 describe PublishingAPIPublisher do
   let(:publishing_api) { double(:publishing_api, publish: nil) }
@@ -17,7 +18,7 @@ describe PublishingAPIPublisher do
   end
 
   it "accepts major, minor, and republish as options for update_type" do
-    %w(major minor republish).each do |update_type|
+    PublishingAPIUpdateTypes::UPDATE_TYPES.each do |update_type|
       expect {
         described_class.new(
           entity: section,
@@ -59,14 +60,14 @@ describe PublishingAPIPublisher do
       subject do
         described_class.new(
           entity: section,
-          update_type: "republish"
+          update_type: GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE
         )
       end
 
       it "asks the publishing api to publish the section with the specific update_type" do
         subject.call
 
-        expect(publishing_api).to have_received(:publish).with(section_uuid, "republish")
+        expect(publishing_api).to have_received(:publish).with(section_uuid, GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
       end
     end
   end

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -111,7 +111,7 @@ describe SectionPublishingAPIExporter do
   end
 
   it "exports a manual_section valid against the schema" do
-    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema("manual_section")
+    expect(subject.send(:exportable_attributes).to_json).to be_valid_against_schema(GdsApiConstants::PublishingApiV2::SECTION_SCHEMA_NAME)
   end
 
   it "exports the serialized section attributes" do

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -127,7 +127,7 @@ describe SectionPublishingAPIExporter do
           title: "Document title",
           description: "This is the first section",
           update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE,
-          publishing_app: "manuals-publisher",
+          publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
           rendering_app: "manuals-frontend",
           routes: [
             {

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -128,7 +128,7 @@ describe SectionPublishingAPIExporter do
           description: "This is the first section",
           update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE,
           publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
-          rendering_app: "manuals-frontend",
+          rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
           routes: [
             {
               path: section_base_path,

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -3,6 +3,7 @@ require "support/all_of_matcher"
 require "support/govuk_content_schema_helpers"
 
 require "section_publishing_api_exporter"
+require "gds_api_constants"
 
 describe SectionPublishingAPIExporter do
   subject {
@@ -121,8 +122,8 @@ describe SectionPublishingAPIExporter do
       all_of(
         hash_including(
           base_path: section_base_path,
-          schema_name: SectionPublishingAPIExporter::PUBLISHING_API_SCHEMA_NAME,
-          document_type: SectionPublishingAPIExporter::PUBLISHING_API_DOCUMENT_TYPE,
+          schema_name: GdsApiConstants::PublishingApiV2::SECTION_SCHEMA_NAME,
+          document_type: GdsApiConstants::PublishingApiV2::SECTION_DOCUMENT_TYPE,
           title: "Document title",
           description: "This is the first section",
           update_type: "minor",

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -87,7 +87,7 @@ describe SectionPublishingAPIExporter do
   end
 
   it "accepts major, minor, and republish as options for update_type" do
-    %w(major minor republish).each do |update_type|
+    PublishingAPIUpdateTypes::UPDATE_TYPES.each do |update_type|
       expect {
         described_class.new(
           organisation,
@@ -126,7 +126,7 @@ describe SectionPublishingAPIExporter do
           document_type: GdsApiConstants::PublishingApiV2::SECTION_DOCUMENT_TYPE,
           title: "Document title",
           description: "This is the first section",
-          update_type: "minor",
+          update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE,
           publishing_app: "manuals-publisher",
           rendering_app: "manuals-frontend",
           routes: [
@@ -203,23 +203,23 @@ describe SectionPublishingAPIExporter do
       }
 
       context "when update_type is provided as 'republish'" do
-        let(:explicit_update_type) { "republish" }
+        let(:explicit_update_type) { GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE }
         it "exports with the update_type set to republish" do
           subject.call
           expect(publishing_api).to have_received(:put_content).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
-            hash_including(update_type: "republish")
+            hash_including(update_type: GdsApiConstants::PublishingApiV2::REPUBLISH_UPDATE_TYPE)
           )
         end
       end
 
       context "when update_type is provided as 'minor'" do
-        let(:explicit_update_type) { "minor" }
+        let(:explicit_update_type) { GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE }
         it "exports with the update_type set to minor" do
           subject.call
           expect(publishing_api).to have_received(:put_content).with(
             "c19ffb7d-448c-4cc8-bece-022662ef9611",
-            hash_including(update_type: "minor")
+            hash_including(update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE)
           )
         end
       end
@@ -233,7 +233,7 @@ describe SectionPublishingAPIExporter do
 
         expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
-          hash_including(update_type: "major")
+          hash_including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
         )
       end
 
@@ -248,7 +248,7 @@ describe SectionPublishingAPIExporter do
 
         expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
-          hash_including(update_type: "minor")
+          hash_including(update_type: GdsApiConstants::PublishingApiV2::MINOR_UPDATE_TYPE)
         )
       end
 
@@ -263,7 +263,7 @@ describe SectionPublishingAPIExporter do
 
         expect(publishing_api).to have_received(:put_content).with(
           "c19ffb7d-448c-4cc8-bece-022662ef9611",
-          hash_including(update_type: "major")
+          hash_including(update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE)
         )
       end
 

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -132,7 +132,7 @@ describe SectionPublishingAPIExporter do
           routes: [
             {
               path: section_base_path,
-              type: "exact",
+              type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE,
             }
           ],
         ),

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "manual_relocator"
+require "gds_api_constants"
 
 describe ManualRelocator do
   include GdsApi::TestHelpers::PublishingApiV2
@@ -199,7 +200,7 @@ describe ManualRelocator do
             base_path: "/#{existing_slug}",
             content_id: existing_manual_id,
             document_type: "gone",
-            publishing_app: "manuals-publisher",
+            publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
             schema_name: "gone",
             routes: [
               {
@@ -230,7 +231,7 @@ describe ManualRelocator do
             base_path: "/#{existing_section_3.slug}",
             content_id: existing_section_3.section_uuid,
             document_type: "gone",
-            publishing_app: "manuals-publisher",
+            publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
             schema_name: "gone",
             routes: [
               {

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -205,7 +205,7 @@ describe ManualRelocator do
             routes: [
               {
                 path: "/#{existing_slug}",
-                type: "exact"
+                type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE
               }
             ]
           }
@@ -236,7 +236,7 @@ describe ManualRelocator do
             routes: [
               {
                 path: "/#{existing_section_3.slug}",
-                type: "exact"
+                type: GdsApiConstants::PublishingApiV2::EXACT_ROUTE_TYPE
               }
             ]
           }

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require 'section_reslugger'
 require "gds_api/test_helpers/content_store"
 require "gds_api/test_helpers/rummager"
+require "gds_api_constants"
 
 describe SectionReslugger do
   include GdsApi::TestHelpers::ContentStore
@@ -57,6 +58,6 @@ describe SectionReslugger do
   it "removes content stored against the old section slug from the search index" do
     subject.call
 
-    expect(Services.rummager).to have_received(:delete_document).with("manual_section", "/manual-slug/old-section-slug")
+    expect(Services.rummager).to have_received(:delete_document).with(GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE, "/manual-slug/old-section-slug")
   end
 end


### PR DESCRIPTION
This extracts a bunch of string literals into constants in a new namespace, `GdsApiConstants`, and moves some existing constants into that new namespace.

Although the resulting code is more verbose, I think this is outweighed by my motivations:

* Make the code more explicit / intention-revealing
* Reduce duplication across the application
* Reduce duplication between application and specs
* Highlight the number of places some of these constants are used - they probably shouldn't be so widespread!
* Make it easier to refactor the code in these areas

As we bring the rest of the exporter code into `PublishingAdapter`, the number places these constants are used should decrease.

In the longer term I think these constants should live in the `gds-api-adapters` gem or in some cases further "downstream", e.g. in `publishing-api`, `govuk-content-schemas`, `content-store`, or `rummager`. Constants (or enums) like this could be helpful in making it easier to discover the allowable values of method arguments for the various API client methods.
