### PR TITLE
Fix section publishing when relocating a manual

### DIFF
--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -195,11 +195,8 @@ private
   end
 
   def send_draft(manual)
-    puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number})"
-    manual.sections.each do |section|
-      puts "Sending a draft of manual section #{section.uuid} (version: #{section.version_number})"
-    end
-    Adapters.publishing.save(manual, include_links: false)
+    puts "Sending a draft of manual #{manual.id} (version: #{manual.version_number}) and its sections"
+    Adapters.publishing.save(manual, include_links: false, republish: true)
   end
 
   def send_gone(section_uuid, slug)

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -160,8 +160,8 @@ private
 
     # Clean up manual sections belonging to the temporary manual path
     new_section_uuids.each do |section_uuid|
-      puts "Redirecting #{section_uuid} to '/#{to_slug}'"
       most_recent_edition = most_recent_edition_of_section(section_uuid)
+      puts "Redirecting #{section_uuid} to '#{most_recent_edition.slug}'"
       publishing_api.unpublish(section_uuid,
                                type: "redirect",
                                alternative_path: "/#{most_recent_edition.slug}",

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -46,13 +46,13 @@ describe ManualRelocator do
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }
-    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published") }
-    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published") }
-    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published") }
-    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published") }
+    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published", exported_at: DateTime.now) }
 
-    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published") }
-    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published") }
+    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published", exported_at: DateTime.now) }
 
     let!(:existing_publication_log) { FactoryGirl.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
     let!(:temporary_publication_log) { FactoryGirl.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }


### PR DESCRIPTION
When moving a manual from one URL to another, ensure that its sections are properly created as drafts with the correct slug and then published.

Previously, the section publishing step was failing because the section drafts had not been created. This was because the `PublishingAdapter` only creates drafts for sections if the `republish` flag is added or if the section has never been exported. This has been fixed by adding the `republish` flag.

The tests did not catch the problem because the sections in the test data had no export date, so they *were* being created as drafts and republished. This has been fixed by adding export dates to the sections in the test.

(Side-note: I've made this change so I can move a manual that's been renamed to fix a 2ndline ZenDesk ticket. I'm not completely certain about whether adding `republish: true` flag is the correct thing to do, so feedback on that would be good.)