### PR TITLE
Parameterize services

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -129,7 +129,7 @@ class ManualsController < ApplicationController
     service = Manual::PreviewService.new(
       manual_id: params[:id],
       attributes: update_manual_params,
-      context: self,
+      user: current_user,
     )
     manual = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -98,7 +98,7 @@ class ManualsController < ApplicationController
     service = Manual::UpdateOriginalPublicationDateService.new(
       manual_id: manual_id,
       attributes: publication_date_manual_params,
-      context: self,
+      user: current_user,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -115,7 +115,7 @@ class ManualsController < ApplicationController
   def publish
     service = Manual::QueuePublishService.new(
       manual_id: manual_id,
-      context: self,
+      user: current_user,
     )
     manual = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -5,7 +5,7 @@ class ManualsController < ApplicationController
 
   def index
     service = Manual::ListService.new(
-      context: self,
+      user: current_user,
     )
     all_manuals = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -70,7 +70,7 @@ class ManualsController < ApplicationController
     service = Manual::UpdateService.new(
       manual_id: manual_id,
       attributes: update_manual_params,
-      context: self,
+      user: current_user,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -15,7 +15,7 @@ class ManualsController < ApplicationController
   def show
     service = Manual::ShowService.new(
       manual_id: manual_id,
-      context: self,
+      user: current_user,
     )
     manual = service.call
     slug_unique = manual.slug_unique?(current_user)
@@ -59,7 +59,7 @@ class ManualsController < ApplicationController
   def edit
     service = Manual::ShowService.new(
       manual_id: manual_id,
-      context: self,
+      user: current_user,
     )
     manual = service.call
 
@@ -87,7 +87,7 @@ class ManualsController < ApplicationController
   def edit_original_publication_date
     service = Manual::ShowService.new(
       manual_id: manual_id,
-      context: self,
+      user: current_user,
     )
     manual = service.call
 

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -42,7 +42,7 @@ class ManualsController < ApplicationController
   def create
     service = Manual::CreateService.new(
       attributes: create_manual_params,
-      context: self,
+      user: current_user,
     )
     manual = service.call
     manual = manual_form(manual)

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -14,9 +14,11 @@ class SectionAttachmentsController < ApplicationController
 
   def create
     service = Attachment::CreateService.new(
-      context: self,
       file: attachment_params.fetch(:file),
-      title: attachment_params.fetch(:title)
+      title: attachment_params.fetch(:title),
+      section_uuid: params.fetch(:section_id),
+      user: current_user,
+      manual_id: params.fetch(:manual_id)
     )
     manual, section, _attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -29,7 +29,10 @@ class SectionAttachmentsController < ApplicationController
 
   def edit
     service = Attachment::ShowService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:section_id),
+      manual_id: params.fetch(:manual_id),
+      attachment_id: params.fetch(:id)
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -15,6 +15,7 @@ class SectionAttachmentsController < ApplicationController
   def create
     service = Attachment::CreateService.new(
       context: self,
+      attachment_params: attachment_params
     )
     manual, section, _attachment = service.call
 
@@ -49,5 +50,11 @@ class SectionAttachmentsController < ApplicationController
         attachment: attachment,
       })
     end
