### PR TITLE
Use Manual vs ManualRecord in AttachmentReporting

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -171,6 +171,10 @@ class Section
     end
   end
 
+  def all_editions
+    SectionEdition.all_for_section(uuid)
+  end
+
 private
 
   attr_reader :slug_generator

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -874,4 +874,16 @@ describe Section do
       end
     end
   end
+
+  describe "#all_editions" do
+    let(:editions) { [FactoryGirl.build(:section_edition)] }
+
+    before do
+      allow(SectionEdition).to receive(:all_for_section).with(section_uuid).and_return(editions)
+    end
+
+    it "returns all editions for section" do
+      expect(section.all_editions).to eq(editions)
+    end
+  end
 end


### PR DESCRIPTION
`ManualRecord` should be an implementation detail of `Manual`. Ideally classes other than `Manual` shouldn't access `ManualRecord` directly.

I've also removed a comment which has been rendered obsolete by these changes.