### PR TITLE
Remove unused extra_fields field from SectionEdition

### DIFF
--- a/db/migrate/20170518100414_remove_extra_fields_field_from_section_editions.rb
+++ b/db/migrate/20170518100414_remove_extra_fields_field_from_section_editions.rb
@@ -1,0 +1,9 @@
+class RemoveExtraFieldsFieldFromSectionEditions < Mongoid::Migration
+  def self.up
+    SectionEdition.update_all('$unset' => { 'extra_fields' => true })
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Although this field was removed from the `SectionEdition` model class in [this commit][1], many/all of the documents in the `manual_section_editions` collection in MongoDB still had this field set to an empty Hash.

The presence of this field seems to have started causing `Mongoid::Errors::UnknownAttribute` exceptions in production recently ([exception 1][2], [exception 2][3]) when a `SectionEdition` is updated. My suspicion is that this is related to the recent upgrade to Mongoid v4, however, I haven't yet investigated that, because I wanted to get a fix into production as soon as possible.

I have reproduced both the production exceptions locally using a recent copy of production data. When I run the migration in this commit, the exceptions no longer occur. Thus I'm confident that this is a sensible fix.

I'm pretty sure the `extra_fields` value was [being copied from the previous edition](https://github.com/alphagov/manuals-publisher/blob/bc758a8f15443ba0d03b596be32afe5d9fd918a4/app/models/section.rb#L225.) when a new draft of a section is created.

[1]: https://github.com/alphagov/manuals-publisher/commit/5f18aba14c9cbe60a82ecd8e0bcdb015de90a3fa
[2]: https://errbit.publishing.service.gov.uk/apps/57e3ddba6578636ac8300000/problems/591c67566578636e62d53500
[3]: https://errbit.publishing.service.gov.uk/apps/57e3ddba6578636ac8300000/problems/591d4b1c6578636e62fcbf00