### PR TITLE
Remove unused change_history field from SectionEdition

### DIFF
--- a/db/migrate/20170518111550_remove_change_history_field_from_section_editions.rb
+++ b/db/migrate/20170518111550_remove_change_history_field_from_section_editions.rb
@@ -1,0 +1,9 @@
+class RemoveChangeHistoryFieldFromSectionEditions < Mongoid::Migration
+  def self.up
+    SectionEdition.update_all('$unset' => { 'change_history' => true })
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Although this field was moved from the `manual_section_editions` collection in MongoDB to `publication_logs` in [this commit][1], some documents still have this field set and now that we've upgraded to Mongoid v4 it seems to be causing [`Mongoid::Errors::UnknownAttribute` exceptions][2] in staging even after the change in #1111 was deployed.

I have reproduced both the production exceptions locally using a recent copy of production data. When I run the migration in this commit, the exceptions no longer occur. Thus I'm confident that this is a sensible fix.

[1]: https://github.com/alphagov/manuals-publisher/commit/d8be88048609f4dedec04937c442da0f73e7ced7
[2]: https://errbit.staging.publishing.service.gov.uk/apps/57e3cb566578634fb7950600/problems/591d6fb3657863544fadbe06