### PR TITLE
Upgrade gds-api-adapters to v45.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'test-unit', require: false
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "~> 39.0"
+  gem "gds-api-adapters", "~> 45.0"
 end
 
 if ENV["GOVSPEAK_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     event-bus (0.1.0)
@@ -110,7 +110,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     foreman (0.84.0)
       thor (~> 0.19.1)
-    gds-api-adapters (39.2.0)
+    gds-api-adapters (45.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -356,7 +356,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (1.1.3)
     unicorn (4.8.2)
       kgio (~> 2.6)
@@ -390,7 +390,7 @@ DEPENDENCIES
   factory_girl_rails
   faraday (= 0.9.0)
   foreman
-  gds-api-adapters (~> 39.0)
+  gds-api-adapters (~> 45.0)
   gds-sso (~> 11.0)
   generic_form_builder (= 0.11.0)
   govspeak (~> 3.1)


### PR DESCRIPTION
I've read through the [`CHANGELOG`][1] between v39.2.0 and v45.0.0 and I couldn't see anything that looked worrying. What's more all the tests pass after this upgrade.

Note that I've intentionally avoided upgrading `rest-client` to its latest version (v2.0.2), because it introduced warnings when I ran the tests and the new version of `gds-api-adapters` does not require it to be upgraded from v2.0.0.

Note that these warnings are mentioned in #1038 and are present if you run the tests in the `gds-api-adapters` project with the latest version of `rest-client`, so I don't think the warnings are specific to `manuals-publisher`.

Closes #1038.

[1]: https://github.com/alphagov/gds-api-adapters/blob/v45.0.0/CHANGELOG.md