### PR TITLE
Exclude arbitrary attrs when copying SectionEditions

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -244,8 +244,7 @@ protected
 
   def previous_edition_attributes
     latest_edition.attributes
-      .slice(:_id, :section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update, :public_updated_at, :exported_at, :created_at, :updated_at)
-      .except(*no_copy_attributes)
+      .slice(:section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update, :public_updated_at)
       .symbolize_keys
   end
 
@@ -260,15 +259,6 @@ protected
       :updated_at,
       :slug,
       :version_number,
-    ]
-  end
-
-  def no_copy_attributes
-    %w[
-      _id
-      created_at
-      updated_at
-      exported_at
     ]
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -244,6 +244,7 @@ protected
 
   def previous_edition_attributes
     latest_edition.attributes
+      .slice(:_id, :section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update, :public_updated_at, :exported_at, :created_at, :updated_at)
       .except(*no_copy_attributes)
       .symbolize_keys
   end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -360,7 +360,8 @@ describe Section do
           "_id" => "superfluous id",
           "updated_at" => "superfluous timestamp",
           "body" => edition_body,
-        }
+          "arbitrary_attribute" => "arbitrary-attribute"
+        }.with_indifferent_access
       }
 
       before do
@@ -380,6 +381,13 @@ describe Section do
 
         expect(SectionEdition).to have_received(:new)
           .with(hash_including(body: edition_body))
+      end
+
+      it "excludes attributes not defined as fields on the section edition" do
+        section.update(params)
+
+        expect(SectionEdition).to_not have_received(:new)
+          .with(hash_including(arbitrary_attribute: anything))
       end
 
       it "filters the previous edition's attributes" do


### PR DESCRIPTION
This should hopefully avoid the following errors when creating new
drafts of SectionEditions that contain old data:

> Mongoid::Errors::UnknownAttribute: Problem: Attempted to set a value
> for '<old-field-name>' which is not allowed on the model SectionEdition.
> Summary: Without including Mongoid::Attributes::Dynamic in your model
> and the attribute does not already exist in the attributes hash,
> attempting to call SectionEdition#old-field-name= for it is not
> allowed. This is also triggered by passing the attribute to any method
> that accepts an attributes hash, and is raised instead of getting a
> NoMethodError. Resolution: You can include
> Mongoid::Attributes::Dynamic if you expect to be writing values for
> undefined fields often.

We've been seeing this error since the upgrade to Mongoid 4 where the default
behaviour of allowing dynamic fields has changed. In Mongoid 3 the
behaviour was controlled by `Mongoid.allow_dynamic_fields` which was set
to true by default. In Mongoid 4 it's controlled at the model level by
including the `Mongoid::Attributes::Dynamic` module.

I think the test I've added could be better but I think it's good enough
for now. I have a separate branch where I'm refactoring Section and I
hope to improve the tests in there.

Note the call to `#with_indifferent_access` in the setup for the test.
This better mirrors the behaviour of `SectionEdition#attributes`.