+  end
+
+private
+
+  def attachment_params
+    params.require("attachment").permit(:title, :file)
   end
 end

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -45,9 +45,12 @@ class SectionAttachmentsController < ApplicationController
 
   def update
     service = Attachment::UpdateService.new(
-      context: self,
       file: attachment_params.fetch(:file),
-      title: attachment_params.fetch(:title)
+      title: attachment_params.fetch(:title),
+      user: current_user,
+      attachment_id: params.fetch(:id),
+      manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:section_id)
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -15,7 +15,8 @@ class SectionAttachmentsController < ApplicationController
   def create
     service = Attachment::CreateService.new(
       context: self,
-      attachment_params: attachment_params
+      file: attachment_params.fetch(:file),
+      title: attachment_params.fetch(:title)
     )
     manual, section, _attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -46,7 +46,8 @@ class SectionAttachmentsController < ApplicationController
   def update
     service = Attachment::UpdateService.new(
       context: self,
-      attachment_params: attachment_params
+      file: attachment_params.fetch(:file),
+      title: attachment_params.fetch(:title)
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -46,6 +46,7 @@ class SectionAttachmentsController < ApplicationController
   def update
     service = Attachment::UpdateService.new(
       context: self,
+      attachment_params: attachment_params
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -1,7 +1,9 @@
 class SectionAttachmentsController < ApplicationController
   def new
     service = Attachment::NewService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:section_id),
+      manual_id: params.fetch(:manual_id)
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -27,7 +27,9 @@ class SectionsController < ApplicationController
 
   def create
     service = Section::CreateService.new(
-      context: self,
+      user: current_user,
+      manual_id: params.fetch(:manual_id),
+      section_params: params.fetch(:section)
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -74,7 +74,10 @@ class SectionsController < ApplicationController
 
   def preview
     service = Section::PreviewService.new(
-      context: self,
+      user: current_user,
+      section_params: params.fetch(:section),
+      section_uuid: params.fetch(:id, nil),
+      manual_id: params.fetch(:manual_id, nil)
     )
     section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -113,7 +113,9 @@ class SectionsController < ApplicationController
 
   def update_order
     service = Section::ReorderService.new(
-      context: self,
+      user: current_user,
+      manual_id: params.fetch(:manual_id),
+      section_order: params.fetch(:section_order)
     )
     manual, _sections = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -96,7 +96,8 @@ class SectionsController < ApplicationController
 
   def reorder
     service = Section::ListService.new(
-      context: self,
+      user: current_user,
+      manual_id: params.fetch(:manual_id)
     )
     manual, sections = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -15,7 +15,8 @@ class SectionsController < ApplicationController
 
   def new
     service = Section::NewService.new(
-      context: self,
+      user: current_user,
+      manual_id: params.fetch(:manual_id)
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -62,7 +62,10 @@ class SectionsController < ApplicationController
 
   def update
     service = Section::UpdateService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:id),
+      manual_id: params.fetch(:manual_id),
+      section_params: params.fetch(:section)
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -139,7 +139,10 @@ class SectionsController < ApplicationController
 
   def destroy
     service = Section::RemoveService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:id),
+      manual_id: params.fetch(:manual_id),
+      section_params: params.fetch(:section)
     )
     manual, section = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -3,7 +3,9 @@ class SectionsController < ApplicationController
 
   def show
     service = Section::ShowService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:id),
+      manual_id: params.fetch(:manual_id)
     )
     manual, section = service.call
 
@@ -46,7 +48,9 @@ class SectionsController < ApplicationController
 
   def edit
     service = Section::ShowService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:id),
+      manual_id: params.fetch(:manual_id)
     )
     manual, section = service.call
 
@@ -129,7 +133,9 @@ class SectionsController < ApplicationController
 
   def withdraw
     service = Section::ShowService.new(
-      context: self,
+      user: current_user,
+      section_uuid: params.fetch(:id),
+      manual_id: params.fetch(:manual_id)
     )
     manual, section = service.call
 

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -1,10 +1,11 @@
 class Attachment::CreateService
-  def initialize(context:)
+  def initialize(context:, attachment_params:)
     @context = context
+    @attachment_params = attachment_params
   end
 
   def call
-    attachment = section.add_attachment(attachment_params)
+    attachment = section.add_attachment(@attachment_params)
 
     manual.save(context.current_user)
 
@@ -21,10 +22,6 @@ private
 
   def manual
     @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def attachment_params
-    context.params.require("attachment").permit(:title, :file)
   end
 
   def manual_id

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -1,35 +1,29 @@
 class Attachment::CreateService
-  def initialize(context:, file:, title:)
-    @context = context
+  def initialize(file:, title:, section_uuid:, user:, manual_id:)
     @file = file
     @title = title
+    @section_uuid = section_uuid
+    @user = user
+    @manual_id = manual_id
   end
 
   def call
     attachment = section.add_attachment(file: file, title: title)
 
-    manual.save(context.current_user)
+    manual.save(user)
 
     [manual, section, attachment]
   end
 
 private
 
-  attr_reader :context, :file, :title
+  attr_reader :file, :title, :section_uuid, :user, :manual_id
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
-  def section_uuid
-    context.params.fetch("section_id")
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -1,11 +1,12 @@
 class Attachment::CreateService
-  def initialize(context:, attachment_params:)
+  def initialize(context:, file:, title:)
     @context = context
-    @attachment_params = attachment_params
+    @file = file
+    @title = title
   end
 
   def call
-    attachment = section.add_attachment(file: @attachment_params.fetch(:file), title: @attachment_params.fetch(:title))
+    attachment = section.add_attachment(file: file, title: title)
 
     manual.save(context.current_user)
 
@@ -14,7 +15,7 @@ class Attachment::CreateService
 
 private
 
