### PR TITLE
Fix mongoid.yml for Mongoid 4

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -110,7 +110,7 @@ production:
       options:
         logger: false
         read: :primary
+        refresh_interval: 120
   options:
     use_activesupport_time_zone: true
-    refresh_interval: 120
     refresh_mode: :sync

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -113,4 +113,3 @@ production:
         refresh_interval: 120
   options:
     use_activesupport_time_zone: true
-    refresh_mode: :sync

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -108,7 +108,6 @@ production:
     default:
       uri: <%= ENV['MONGODB_URI'] %>
       options:
-        logger: false
         read: :primary
         refresh_interval: 120
   options:


### PR DESCRIPTION
The automatic deploy to integration failed after merging PR #1102 (upgrade to Rails 4/Mongoid 4). This was caused by some invalid options in the production config of mongoid.yml.

I've deployed this branch to integration and can confirm that it both deploys successfully and that the app works as expected.