### PR TITLE
Inline PublishingAPIDraftSectionDiscarder into PublishingAdapter#discard_section

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -41,6 +41,10 @@ class PublishingAdapter
     )
   end
 
+  def discard_section(section)
+    PublishingApiDraftSectionDiscarder.new.call(section)
+  end
+
 private
 
   def organisation_for(manual)

--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -43,7 +43,6 @@ class PublishingAdapter
 
   def discard_section(section)
     Services.publishing_api.discard_draft(section.uuid)
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end
 
 private

--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -42,7 +42,8 @@ class PublishingAdapter
   end
 
   def discard_section(section)
-    PublishingApiDraftSectionDiscarder.new.call(section)
+    Services.publishing_api.discard_draft(section.uuid)
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end
 
 private

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,7 +1,7 @@
 require "services"
 
 class PublishingApiDraftSectionDiscarder
-  def call(section, _manual)
+  def call(section)
     Services.publishing_api.discard_draft(section.uuid)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
   end

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,8 +1,0 @@
-require "services"
-
-class PublishingApiDraftSectionDiscarder
-  def call(section)
-    Services.publishing_api.discard_draft(section.uuid)
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity # rubocop:disable Lint/HandleExceptions
-  end
-end

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -62,7 +62,7 @@ private
   end
 
   def discard_section_via_publishing_api
-    PublishingApiDraftSectionDiscarder.new.call(section)
+    Adapters.publishing.discard_section(section)
   end
 
   def export_draft_manual_to_publishing_api

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -62,7 +62,7 @@ private
   end
 
   def discard_section_via_publishing_api
-    PublishingApiDraftSectionDiscarder.new.call(section, manual)
+    PublishingApiDraftSectionDiscarder.new.call(section)
   end
 
   def export_draft_manual_to_publishing_api

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -550,6 +550,14 @@ describe PublishingAdapter do
     end
   end
 
+  describe "#discard_draft_section" do
+    it "discard draft section via Publishing API" do
+      expect(publishing_api).to receive(:discard_draft).with(section_uuid)
+
+      subject.discard_section(section)
+    end
+  end
+
 private
 
   def attributes_valid_according_to_schema(schema_name)

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "discards a section" do
-        expect(discarder).to have_received(:call).with(section, manual)
+        expect(discarder).to have_received(:call).with(section)
       end
     end
 
@@ -217,7 +217,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "discards a section" do
-        expect(discarder).to have_received(:call).with(section, manual)
+        expect(discarder).to have_received(:call).with(section)
       end
     end
 

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -31,14 +31,12 @@ RSpec.describe Section::RemoveService do
       context: service_context,
     )
   }
-  let(:discarder) { spy(PublishingApiDraftSectionDiscarder) }
   let(:publishing_adapter) { spy(PublishingAdapter) }
 
   before do
     allow(Manual).to receive(:find).and_return(manual)
     allow(manual).to receive(:save)
     allow(Adapters).to receive(:publishing).and_return(publishing_adapter)
-    allow(PublishingApiDraftSectionDiscarder).to receive(:new).and_return(discarder)
   end
 
   context "with a section id that doesn't belong to the manual" do
@@ -79,7 +77,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "does not discard a section" do
-        expect(discarder).not_to have_received(:call)
+        expect(publishing_adapter).not_to have_received(:discard_section)
       end
 
       def ignoring(exception_class)
@@ -130,7 +128,7 @@ RSpec.describe Section::RemoveService do
     end
 
     it "does not discard a section" do
-      expect(discarder).not_to have_received(:call)
+      expect(publishing_adapter).not_to have_received(:discard_section)
     end
   end
 
@@ -177,7 +175,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "discards a section" do
-        expect(discarder).to have_received(:call).with(section)
+        expect(publishing_adapter).to have_received(:discard_section).with(section)
       end
     end
 
@@ -217,7 +215,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "discards a section" do
-        expect(discarder).to have_received(:call).with(section)
+        expect(publishing_adapter).to have_received(:discard_section).with(section)
       end
     end
 


### PR DESCRIPTION
This continues the work to [extract API adapters from exporters][1].

[1]: https://github.com/alphagov/manuals-publisher/issues/996