-  attr_reader :context
+  attr_reader :context, :file, :title
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -5,7 +5,7 @@ class Attachment::CreateService
   end
 
   def call
-    attachment = section.add_attachment(@attachment_params)
+    attachment = section.add_attachment(file: @attachment_params.fetch(:file), title: @attachment_params.fetch(:title))
 
     manual.save(context.current_user)
 

--- a/app/services/attachment/new_service.rb
+++ b/app/services/attachment/new_service.rb
@@ -1,6 +1,8 @@
 class Attachment::NewService
-  def initialize(context:)
-    @context = context
+  def initialize(manual_id:, section_uuid:, user:)
+    @manual_id = manual_id
+    @section_uuid = section_uuid
+    @user = user
   end
 
   def call
@@ -9,7 +11,7 @@ class Attachment::NewService
 
 private
 
-  attr_reader :context
+  attr_reader :manual_id, :section_uuid, :user
 
   def attachment
     Attachment.new(initial_params)
@@ -20,18 +22,10 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   end
 
   def initial_params
     {}
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
-  def section_uuid
-    context.params.fetch("section_id")
   end
 end

--- a/app/services/attachment/show_service.rb
+++ b/app/services/attachment/show_service.rb
@@ -1,6 +1,9 @@
 class Attachment::ShowService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, section_uuid:, manual_id:, attachment_id:)
+    @user = user
+    @section_uuid = section_uuid
+    @manual_id = manual_id
+    @attachment_id = attachment_id
   end
 
   def call
@@ -9,7 +12,7 @@ class Attachment::ShowService
 
 private
 
-  attr_reader :context
+  attr_reader :user, :section_uuid, :manual_id, :attachment_id
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)
@@ -20,18 +23,6 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
-  def section_uuid
-    context.params.fetch("section_id")
-  end
-
-  def attachment_id
-    context.params.fetch("id")
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -1,11 +1,12 @@
 class Attachment::UpdateService
-  def initialize(context:, attachment_params:)
+  def initialize(context:, file:, title:)
     @context = context
-    @attachment_params = attachment_params
+    @file = file
+    @title = title
   end
 
   def call
-    attachment.update_attributes(attachment_params.merge("filename" => uploaded_filename))
+    attachment.update_attributes(file: file, title: title, filename: file.original_filename)
 
     manual.save(context.current_user)
 
@@ -14,7 +15,7 @@ class Attachment::UpdateService
 
 private
 
-  attr_reader :context, :attachment_params
+  attr_reader :context, :file, :title
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)
@@ -26,10 +27,6 @@ private
 
   def manual
     @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def uploaded_filename
-    attachment_params.fetch(:file).original_filename
   end
 
   def manual_id

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -1,10 +1,11 @@
 class Attachment::UpdateService
-  def initialize(context:)
+  def initialize(context:, attachment_params:)
     @context = context
+    @attachment_params = attachment_params
   end
 
   def call
-    attachment.update_attributes(attachment_params)
+    attachment.update_attributes(attachment_params.merge("filename" => uploaded_filename))
 
     manual.save(context.current_user)
 
@@ -13,7 +14,7 @@ class Attachment::UpdateService
 
 private
 
-  attr_reader :context
+  attr_reader :context, :attachment_params
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)
@@ -27,18 +28,8 @@ private
     @manual ||= Manual.find(manual_id, context.current_user)
   end
 
-  def attachment_params
-    context.params
-      .require("attachment")
-      .permit(:title, :file)
-      .merge("filename" => uploaded_filename)
-  end
-
   def uploaded_filename
-    context.params
-      .require("attachment")
-      .fetch(:file)
-      .original_filename
+    attachment_params.fetch(:file).original_filename
   end
 
   def manual_id

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -1,21 +1,24 @@
 class Attachment::UpdateService
-  def initialize(context:, file:, title:)
-    @context = context
+  def initialize(file:, title:, user:, manual_id:, section_uuid:, attachment_id:)
+    @user = user
     @file = file
     @title = title
+    @manual_id = manual_id
+    @section_uuid = section_uuid
+    @attachment_id = attachment_id
   end
 
   def call
     attachment.update_attributes(file: file, title: title, filename: file.original_filename)
 
-    manual.save(context.current_user)
+    manual.save(user)
 
     [manual, section, attachment]
   end
 
 private
 
