### PR TITLE
Add missing require statements for the Services module

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -1,3 +1,4 @@
+require "services"
 require "adapters"
 require "securerandom"
 require "gds_api_constants"

--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -1,3 +1,4 @@
+require "services"
 require "gds_api_constants"
 
 class ManualPublishingAPIExporter

--- a/app/exporters/publishing_api_draft_section_discarder.rb
+++ b/app/exporters/publishing_api_draft_section_discarder.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class PublishingApiDraftSectionDiscarder
   def call(section, _manual)
     Services.publishing_api.discard_draft(section.uuid)

--- a/app/exporters/publishing_api_manual_with_sections_publisher.rb
+++ b/app/exporters/publishing_api_manual_with_sections_publisher.rb
@@ -1,3 +1,4 @@
+require "services"
 require "gds_api_constants"
 
 class PublishingApiManualWithSectionsPublisher

--- a/app/exporters/publishing_api_publisher.rb
+++ b/app/exporters/publishing_api_publisher.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class PublishingAPIPublisher
   include PublishingAPIUpdateTypes
 

--- a/app/exporters/publishing_api_withdrawer.rb
+++ b/app/exporters/publishing_api_withdrawer.rb
@@ -1,3 +1,5 @@
+require "services"
+
 class PublishingAPIWithdrawer
   def initialize(entity:)
     @entity = entity

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -1,3 +1,4 @@
+require "services"
 require "gds_api_constants"
 
 class SectionPublishingAPIExporter

--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -1,4 +1,5 @@
 require "singleton"
+require "services"
 
 module RummagerHelpers
   class FakeRummager

--- a/spec/adapters/organisations_adapter_spec.rb
+++ b/spec/adapters/organisations_adapter_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "services"
 
 describe OrganisationsAdapter do
   let(:api) { double(:organisations_api) }

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "services"
 require "gds_api_constants"
 
 describe PublishingAdapter do

--- a/spec/adapters/search_index_adapter_spec.rb
+++ b/spec/adapters/search_index_adapter_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "services"
 require "gds_api_constants"
 
 describe SearchIndexAdapter do

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -3,6 +3,7 @@ require "support/all_of_matcher"
 require "support/govuk_content_schema_helpers"
 
 require "manual_publishing_api_exporter"
+require "services"
 require "gds_api_constants"
 
 describe ManualPublishingAPIExporter do

--- a/spec/exporters/publishing_api_publisher_spec.rb
+++ b/spec/exporters/publishing_api_publisher_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 require "publishing_api_publisher"
+require "services"
 require "gds_api_constants"
 
 describe PublishingAPIPublisher do

--- a/spec/exporters/publishing_api_withdrawer_spec.rb
+++ b/spec/exporters/publishing_api_withdrawer_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "services"
 
 describe PublishingAPIWithdrawer do
   it 'unpublishes the entity' do

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -3,6 +3,7 @@ require "support/all_of_matcher"
 require "support/govuk_content_schema_helpers"
 
 require "section_publishing_api_exporter"
+require "services"
 require "gds_api_constants"
 
 describe SectionPublishingAPIExporter do

--- a/spec/lib/marked_section_deleter_spec.rb
+++ b/spec/lib/marked_section_deleter_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "marked_section_deleter"
+require "services"
 
 describe MarkedSectionDeleter do
   subject {

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require 'section_reslugger'
 require "gds_api/test_helpers/content_store"
 require "gds_api/test_helpers/rummager"
+require "services"
 require "gds_api_constants"
 
 describe SectionReslugger do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "attachment"
+require "services"
 
 describe Attachment do
   subject(:attachment) do


### PR DESCRIPTION
This module is defined in a file in the `lib` directory which is not auto-loaded. Thus to be thorough, we should require the file in any files which make use of the module.