### PR TITLE
Fix JS toggle for hiding/showing the change note field

### DIFF
--- a/app/views/sections/_form.html.erb
+++ b/app/views/sections/_form.html.erb
@@ -85,13 +85,13 @@
   });
 
   window.toggleDisplayWithCheckedInput({
-    $input: $("#document_minor_update_1"),
-    $element: $("#document_change_note").parent(),
+    $input: $("#section_minor_update_1"),
+    $element: $("#section_change_note").parent(),
     mode: 'hide'
   });
   window.toggleDisplayWithCheckedInput({
-    $input: $("#document_minor_update_0"),
-    $element: $("#document_change_note").parent(),
+    $input: $("#section_minor_update_0"),
+    $element: $("#section_change_note").parent(),
     mode: 'show'
   });
   $('.js-hidden').hide();

--- a/app/views/sections/withdraw.html.erb
+++ b/app/views/sections/withdraw.html.erb
@@ -39,13 +39,13 @@
 
 <%= content_for :document_ready do %>
   window.toggleDisplayWithCheckedInput({
-    $input: $("#document_minor_update_1"),
-    $element: $("#document_change_note").parent(),
+    $input: $("#section_minor_update_1"),
+    $element: $("#section_change_note").parent(),
     mode: 'hide'
   });
   window.toggleDisplayWithCheckedInput({
-    $input: $("#document_minor_update_0"),
-    $element: $("#document_change_note").parent(),
+    $input: $("#section_minor_update_0"),
+    $element: $("#section_change_note").parent(),
     mode: 'show'
   });
   $('.js-hidden').hide();

--- a/spec/views/sections/_form.html.erb_spec.rb
+++ b/spec/views/sections/_form.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'sections/_form.html.erb', type: :view do
+  it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
+    manual = Manual.new(id: 'manual-id')
+    section = Section.new(manual: manual, uuid: 'section-uuid', editions: [])
+
+    allow(manual).to receive(:has_ever_been_published?).and_return(true)
+    allow(section).to receive(:has_ever_been_published?).and_return(true)
+
+    allow(view).to receive(:manual).and_return(ManualViewAdapter.new(manual))
+    allow(view).to receive(:section).and_return(SectionViewAdapter.new(manual, section))
+
+    render
+
+    expect(rendered).to have_css('#section_minor_update_0')
+    expect(rendered).to have_css('#section_minor_update_1')
+    expect(rendered).to have_css('#section_change_note')
+  end
+end

--- a/spec/views/sections/withdraw.html.erb_spec.rb
+++ b/spec/views/sections/withdraw.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'sections/withdraw.html.erb', type: :view do
+  it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
+    manual = Manual.new(id: 'manual-id')
+    section = Section.new(manual: manual, uuid: 'section-uuid', editions: [])
+
+    allow(view).to receive(:manual).and_return(ManualViewAdapter.new(manual))
+    allow(view).to receive(:section).and_return(SectionViewAdapter.new(manual, section))
+
+    render
+
+    expect(rendered).to have_css('#section_minor_update_0')
+    expect(rendered).to have_css('#section_minor_update_1')
+    expect(rendered).to have_css('#section_change_note')
+  end
+end


### PR DESCRIPTION
I presume this was broken when we renamed document to section.

I've updated the selectors and checked that the toggling works as
expected in the browser. I've added a couple of view specs in the hope
that they'll help us catch these sort of problems earlier in future.