-  attr_reader :context, :file, :title
+  attr_reader :user, :file, :title, :manual_id, :section_uuid, :attachment_id
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)
@@ -26,18 +29,6 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
-  def section_uuid
-    context.params.fetch("section_id")
-  end
-
-  def attachment_id
-    context.params.fetch("id")
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -1,9 +1,9 @@
 require "adapters"
 
 class Manual::CreateService
-  def initialize(attributes:, context:)
+  def initialize(attributes:, user:)
     @attributes = attributes
-    @context = context
+    @user = user
   end
 
   def call
@@ -19,7 +19,7 @@ private
 
   attr_reader(
     :attributes,
-    :context,
+    :user,
   )
 
   def manual
@@ -27,11 +27,11 @@ private
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
   end
 
   def export_draft_to_publishing_api
-    reloaded_manual = Manual.find(manual.id, context.current_user)
+    reloaded_manual = Manual.find(manual.id, user)
     Adapters.publishing.save(reloaded_manual)
   end
 end

--- a/app/services/manual/list_service.rb
+++ b/app/services/manual/list_service.rb
@@ -1,13 +1,13 @@
 class Manual::ListService
-  def initialize(context:)
-    @context = context
+  def initialize(user:)
+    @user = user
   end
 
   def call
-    Manual.all(context.current_user, load_associations: false)
+    Manual.all(user, load_associations: false)
   end
 
 private
 
-  attr_reader :context
+  attr_reader :user
 end

--- a/app/services/manual/preview_service.rb
+++ b/app/services/manual/preview_service.rb
@@ -1,8 +1,8 @@
 class Manual::PreviewService
-  def initialize(manual_id:, attributes:, context:)
+  def initialize(manual_id:, attributes:, user:)
     @manual_id = manual_id
     @attributes = attributes
-    @context = context
+    @user = user
   end
 
   def call
@@ -16,7 +16,7 @@ private
   attr_reader(
     :manual_id,
     :attributes,
-    :context,
+    :user,
   )
 
   def manual
@@ -32,6 +32,6 @@ private
   end
 
   def existing_manual
-    @existing_manual ||= Manual.find(manual_id, context.current_user)
+    @existing_manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/manual/publish_service.rb
+++ b/app/services/manual/publish_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Manual::PublishService
-  def initialize(manual_id:, version_number:, context:)
+  def initialize(manual_id:, version_number:, user:)
     @manual_id = manual_id
     @version_number = version_number
-    @context = context
+    @user = user
   end
 
   def call
@@ -30,7 +30,7 @@ private
   attr_reader(
     :manual_id,
     :version_number,
-    :context,
+    :user,
   )
 
   def versions_match?
@@ -42,7 +42,7 @@ private
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
   end
 
   def log_publication
@@ -62,7 +62,7 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   end
 
   class VersionMismatchError < StandardError

--- a/app/services/manual/queue_publish_service.rb
+++ b/app/services/manual/queue_publish_service.rb
@@ -1,9 +1,9 @@
 require "manual_publish_task"
 
 class Manual::QueuePublishService
-  def initialize(manual_id:, context:)
+  def initialize(manual_id:, user:)
     @manual_id = manual_id
-    @context = context
+    @user = user
   end
 
   def call
@@ -22,7 +22,7 @@ private
 
   attr_reader(
     :manual_id,
-    :context,
+    :user,
   )
 
   def create_publish_task(manual)
@@ -33,7 +33,7 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   end
 
   def govuk_header_params

--- a/app/services/manual/republish_service.rb
+++ b/app/services/manual/republish_service.rb
@@ -1,9 +1,9 @@
 require "adapters"
 
 class Manual::RepublishService
-  def initialize(manual_id:, context:)
+  def initialize(manual_id:, user:)
     @manual_id = manual_id
-    @context = context
+    @user = user
   end
 
   def call
@@ -22,7 +22,7 @@ class Manual::RepublishService
 
 private
 
-  attr_reader :manual_id, :context
+  attr_reader :manual_id, :user
 
   def published_manual_version
     manual_versions[:published]
@@ -49,6 +49,6 @@ private
   end
 
   def manual_versions
-    @manual_versions ||= Manual.find(manual_id, context.current_user).current_versions
+    @manual_versions ||= Manual.find(manual_id, user).current_versions
   end
 end

--- a/app/services/manual/show_service.rb
+++ b/app/services/manual/show_service.rb
@@ -1,7 +1,7 @@
 class Manual::ShowService
-  def initialize(manual_id:, context:)
+  def initialize(manual_id:, user:)
     @manual_id = manual_id
