### PR TITLE
Use PublishingAdapter in CliManualDeleter instead of using Publishing API directly

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -34,6 +34,13 @@ class PublishingAdapter
     end
   end
 
+  def discard(manual)
+    manual.sections.each do |section|
+      discard_section(section)
+    end
+    Services.publishing_api.discard_draft(manual.id)
+  end
+
   def save_section(section, manual, republish: false, include_links: true)
     if section.needs_exporting? || republish
       save_section_links(section, manual) if include_links

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -340,5 +340,10 @@ class Manual
     PublicationLog.change_notes_for(slug)
   end
 
+  def destroy
+    manual_record = ManualRecord.find_by(manual_id: id)
+    manual_record.destroy
+  end
+
   class RemovedSectionIdNotFoundError < StandardError; end
 end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -341,6 +341,10 @@ class Manual
   end
 
   def destroy
+    sections.each do |section|
+      section.editions.each(&:destroy)
+    end
+
     manual_record = ManualRecord.find_by(manual_id: id)
     manual_record.destroy
   end

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -82,10 +82,6 @@ private
     manual.sections.each { |section| discard_draft_from_publishing_api(section.uuid) }
     discard_draft_from_publishing_api(manual.id)
 
-    manual.sections.each do |section|
-      section.editions.each(&:destroy)
-    end
-
     manual.destroy
 
     log "Manual destroyed."

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -16,8 +16,9 @@ class CliManualDeleter
 
   def call
     manual_record = find_manual_record
+    manual = Manual.build_manual_for(manual_record)
 
-    user_must_confirm(manual_record)
+    user_must_confirm(manual)
 
     complete_removal(manual_record)
   end
@@ -63,12 +64,12 @@ private
     end
   end
 
-  def user_must_confirm(manual_record)
-    number_of_sections = section_uuids_for(manual_record).count
+  def user_must_confirm(manual)
+    number_of_sections = manual.sections.count
     log "### PLEASE CONFIRM -------------------------------------"
-    log "Manual to be deleted: #{manual_record.slug}"
-    log "Organisation: #{manual_record.organisation_slug}"
-    log "This manual has #{number_of_sections} sections, and was last edited at #{manual_record.updated_at}"
+    log "Manual to be deleted: #{manual.slug}"
+    log "Organisation: #{manual.organisation_slug}"
+    log "This manual has #{number_of_sections} sections, and was last edited at #{manual.updated_at}"
     log "Type 'y' to proceed and delete this manual or anything else to exit:"
 
     response = stdin.gets

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -666,6 +666,26 @@ describe PublishingAdapter do
     end
   end
 
+  describe "#discard" do
+    before do
+      manual.sections = [section]
+
+      allow(publishing_api).to receive(:discard_draft).with(anything)
+    end
+
+    it "discards draft manual via Publishing API" do
+      expect(publishing_api).to receive(:discard_draft).with(manual_id)
+
+      subject.discard(manual)
+    end
+
+    it "discards all manual's draft sections via Publishing API" do
+      expect(publishing_api).to receive(:discard_draft).with(section_uuid)
+
+      subject.discard(manual)
+    end
+  end
+
   describe "#redirect_section" do
     let(:redirect_content_id) { "179cd671-766b-47af-ae4a-5054e9b99b89" }
 
@@ -703,7 +723,7 @@ describe PublishingAdapter do
   end
 
   describe "#discard_draft_section" do
-    it "discard draft section via Publishing API" do
+    it "discards draft section via Publishing API" do
       expect(publishing_api).to receive(:discard_draft).with(section_uuid)
 
       subject.discard_section(section)

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -972,4 +972,14 @@ describe Manual do
       expect(manual.publication_logs).to eq([publication_log])
     end
   end
+
+  describe "#destroy" do
+    let!(:manual_record) { FactoryGirl.create(:manual_record, manual_id: manual.id) }
+
+    it "destroys underlying manual record" do
+      manual.destroy
+
+      expect(ManualRecord.find_by(id: manual_record.id)).not_to be_present
+    end
+  end
 end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -981,5 +981,39 @@ describe Manual do
 
       expect(ManualRecord.find_by(id: manual_record.id)).not_to be_present
     end
+
+    context "when manual has some sections with editions" do
+      let(:section_1_edition_1) { FactoryGirl.create(:section_edition, section_uuid: "section-1") }
+      let(:section_1_edition_2) { FactoryGirl.create(:section_edition, section_uuid: "section-1") }
+      let(:section_2_edition_1) { FactoryGirl.create(:section_edition, section_uuid: "section-2") }
+      let(:section_2_edition_2) { FactoryGirl.create(:section_edition, section_uuid: "section-2") }
+
+      let(:section_1) do
+        Section.new(manual: manual, uuid: "section-1", editions: [
+          section_1_edition_1,
+          section_1_edition_2
+        ])
+      end
+
+      let(:section_2) do
+        Section.new(manual: manual, uuid: "section-2", editions: [
+          section_2_edition_1,
+          section_2_edition_2
+        ])
+      end
+
+      before do
+        manual.sections = [section_1, section_2]
+      end
+
+      it "destroys all associated section editions" do
+        manual.destroy
+
+        expect(SectionEdition.where(id: section_1_edition_1.id)).to be_empty
+        expect(SectionEdition.where(id: section_1_edition_2.id)).to be_empty
+        expect(SectionEdition.where(id: section_2_edition_1.id)).to be_empty
+        expect(SectionEdition.where(id: section_2_edition_2.id)).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
This is closely related to the work in #996.

This means the code can operate at a higher level of abstraction, passing instances of `Manual` rather than just some magic IDs. In doing this, I've extracted `PublishingAdapter#discard` which calls the already existing `PublishingAdapter#discard_section`.

In doing this I've also improved the overall level of abstraction used in this class, by using instances of `Manual` as much as possible rather than instances of `ManualRecord`. In doing so, I've extracted `Manual#destroy` which destroys the underlying `ManualRecord` and all associated `SectionEditions`.
