### PR TITLE
Avoid unnecessary calls to Time#iso8601

### DIFF
--- a/app/exporters/manual_publishing_api_exporter.rb
+++ b/app/exporters/manual_publishing_api_exporter.rb
@@ -62,8 +62,8 @@ private
   def optional_exportable_attributes
     attrs = {}
     if manual.originally_published_at.present?
-      attrs[:first_published_at] = manual.originally_published_at.iso8601
-      attrs[:public_updated_at] = manual.originally_published_at.iso8601 if manual.use_originally_published_at_for_public_timestamp?
+      attrs[:first_published_at] = manual.originally_published_at
+      attrs[:public_updated_at] = manual.originally_published_at if manual.use_originally_published_at_for_public_timestamp?
     end
     attrs
   end
@@ -125,7 +125,7 @@ private
         base_path: "/#{publication.slug}",
         title: publication.title,
         change_note: publication.change_note,
-        published_at: publication.published_at.iso8601,
+        published_at: publication.published_at,
       }
     }
   end

--- a/app/exporters/section_publishing_api_exporter.rb
+++ b/app/exporters/section_publishing_api_exporter.rb
@@ -52,8 +52,8 @@ private
   def optional_exportable_attributes
     attrs = {}
     if manual.originally_published_at.present?
-      attrs[:first_published_at] = manual.originally_published_at.iso8601
-      attrs[:public_updated_at] = manual.originally_published_at.iso8601 if manual.use_originally_published_at_for_public_timestamp?
+      attrs[:first_published_at] = manual.originally_published_at
+      attrs[:public_updated_at] = manual.originally_published_at if manual.use_originally_published_at_for_public_timestamp?
     end
     attrs
   end

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -292,8 +292,8 @@ describe PublishingAdapter do
         expect(publishing_api).to receive(:put_content).with(
           manual_id,
           including(
-            first_published_at: timestamp.iso8601,
-            public_updated_at: timestamp.iso8601
+            first_published_at: timestamp,
+            public_updated_at: timestamp
           ),
         )
 
@@ -304,8 +304,8 @@ describe PublishingAdapter do
         expect(publishing_api).to receive(:put_content).with(
           section_uuid,
           including(
-            first_published_at: timestamp.iso8601,
-            public_updated_at: timestamp.iso8601
+            first_published_at: timestamp,
+            public_updated_at: timestamp
           ),
         )
 
@@ -321,7 +321,7 @@ describe PublishingAdapter do
           expect(publishing_api).to receive(:put_content).with(
             manual_id,
             excluding(
-              public_updated_at: timestamp.iso8601
+              public_updated_at: timestamp
             ),
           )
 
@@ -332,7 +332,7 @@ describe PublishingAdapter do
           expect(publishing_api).to receive(:put_content).with(
             section_uuid,
             excluding(
-              public_updated_at: timestamp.iso8601
+              public_updated_at: timestamp
             ),
           )
 
@@ -464,7 +464,7 @@ describe PublishingAdapter do
               title: "section-title",
               base_path: "/manual-slug/section-slug",
               change_note: "section-change-note",
-              published_at: timestamp.iso8601
+              published_at: timestamp
             }]
           ))
         )

--- a/spec/exporters/manual_publishing_api_exporter_spec.rb
+++ b/spec/exporters/manual_publishing_api_exporter_spec.rb
@@ -146,7 +146,7 @@ describe ManualPublishingAPIExporter do
       expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(
-          first_published_at: previously_published_date.iso8601,
+          first_published_at: previously_published_date,
         )
       )
     end
@@ -158,7 +158,7 @@ describe ManualPublishingAPIExporter do
       expect(publishing_api).to have_received(:put_content).with(
         "52ab9439-95c8-4d39-9b83-0a2050a0978b",
         hash_including(
-          public_updated_at: previously_published_date.iso8601,
+          public_updated_at: previously_published_date,
         )
       )
     end
@@ -206,13 +206,13 @@ describe ManualPublishingAPIExporter do
               base_path: "/guidance/my-first-manual/first-section",
               title: "Document title",
               change_note: "Added more text",
-              published_at: Time.new(2013, 12, 31, 12, 0, 0).iso8601,
+              published_at: Time.new(2013, 12, 31, 12, 0, 0),
             },
             {
               base_path: "/guidance/my-first-manual",
               title: "My manual",
               change_note: "Changed manual title",
-              published_at: Time.new(2013, 12, 31, 12, 30, 0).iso8601,
+              published_at: Time.new(2013, 12, 31, 12, 30, 0),
             },
           ],
           organisations: [

--- a/spec/exporters/section_publishing_api_exporter_spec.rb
+++ b/spec/exporters/section_publishing_api_exporter_spec.rb
@@ -121,7 +121,7 @@ describe SectionPublishingAPIExporter do
       expect(publishing_api).to have_received(:put_content).with(
         section.uuid,
         hash_including(
-          first_published_at: previously_published_date.iso8601,
+          first_published_at: previously_published_date,
         )
       )
     end
@@ -133,7 +133,7 @@ describe SectionPublishingAPIExporter do
       expect(publishing_api).to have_received(:put_content).with(
         section.uuid,
         hash_including(
-          public_updated_at: previously_published_date.iso8601,
+          public_updated_at: previously_published_date,
         )
       )
     end


### PR DESCRIPTION
There's no need to convert instances of `Time` into an ISO8601 string when we're sending a Hash to `GdsApi::PublishingApiV2`, because `gds-api-adapters` [does this in `GdsApi::JsonClient#do_json_request`][1] when `Object#to_json` gets called on the `params` Hash passed in.

```
> time = Time.now
=> 2017-05-15 18:48:14 +0100
> JSON.parse({test: time}.to_json)['test'] == time.iso8601
=> true
```

Note that `JSON.parse` does not reverse this conversion, so I've left the relevant test assertions in `ManualHelpers` unchanged. I've also left `DateTimeHelper#nice_time_format`, because that is unrelated to exporting to the Publishing API.

[1]: https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/json_client.rb#L137