-    @context = context
+    @user = user
   end
 
   def call
@@ -12,10 +12,10 @@ private
 
   attr_reader(
     :manual_id,
-    :context,
+    :user,
   )
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/manual/update_original_publication_date_service.rb
+++ b/app/services/manual/update_original_publication_date_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Manual::UpdateOriginalPublicationDateService
-  def initialize(manual_id:, attributes:, context:)
+  def initialize(manual_id:, attributes:, user:)
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
-    @context = context
+    @user = user
   end
 
   def call
@@ -23,7 +23,7 @@ private
   attr_reader(
     :manual_id,
     :attributes,
-    :context,
+    :user,
   )
 
   def update
@@ -31,7 +31,7 @@ private
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
     @manual = fetch_manual
   end
 
@@ -51,6 +51,6 @@ private
   end
 
   def fetch_manual
-    Manual.find(manual_id, context.current_user)
+    Manual.find(manual_id, user)
   end
 end

--- a/app/services/manual/update_service.rb
+++ b/app/services/manual/update_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Manual::UpdateService
-  def initialize(manual_id:, attributes:, context:)
+  def initialize(manual_id:, attributes:, user:)
     @manual_id = manual_id
     @attributes = attributes
-    @context = context
+    @user = user
   end
 
   def call
@@ -21,7 +21,7 @@ private
   attr_reader(
     :manual_id,
     :attributes,
-    :context,
+    :user,
   )
 
   def update
@@ -29,15 +29,15 @@ private
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   end
 
   def export_draft_to_publishing_api
-    reloaded_manual = Manual.find(manual.id, context.current_user)
+    reloaded_manual = Manual.find(manual.id, user)
     Adapters.publishing.save(reloaded_manual)
   end
 end

--- a/app/services/manual/withdraw_service.rb
+++ b/app/services/manual/withdraw_service.rb
@@ -1,9 +1,9 @@
 require "adapters"
 
 class Manual::WithdrawService
-  def initialize(manual_id:, context:)
+  def initialize(manual_id:, user:)
     @manual_id = manual_id
-    @context = context
+    @user = user
   end
 
   def call
@@ -20,14 +20,14 @@ class Manual::WithdrawService
 
 private
 
-  attr_reader :manual_id, :context
+  attr_reader :manual_id, :user
 
   def withdraw
     manual.withdraw
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
   end
 
   def withdraw_via_publishing_api
@@ -39,7 +39,7 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   rescue KeyError => error
     raise ManualNotFoundError.new(error)
   end

--- a/app/services/section/create_service.rb
+++ b/app/services/section/create_service.rb
@@ -1,8 +1,10 @@
 require "adapters"
 
 class Section::CreateService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, manual_id:, section_params:)
+    @user = user
+    @manual_id = manual_id
+    @section_params = section_params
   end
 
   def call
@@ -10,7 +12,7 @@ class Section::CreateService
 
     if new_section.valid?
       manual.draft
-      manual.save(context.current_user)
+      manual.save(user)
       export_draft_manual_to_publishing_api
       export_draft_section_to_publishing_api
     end
@@ -20,12 +22,12 @@ class Section::CreateService
 
 private
 
-  attr_reader :context
+  attr_reader :user, :manual_id, :section_params
 
   attr_reader :new_section
 
   def manual
-    @manual ||= Manual.find(context.params.fetch("manual_id"), context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   end
 
   def export_draft_manual_to_publishing_api
@@ -34,9 +36,5 @@ private
 
   def export_draft_section_to_publishing_api
     Adapters.publishing.save_section(new_section, manual)
-  end
-
-  def section_params
-    context.params.fetch("section")
   end
 end

--- a/app/services/section/list_service.rb
+++ b/app/services/section/list_service.rb
@@ -1,6 +1,7 @@
 class Section::ListService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, manual_id:)
+    @user = user
+    @manual_id = manual_id
   end
 
   def call
@@ -9,17 +10,13 @@ class Section::ListService
 
 private
 
-  attr_reader :context
+  attr_reader :user, :manual_id
 
   def sections
     manual.sections
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/section/new_service.rb
+++ b/app/services/section/new_service.rb
@@ -1,6 +1,7 @@
 class Section::NewService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, manual_id:)
+    @user = user
+    @manual_id = manual_id
   end
 
   def call
@@ -9,15 +10,9 @@ class Section::NewService
 
 private
 
-  attr_reader(
-    :context,
-  )
+  attr_reader :user, :manual_id
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -1,6 +1,9 @@
 class Section::PreviewService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, section_params:, section_uuid:, manual_id:)
+    @user = user
+    @section_params = section_params
+    @section_uuid = section_uuid
+    @manual_id = manual_id
   end
 
   def call
@@ -11,16 +14,14 @@ class Section::PreviewService
 
 private
 
-  attr_reader(
-    :context,
-  )
+  attr_reader :user, :section_params, :section_uuid, :manual_id
 
   def section
     section_uuid ? existing_section : ephemeral_section
   end
 
   def manual
-    Manual.find(manual_id, context.current_user)
+    Manual.find(manual_id, user)
   end
 
   def ephemeral_section
@@ -31,17 +32,5 @@ private
     @existing_section ||= manual.sections.find { |section|
       section.uuid == section_uuid
     }
-  end
-
-  def section_params
-    context.params.fetch("section")
-  end
-
-  def section_uuid
-    context.params.fetch("id", nil)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id", nil)
   end
 end

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -1,8 +1,11 @@
 require "adapters"
 
 class Section::RemoveService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, section_uuid:, manual_id:, section_params:)
+    @user = user
+    @section_uuid = section_uuid
+    @manual_id = manual_id
+    @section_params = section_params
   end
 
   def call
@@ -25,14 +28,14 @@ class Section::RemoveService
 
 private
 
-  attr_reader :context
+  attr_reader :user, :section_uuid, :manual_id, :section_params
 
   def remove
     manual.remove_section(section_uuid)
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
   end
 
   def section
@@ -40,21 +43,12 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
+    @manual ||= Manual.find(manual_id, user)
   rescue KeyError
     raise ManualNotFoundError.new(manual_id)
   end
 
-  def section_uuid
-    context.params.fetch("id")
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
   def change_note_params
-    section_params = context.params.fetch("section")
     {
       "minor_update" => section_params.fetch("minor_update", "0"),
       "change_note" => section_params.fetch("change_note", ""),

--- a/app/services/section/reorder_service.rb
+++ b/app/services/section/reorder_service.rb
@@ -1,8 +1,10 @@
 require "adapters"
 
 class Section::ReorderService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, manual_id:, section_order:)
+    @user = user
+    @manual_id = manual_id
+    @section_order = section_order
   end
 
   def call
@@ -16,14 +18,14 @@ class Section::ReorderService
 
 private
 
-  attr_reader :context
+  attr_reader :user, :manual_id, :section_order
 
   def update
     manual.reorder_sections(section_order)
   end
 
   def persist
-    manual.save(context.current_user)
+    manual.save(user)
   end
 
   def sections
@@ -31,15 +33,7 @@ private
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
-  def section_order
-    context.params.fetch("section_order")
+    @manual ||= Manual.find(manual_id, user)
   end
 
   def export_draft_manual_to_publishing_api

--- a/app/services/section/show_service.rb
+++ b/app/services/section/show_service.rb
@@ -1,6 +1,8 @@
 class Section::ShowService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, section_uuid:, manual_id:)
+    @user = user
+    @section_uuid = section_uuid
+    @manual_id = manual_id
   end
 
   def call
@@ -9,21 +11,13 @@ class Section::ShowService
 
 private
 
-  attr_reader :context
+  attr_reader :user, :section_uuid, :manual_id
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def section_uuid
-    context.params.fetch("id")
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
+    @manual ||= Manual.find(manual_id, user)
   end
 end

--- a/app/services/section/update_service.rb
+++ b/app/services/section/update_service.rb
@@ -1,8 +1,11 @@
 require "adapters"
 
 class Section::UpdateService
-  def initialize(context:)
-    @context = context
+  def initialize(user:, section_uuid:, manual_id:, section_params:)
+    @user = user
+    @section_uuid = section_uuid
+    @manual_id = manual_id
+    @section_params = section_params
   end
 
   def call
@@ -10,7 +13,7 @@ class Section::UpdateService
 
     if section.valid?
       manual.draft
-      manual.save(context.current_user)
+      manual.save(user)
       export_draft_manual_to_publishing_api
       export_draft_section_to_publishing_api
     end
@@ -20,26 +23,14 @@ class Section::UpdateService
 
 private
 
-  attr_reader :context, :listeners
+  attr_reader :user, :section_uuid, :manual_id, :section_params, :listeners
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }
   end
 
   def manual
-    @manual ||= Manual.find(manual_id, context.current_user)
-  end
-
-  def section_uuid
-    context.params.fetch("id")
-  end
-
-  def manual_id
-    context.params.fetch("manual_id")
-  end
-
-  def section_params
-    context.params.fetch("section")
+    @manual ||= Manual.find(manual_id, user)
   end
 
   def export_draft_manual_to_publishing_api

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -17,7 +17,7 @@ class PublishManualWorker
     service = Manual::PublishService.new(
       manual_id: task.manual_id,
       version_number: task.version_number,
-      context: context,
+      user: User.gds_editor
     )
     service.call
 
@@ -32,10 +32,6 @@ class PublishManualWorker
   end
 
 private
-
-  def context
-    OpenStruct.new(current_user: User.gds_editor)
-  end
 
   def requeue_task(manual_id, error)
     # Raise a FailedToPublishError in order for Sidekiq to catch and requeue it

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -92,17 +92,11 @@ module ManualHelpers
   def edit_section_without_ui(manual, section, fields, organisation_slug: "ministry-of-tea")
     user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
-    service_context = OpenStruct.new(
-      params: {
-        "manual_id" => manual.id,
-        "id" => section.uuid,
-        "section" => fields,
-      },
-      current_user: user
-    )
-
     service = Section::UpdateService.new(
-      context: service_context,
+      user: user,
+      section_uuid: section.uuid,
+      manual_id: manual.id,
+      section_params: fields
     )
     _, section = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -155,12 +155,10 @@ module ManualHelpers
   def publish_manual_without_ui(manual, organisation_slug: "ministry-of-tea")
     stub_manual_publication_observers(organisation_slug)
 
-    user = FactoryGirl.build(:gds_editor)
-
     service = Manual::PublishService.new(
       manual_id: manual.id,
       version_number: manual.version_number,
-      context: OpenStruct.new(current_user: user)
+      user: FactoryGirl.build(:gds_editor)
     )
     service.call
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -23,7 +23,7 @@ module ManualHelpers
 
     service = Manual::CreateService.new(
       attributes: fields.merge(organisation_slug: organisation_slug),
-      context: OpenStruct.new(current_user: user)
+      user: user
     )
     manual = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -77,7 +77,7 @@ module ManualHelpers
     service = Manual::UpdateService.new(
       manual_id: manual.id,
       attributes: fields.merge(organisation_slug: organisation_slug),
-      context: OpenStruct.new(current_user: user)
+      user: user
     )
     manual = service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -44,16 +44,10 @@ module ManualHelpers
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
-    create_service_context = OpenStruct.new(
-      params: {
-        "manual_id" => manual.id,
-        "section" => fields,
-      },
-      current_user: user
-    )
-
     service = Section::CreateService.new(
-      context: create_service_context,
+      user: user,
+      manual_id: manual.id,
+      section_params: fields,
     )
     _, section = service.call
 

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -8,7 +8,7 @@ class ManualWithdrawer
   def execute(manual_id)
     service = Manual::WithdrawService.new(
       manual_id: manual_id,
-      context: OpenStruct.new(current_user: User.gds_editor),
+      user: User.gds_editor,
     )
     manual = service.call
 

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -15,7 +15,7 @@ class ManualsRepublisher
         logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
         service = Manual::RepublishService.new(
           manual_id: manual_record.manual_id,
-          context: OpenStruct.new(current_user: User.gds_editor),
+          user: User.gds_editor,
         )
         service.call
       rescue Manual::RemovedSectionIdNotFoundError => e

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -108,13 +108,13 @@ private
     service = Manual::PublishService.new(
       manual_id: manual_record.manual_id,
       version_number: manual_version_number,
-      context: context,
+      user: user
     )
     service.call
   end
 
-  def context
-    OpenStruct.new(current_user: User.gds_editor)
+  def user
+    User.gds_editor
   end
 
   def manual_record
@@ -122,7 +122,7 @@ private
   end
 
   def manual
-    Manual.find(manual_record.manual_id, context.current_user)
+    Manual.find(manual_record.manual_id, user)
   end
 
   def manual_version_number

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -77,16 +77,17 @@ private
     user = OpenStruct.new(manual_records: manual_records)
 
     service = Section::UpdateService.new(
-      context: context_for_section_edition_update(user),
+      user: user,
+      section_uuid: context_for_section_edition_update['id'],
+      manual_id: context_for_section_edition_update['manual_id'],
+      section_params: context_for_section_edition_update['section']
     )
     _manual, section = service.call
     section.latest_edition
   end
 
-  FakeController = Struct.new(:params, :current_user)
-
-  def context_for_section_edition_update(user)
-    params_hash = {
+  def context_for_section_edition_update
+    {
       "id" => old_section_edition.section_uuid,
       "section" => {
         title: old_section_edition.title,
@@ -97,7 +98,6 @@ private
       },
       "manual_id" => manual_record.manual_id,
     }
-    FakeController.new(params_hash, user)
   end
 
   def change_note

--- a/spec/services/manual/list_service_spec.rb
+++ b/spec/services/manual/list_service_spec.rb
@@ -2,11 +2,10 @@ require "spec_helper"
 
 RSpec.describe Manual::ListService do
   let(:user) { double(:user) }
-  let(:context) { double(:context, current_user: user) }
 
   subject {
     Manual::ListService.new(
-      context: context,
+      user: user,
     )
   }
 

--- a/spec/services/manual/publish_service_spec.rb
+++ b/spec/services/manual/publish_service_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe Manual::PublishService do
   let(:publishing_adapter) { double(:publishing_adapter) }
   let(:search_index_adapter) { double(:search_index_adapter) }
   let(:user) { double(:user) }
-  let(:context) { double(:context, current_user: user) }
 
   subject {
     Manual::PublishService.new(
       manual_id: manual_id,
       version_number: version_number,
-      context: context,
+      user: user,
     )
   }
 

--- a/spec/services/manual/queue_publish_service_spec.rb
+++ b/spec/services/manual/queue_publish_service_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe Manual::QueuePublishService do
   let(:manual_id) { double(:manual_id) }
   let(:manual) { double(:manual, id: manual_id, version_number: 1, draft?: draft) }
   let(:draft) { true }
-  let(:context) { double(:context, current_user: user) }
   let(:user) { double(:user) }
 
-  subject { Manual::QueuePublishService.new(manual_id: manual_id, context: context) }
+  subject { Manual::QueuePublishService.new(manual_id: manual_id, user: user) }
 
   before do
     allow(Manual).to receive(:find) { manual }

--- a/spec/services/manual/republish_service_spec.rb
+++ b/spec/services/manual/republish_service_spec.rb
@@ -8,12 +8,11 @@ RSpec.describe Manual::RepublishService do
   let(:search_index_adapter) { double(:search_index_adapter) }
   let(:manual) { double(:manual) }
   let(:user) { double(:user) }
-  let(:context) { double(:context, current_user: user) }
 
   subject {
     described_class.new(
       manual_id: manual_id,
-      context: context,
+      user: user,
     )
   }
 

--- a/spec/services/manual/update_original_publication_date_service_spec.rb
+++ b/spec/services/manual/update_original_publication_date_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Manual::UpdateOriginalPublicationDateService do
   let(:sections) { [section_1, section_2] }
   let(:originally_published_at) { 10.years.ago }
   let(:publishing_adapter) { double(:publishing_adapter) }
-  let(:context) { double(:context, current_user: user) }
   let(:user) { double(:user) }
 
   subject {
@@ -19,7 +18,7 @@ RSpec.describe Manual::UpdateOriginalPublicationDateService do
         use_originally_published_at_for_public_timestamp: "1",
         title: "hats",
       },
-      context: context
+      user: user
     )
   }
 

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -15,20 +15,12 @@ RSpec.describe Section::RemoveService do
 
   let(:user) { double(:user) }
 
-  let(:service_context) {
-    double(
-      params: {
-        "id" => section_uuid,
-        "manual_id" => "ABC",
-        "section" => change_note_params
-      },
-      current_user: user
-    )
-  }
-
   let(:service) {
     described_class.new(
-      context: service_context,
+      user: user,
+      section_uuid: section_uuid,
+      manual_id: "ABC",
+      section_params: change_note_params
     )
   }
   let(:publishing_adapter) { spy(PublishingAdapter) }


### PR DESCRIPTION
Before this PR, all of the Service objects took a `context` parameter in the initializer. This made it difficult to see what data each of the services required in order to work, and also meant that when a Service was called from outside of a Controller we had to create a `context` object that behaved like a Controller instance. 

I've expanded the `context` argument to named arguments in all cases. There are some Services which deal with the parameters generated from a Rails form submission - I've left these as hash values as I think this is conventional (and less brittle in case objects change). 

There are a few instances where making this change reveals that some redundant information is being passed into the Service. I've left these for now, but hopefully this change will make it easier to refactor/remove later. 

Fixes: #1106