### PR TITLE
Consistancy improvements to controllers/services

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -41,8 +41,8 @@ class ManualsController < ApplicationController
 
   def create
     service = Manual::CreateService.new(
-      attributes: create_manual_params,
       user: current_user,
+      attributes: create_manual_params
     )
     manual = service.call
     manual = manual_form(manual)
@@ -68,9 +68,9 @@ class ManualsController < ApplicationController
 
   def update
     service = Manual::UpdateService.new(
-      manual_id: manual_id,
-      attributes: update_manual_params,
       user: current_user,
+      manual_id: manual_id,
+      attributes: update_manual_params
     )
     manual = service.call
     manual = manual_form(manual)
@@ -96,9 +96,9 @@ class ManualsController < ApplicationController
 
   def update_original_publication_date
     service = Manual::UpdateOriginalPublicationDateService.new(
-      manual_id: manual_id,
-      attributes: publication_date_manual_params,
       user: current_user,
+      manual_id: manual_id,
+      attributes: publication_date_manual_params
     )
     manual = service.call
     manual = manual_form(manual)
@@ -114,8 +114,8 @@ class ManualsController < ApplicationController
 
   def publish
     service = Manual::QueuePublishService.new(
-      manual_id: manual_id,
       user: current_user,
+      manual_id: manual_id
     )
     manual = service.call
 
@@ -127,9 +127,9 @@ class ManualsController < ApplicationController
 
   def preview
     service = Manual::PreviewService.new(
-      manual_id: params[:id],
-      attributes: update_manual_params,
       user: current_user,
+      manual_id: params[:id],
+      attributes: update_manual_params
     )
     manual = service.call
 

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -16,8 +16,7 @@ class SectionAttachmentsController < ApplicationController
 
   def create
     service = Attachment::CreateService.new(
-      file: attachment_params.fetch(:file),
-      title: attachment_params.fetch(:title),
+      attributes: attachment_params,
       section_uuid: params.fetch(:section_id),
       user: current_user,
       manual_id: params.fetch(:manual_id)

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -66,6 +66,6 @@ class SectionAttachmentsController < ApplicationController
 private
 
   def attachment_params
-    params.require("attachment").permit(:title, :file)
+    params.require(:attachment).permit(:title, :file)
   end
 end

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -44,8 +44,7 @@ class SectionAttachmentsController < ApplicationController
 
   def update
     service = Attachment::UpdateService.new(
-      file: attachment_params.fetch(:file),
-      title: attachment_params.fetch(:title),
+      attributes: attachment_params,
       user: current_user,
       attachment_id: params.fetch(:id),
       manual_id: params.fetch(:manual_id),

--- a/app/controllers/section_attachments_controller.rb
+++ b/app/controllers/section_attachments_controller.rb
@@ -2,8 +2,8 @@ class SectionAttachmentsController < ApplicationController
   def new
     service = Attachment::NewService.new(
       user: current_user,
-      section_uuid: params.fetch(:section_id),
-      manual_id: params.fetch(:manual_id)
+      manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:section_id)
     )
     manual, section, attachment = service.call
 
@@ -16,10 +16,10 @@ class SectionAttachmentsController < ApplicationController
 
   def create
     service = Attachment::CreateService.new(
-      attributes: attachment_params,
-      section_uuid: params.fetch(:section_id),
       user: current_user,
-      manual_id: params.fetch(:manual_id)
+      manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:section_id),
+      attributes: attachment_params
     )
     manual, section, _attachment = service.call
 
@@ -29,9 +29,9 @@ class SectionAttachmentsController < ApplicationController
   def edit
     service = Attachment::ShowService.new(
       user: current_user,
-      section_uuid: params.fetch(:section_id),
+      attachment_id: params.fetch(:id),
       manual_id: params.fetch(:manual_id),
-      attachment_id: params.fetch(:id)
+      section_uuid: params.fetch(:section_id)
     )
     manual, section, attachment = service.call
 
@@ -44,11 +44,11 @@ class SectionAttachmentsController < ApplicationController
 
   def update
     service = Attachment::UpdateService.new(
-      attributes: attachment_params,
       user: current_user,
       attachment_id: params.fetch(:id),
       manual_id: params.fetch(:manual_id),
-      section_uuid: params.fetch(:section_id)
+      section_uuid: params.fetch(:section_id),
+      attributes: attachment_params
     )
     manual, section, attachment = service.call
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -4,8 +4,8 @@ class SectionsController < ApplicationController
   def show
     service = Section::ShowService.new(
       user: current_user,
-      section_uuid: params.fetch(:id),
-      manual_id: params.fetch(:manual_id)
+      manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:id)
     )
     manual, section = service.call
 
@@ -49,8 +49,8 @@ class SectionsController < ApplicationController
   def edit
     service = Section::ShowService.new(
       user: current_user,
-      section_uuid: params.fetch(:id),
-      manual_id: params.fetch(:manual_id)
+      manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:id)
     )
     manual, section = service.call
 
@@ -63,8 +63,8 @@ class SectionsController < ApplicationController
   def update
     service = Section::UpdateService.new(
       user: current_user,
-      section_uuid: params.fetch(:id),
       manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:id),
       attributes: params.fetch(:section)
     )
     manual, section = service.call
@@ -82,9 +82,9 @@ class SectionsController < ApplicationController
   def preview
     service = Section::PreviewService.new(
       user: current_user,
-      attributes: params.fetch(:section),
+      manual_id: params.fetch(:manual_id, nil),
       section_uuid: params.fetch(:id, nil),
-      manual_id: params.fetch(:manual_id, nil)
+      attributes: params.fetch(:section)
     )
     section = service.call
 
@@ -137,8 +137,8 @@ class SectionsController < ApplicationController
   def withdraw
     service = Section::ShowService.new(
       user: current_user,
-      section_uuid: params.fetch(:id),
-      manual_id: params.fetch(:manual_id)
+      manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:id)
     )
     manual, section = service.call
 
@@ -151,8 +151,8 @@ class SectionsController < ApplicationController
   def destroy
     service = Section::RemoveService.new(
       user: current_user,
-      section_uuid: params.fetch(:id),
       manual_id: params.fetch(:manual_id),
+      section_uuid: params.fetch(:id),
       attributes: params.fetch(:section)
     )
     manual, section = service.call

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -32,7 +32,7 @@ class SectionsController < ApplicationController
     service = Section::CreateService.new(
       user: current_user,
       manual_id: params.fetch(:manual_id),
-      section_params: params.fetch(:section)
+      attributes: params.fetch(:section)
     )
     manual, section = service.call
 
@@ -65,7 +65,7 @@ class SectionsController < ApplicationController
       user: current_user,
       section_uuid: params.fetch(:id),
       manual_id: params.fetch(:manual_id),
-      section_params: params.fetch(:section)
+      attributes: params.fetch(:section)
     )
     manual, section = service.call
 
@@ -82,7 +82,7 @@ class SectionsController < ApplicationController
   def preview
     service = Section::PreviewService.new(
       user: current_user,
-      section_params: params.fetch(:section),
+      attributes: params.fetch(:section),
       section_uuid: params.fetch(:id, nil),
       manual_id: params.fetch(:manual_id, nil)
     )
@@ -153,7 +153,7 @@ class SectionsController < ApplicationController
       user: current_user,
       section_uuid: params.fetch(:id),
       manual_id: params.fetch(:manual_id),
-      section_params: params.fetch(:section)
+      attributes: params.fetch(:section)
     )
     manual, section = service.call
 

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -1,14 +1,13 @@
 class Attachment::CreateService
-  def initialize(file:, title:, section_uuid:, user:, manual_id:)
-    @file = file
-    @title = title
+  def initialize(attributes:, section_uuid:, user:, manual_id:)
+    @attributes = attributes
     @section_uuid = section_uuid
     @user = user
     @manual_id = manual_id
   end
 
   def call
-    attachment = section.add_attachment(file: file, title: title)
+    attachment = section.add_attachment(attributes)
 
     manual.save(user)
 
@@ -17,7 +16,7 @@ class Attachment::CreateService
 
 private
 
-  attr_reader :file, :title, :section_uuid, :user, :manual_id
+  attr_reader :attributes, :section_uuid, :user, :manual_id
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -1,9 +1,9 @@
 class Attachment::CreateService
-  def initialize(attributes:, section_uuid:, user:, manual_id:)
-    @attributes = attributes
-    @section_uuid = section_uuid
+  def initialize(user:, manual_id:, section_uuid:, attributes:)
     @user = user
     @manual_id = manual_id
+    @section_uuid = section_uuid
+    @attributes = attributes
   end
 
   def call
@@ -16,7 +16,7 @@ class Attachment::CreateService
 
 private
 
-  attr_reader :attributes, :section_uuid, :user, :manual_id
+  attr_reader :user, :manual_id, :section_uuid, :attributes
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }

--- a/app/services/attachment/new_service.rb
+++ b/app/services/attachment/new_service.rb
@@ -1,8 +1,8 @@
 class Attachment::NewService
-  def initialize(manual_id:, section_uuid:, user:)
+  def initialize(user:, manual_id:, section_uuid:)
+    @user = user
     @manual_id = manual_id
     @section_uuid = section_uuid
-    @user = user
   end
 
   def call
@@ -11,7 +11,7 @@ class Attachment::NewService
 
 private
 
-  attr_reader :manual_id, :section_uuid, :user
+  attr_reader :user, :manual_id, :section_uuid
 
   def attachment
     Attachment.new(initial_params)

--- a/app/services/attachment/show_service.rb
+++ b/app/services/attachment/show_service.rb
@@ -1,9 +1,9 @@
 class Attachment::ShowService
-  def initialize(user:, section_uuid:, manual_id:, attachment_id:)
+  def initialize(user:, attachment_id:, manual_id:, section_uuid:)
     @user = user
-    @section_uuid = section_uuid
-    @manual_id = manual_id
     @attachment_id = attachment_id
+    @manual_id = manual_id
+    @section_uuid = section_uuid
   end
 
   def call
@@ -12,7 +12,7 @@ class Attachment::ShowService
 
 private
 
-  attr_reader :user, :section_uuid, :manual_id, :attachment_id
+  attr_reader :user, :attachment_id, :manual_id, :section_uuid
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -1,10 +1,10 @@
 class Attachment::UpdateService
-  def initialize(attributes:, user:, manual_id:, section_uuid:, attachment_id:)
+  def initialize(user:, attachment_id:, manual_id:, section_uuid:, attributes:)
     @user = user
-    @attributes = attributes
+    @attachment_id = attachment_id
     @manual_id = manual_id
     @section_uuid = section_uuid
-    @attachment_id = attachment_id
+    @attributes = attributes
   end
 
   def call
@@ -17,7 +17,7 @@ class Attachment::UpdateService
 
 private
 
-  attr_reader :user, :attributes, :manual_id, :section_uuid, :attachment_id
+  attr_reader :user, :attachment_id, :manual_id, :section_uuid, :attributes
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -1,15 +1,14 @@
 class Attachment::UpdateService
-  def initialize(file:, title:, user:, manual_id:, section_uuid:, attachment_id:)
+  def initialize(attributes:, user:, manual_id:, section_uuid:, attachment_id:)
     @user = user
-    @file = file
-    @title = title
+    @attributes = attributes
     @manual_id = manual_id
     @section_uuid = section_uuid
     @attachment_id = attachment_id
   end
 
   def call
-    attachment.update_attributes(file: file, title: title, filename: file.original_filename)
+    attachment.update_attributes(attributes.merge(filename: attributes[:file].original_filename))
 
     manual.save(user)
 
@@ -18,7 +17,7 @@ class Attachment::UpdateService
 
 private
 
-  attr_reader :user, :file, :title, :manual_id, :section_uuid, :attachment_id
+  attr_reader :user, :attributes, :manual_id, :section_uuid, :attachment_id
 
   def attachment
     @attachment ||= section.find_attachment_by_id(attachment_id)

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -1,9 +1,9 @@
 require "adapters"
 
 class Manual::CreateService
-  def initialize(attributes:, user:)
-    @attributes = attributes
+  def initialize(user:, attributes:)
     @user = user
+    @attributes = attributes
   end
 
   def call
@@ -17,10 +17,7 @@ class Manual::CreateService
 
 private
 
-  attr_reader(
-    :attributes,
-    :user,
-  )
+  attr_reader :user, :attributes
 
   def manual
     @manual ||= Manual.build(attributes)

--- a/app/services/manual/preview_service.rb
+++ b/app/services/manual/preview_service.rb
@@ -1,8 +1,8 @@
 class Manual::PreviewService
-  def initialize(manual_id:, attributes:, user:)
+  def initialize(user:, manual_id:, attributes:)
+    @user = user
     @manual_id = manual_id
     @attributes = attributes
-    @user = user
   end
 
   def call
@@ -13,11 +13,7 @@ class Manual::PreviewService
 
 private
 
-  attr_reader(
-    :manual_id,
-    :attributes,
-    :user,
-  )
+  attr_reader :user, :manual_id, :attributes
 
   def manual
     manual_id ? existing_manual : ephemeral_manual

--- a/app/services/manual/publish_service.rb
+++ b/app/services/manual/publish_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Manual::PublishService
-  def initialize(manual_id:, version_number:, user:)
+  def initialize(user:, manual_id:, version_number:)
+    @user = user
     @manual_id = manual_id
     @version_number = version_number
-    @user = user
   end
 
   def call
@@ -27,11 +27,7 @@ class Manual::PublishService
 
 private
 
-  attr_reader(
-    :manual_id,
-    :version_number,
-    :user,
-  )
+  attr_reader :user, :manual_id, :version_number
 
   def versions_match?
     version_number == manual.version_number

--- a/app/services/manual/queue_publish_service.rb
+++ b/app/services/manual/queue_publish_service.rb
@@ -1,9 +1,9 @@
 require "manual_publish_task"
 
 class Manual::QueuePublishService
-  def initialize(manual_id:, user:)
-    @manual_id = manual_id
+  def initialize(user:, manual_id:)
     @user = user
+    @manual_id = manual_id
   end
 
   def call
@@ -20,10 +20,7 @@ class Manual::QueuePublishService
 
 private
 
-  attr_reader(
-    :manual_id,
-    :user,
-  )
+  attr_reader :user, :manual_id
 
   def create_publish_task(manual)
     ManualPublishTask.create!(

--- a/app/services/manual/republish_service.rb
+++ b/app/services/manual/republish_service.rb
@@ -1,9 +1,9 @@
 require "adapters"
 
 class Manual::RepublishService
-  def initialize(manual_id:, user:)
-    @manual_id = manual_id
+  def initialize(user:, manual_id:)
     @user = user
+    @manual_id = manual_id
   end
 
   def call
@@ -22,7 +22,7 @@ class Manual::RepublishService
 
 private
 
-  attr_reader :manual_id, :user
+  attr_reader :user, :manual_id
 
   def published_manual_version
     manual_versions[:published]

--- a/app/services/manual/show_service.rb
+++ b/app/services/manual/show_service.rb
@@ -1,7 +1,7 @@
 class Manual::ShowService
-  def initialize(manual_id:, user:)
-    @manual_id = manual_id
+  def initialize(user:, manual_id:)
     @user = user
+    @manual_id = manual_id
   end
 
   def call
@@ -10,10 +10,7 @@ class Manual::ShowService
 
 private
 
-  attr_reader(
-    :manual_id,
-    :user,
-  )
+  attr_reader :user, :manual_id
 
   def manual
     @manual ||= Manual.find(manual_id, user)

--- a/app/services/manual/update_original_publication_date_service.rb
+++ b/app/services/manual/update_original_publication_date_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Manual::UpdateOriginalPublicationDateService
-  def initialize(manual_id:, attributes:, user:)
+  def initialize(user:, manual_id:, attributes:)
+    @user = user
     @manual_id = manual_id
     @attributes = attributes.slice(:originally_published_at, :use_originally_published_at_for_public_timestamp)
-    @user = user
   end
 
   def call
@@ -20,11 +20,7 @@ class Manual::UpdateOriginalPublicationDateService
 
 private
 
-  attr_reader(
-    :manual_id,
-    :attributes,
-    :user,
-  )
+  attr_reader :user, :manual_id, :attributes
 
   def update
     manual.update(attributes)

--- a/app/services/manual/update_service.rb
+++ b/app/services/manual/update_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Manual::UpdateService
-  def initialize(manual_id:, attributes:, user:)
+  def initialize(user:, manual_id:, attributes:)
+    @user = user
     @manual_id = manual_id
     @attributes = attributes
-    @user = user
   end
 
   def call
@@ -18,11 +18,7 @@ class Manual::UpdateService
 
 private
 
-  attr_reader(
-    :manual_id,
-    :attributes,
-    :user,
-  )
+  attr_reader :user, :manual_id, :attributes
 
   def update
     manual.update(attributes)

--- a/app/services/manual/withdraw_service.rb
+++ b/app/services/manual/withdraw_service.rb
@@ -1,9 +1,9 @@
 require "adapters"
 
 class Manual::WithdrawService
-  def initialize(manual_id:, user:)
-    @manual_id = manual_id
+  def initialize(user:, manual_id:)
     @user = user
+    @manual_id = manual_id
   end
 
   def call
@@ -20,7 +20,7 @@ class Manual::WithdrawService
 
 private
 
-  attr_reader :manual_id, :user
+  attr_reader :user, :manual_id
 
   def withdraw
     manual.withdraw

--- a/app/services/section/create_service.rb
+++ b/app/services/section/create_service.rb
@@ -1,14 +1,14 @@
 require "adapters"
 
 class Section::CreateService
-  def initialize(user:, manual_id:, section_params:)
+  def initialize(user:, manual_id:, attributes:)
     @user = user
     @manual_id = manual_id
-    @section_params = section_params
+    @attributes = attributes
   end
 
   def call
-    @new_section = manual.build_section(section_params)
+    @new_section = manual.build_section(attributes)
 
     if new_section.valid?
       manual.draft
@@ -22,7 +22,7 @@ class Section::CreateService
 
 private
 
-  attr_reader :user, :manual_id, :section_params
+  attr_reader :user, :manual_id, :attributes
 
   attr_reader :new_section
 

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -1,20 +1,20 @@
 class Section::PreviewService
-  def initialize(user:, section_params:, section_uuid:, manual_id:)
+  def initialize(user:, attributes:, section_uuid:, manual_id:)
     @user = user
-    @section_params = section_params
+    @attributes = attributes
     @section_uuid = section_uuid
     @manual_id = manual_id
   end
 
   def call
-    section.update(section_params)
+    section.update(attributes)
 
     SectionPresenter.new(section)
   end
 
 private
 
-  attr_reader :user, :section_params, :section_uuid, :manual_id
+  attr_reader :user, :attributes, :section_uuid, :manual_id
 
   def section
     section_uuid ? existing_section : ephemeral_section
@@ -25,7 +25,7 @@ private
   end
 
   def ephemeral_section
-    manual.build_section(section_params)
+    manual.build_section(attributes)
   end
 
   def existing_section

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -1,9 +1,9 @@
 class Section::PreviewService
-  def initialize(user:, attributes:, section_uuid:, manual_id:)
+  def initialize(user:, manual_id:, section_uuid:, attributes:)
     @user = user
-    @attributes = attributes
-    @section_uuid = section_uuid
     @manual_id = manual_id
+    @section_uuid = section_uuid
+    @attributes = attributes
   end
 
   def call
@@ -14,7 +14,7 @@ class Section::PreviewService
 
 private
 
-  attr_reader :user, :attributes, :section_uuid, :manual_id
+  attr_reader :user, :manual_id, :section_uuid, :attributes
 
   def section
     section_uuid ? existing_section : ephemeral_section

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -1,11 +1,11 @@
 require "adapters"
 
 class Section::RemoveService
-  def initialize(user:, section_uuid:, manual_id:, section_params:)
+  def initialize(user:, section_uuid:, manual_id:, attributes:)
     @user = user
     @section_uuid = section_uuid
     @manual_id = manual_id
-    @section_params = section_params
+    @attributes = attributes
   end
 
   def call
@@ -28,7 +28,7 @@ class Section::RemoveService
 
 private
 
-  attr_reader :user, :section_uuid, :manual_id, :section_params
+  attr_reader :user, :section_uuid, :manual_id, :attributes
 
   def remove
     manual.remove_section(section_uuid)
@@ -50,8 +50,8 @@ private
 
   def change_note_params
     {
-      "minor_update" => section_params.fetch("minor_update", "0"),
-      "change_note" => section_params.fetch("change_note", ""),
+      "minor_update" => attributes.fetch("minor_update", "0"),
+      "change_note" => attributes.fetch("change_note", ""),
     }
   end
 

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -50,8 +50,8 @@ private
 
   def change_note_params
     {
-      "minor_update" => attributes.fetch("minor_update", "0"),
-      "change_note" => attributes.fetch("change_note", ""),
+      minor_update: attributes.fetch(:minor_update, "0"),
+      change_note: attributes.fetch(:change_note, ""),
     }
   end
 

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Section::RemoveService
-  def initialize(user:, section_uuid:, manual_id:, attributes:)
+  def initialize(user:, manual_id:, section_uuid:, attributes:)
     @user = user
-    @section_uuid = section_uuid
     @manual_id = manual_id
+    @section_uuid = section_uuid
     @attributes = attributes
   end
 
@@ -28,7 +28,7 @@ class Section::RemoveService
 
 private
 
-  attr_reader :user, :section_uuid, :manual_id, :attributes
+  attr_reader :user, :manual_id, :section_uuid, :attributes
 
   def remove
     manual.remove_section(section_uuid)

--- a/app/services/section/show_service.rb
+++ b/app/services/section/show_service.rb
@@ -1,8 +1,8 @@
 class Section::ShowService
-  def initialize(user:, section_uuid:, manual_id:)
+  def initialize(user:, manual_id:, section_uuid:)
     @user = user
-    @section_uuid = section_uuid
     @manual_id = manual_id
+    @section_uuid = section_uuid
   end
 
   def call
@@ -11,7 +11,7 @@ class Section::ShowService
 
 private
 
-  attr_reader :user, :section_uuid, :manual_id
+  attr_reader :user, :manual_id, :section_uuid
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }

--- a/app/services/section/update_service.rb
+++ b/app/services/section/update_service.rb
@@ -1,15 +1,15 @@
 require "adapters"
 
 class Section::UpdateService
-  def initialize(user:, section_uuid:, manual_id:, section_params:)
+  def initialize(user:, section_uuid:, manual_id:, attributes:)
     @user = user
     @section_uuid = section_uuid
     @manual_id = manual_id
-    @section_params = section_params
+    @attributes = attributes
   end
 
   def call
-    section.update(section_params)
+    section.update(attributes)
 
     if section.valid?
       manual.draft
@@ -23,7 +23,7 @@ class Section::UpdateService
 
 private
 
-  attr_reader :user, :section_uuid, :manual_id, :section_params, :listeners
+  attr_reader :user, :section_uuid, :manual_id, :attributes, :listeners
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }

--- a/app/services/section/update_service.rb
+++ b/app/services/section/update_service.rb
@@ -1,10 +1,10 @@
 require "adapters"
 
 class Section::UpdateService
-  def initialize(user:, section_uuid:, manual_id:, attributes:)
+  def initialize(user:, manual_id:, section_uuid:, attributes:)
     @user = user
-    @section_uuid = section_uuid
     @manual_id = manual_id
+    @section_uuid = section_uuid
     @attributes = attributes
   end
 
@@ -23,7 +23,7 @@ class Section::UpdateService
 
 private
 
-  attr_reader :user, :section_uuid, :manual_id, :attributes, :listeners
+  attr_reader :user, :manual_id, :section_uuid, :attributes, :listeners
 
   def section
     @section ||= manual.sections.find { |s| s.uuid == section_uuid }

--- a/app/workers/publish_manual_worker.rb
+++ b/app/workers/publish_manual_worker.rb
@@ -15,9 +15,9 @@ class PublishManualWorker
     task.start!
 
     service = Manual::PublishService.new(
+      user: User.gds_editor,
       manual_id: task.manual_id,
-      version_number: task.version_number,
-      user: User.gds_editor
+      version_number: task.version_number
     )
     service.call
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -22,8 +22,8 @@ module ManualHelpers
     user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = Manual::CreateService.new(
-      attributes: fields.merge(organisation_slug: organisation_slug),
-      user: user
+      user: user,
+      attributes: fields.merge(organisation_slug: organisation_slug)
     )
     manual = service.call
 
@@ -69,9 +69,9 @@ module ManualHelpers
     user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = Manual::UpdateService.new(
+      user: user,
       manual_id: manual.id,
-      attributes: fields.merge(organisation_slug: organisation_slug),
-      user: user
+      attributes: fields.merge(organisation_slug: organisation_slug)
     )
     manual = service.call
 
@@ -94,8 +94,8 @@ module ManualHelpers
 
     service = Section::UpdateService.new(
       user: user,
-      section_uuid: section.uuid,
       manual_id: manual.id,
+      section_uuid: section.uuid,
       attributes: fields
     )
     _, section = service.call
@@ -144,9 +144,9 @@ module ManualHelpers
     stub_manual_publication_observers(organisation_slug)
 
     service = Manual::PublishService.new(
+      user: FactoryGirl.build(:gds_editor),
       manual_id: manual.id,
-      version_number: manual.version_number,
-      user: FactoryGirl.build(:gds_editor)
+      version_number: manual.version_number
     )
     service.call
   end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -47,7 +47,7 @@ module ManualHelpers
     service = Section::CreateService.new(
       user: user,
       manual_id: manual.id,
-      section_params: fields,
+      attributes: fields,
     )
     _, section = service.call
 
@@ -96,7 +96,7 @@ module ManualHelpers
       user: user,
       section_uuid: section.uuid,
       manual_id: manual.id,
-      section_params: fields
+      attributes: fields
     )
     _, section = service.call
 

--- a/lib/manual_withdrawer.rb
+++ b/lib/manual_withdrawer.rb
@@ -7,8 +7,8 @@ class ManualWithdrawer
 
   def execute(manual_id)
     service = Manual::WithdrawService.new(
-      manual_id: manual_id,
       user: User.gds_editor,
+      manual_id: manual_id
     )
     manual = service.call
 

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -14,8 +14,8 @@ class ManualsRepublisher
       begin
         logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
         service = Manual::RepublishService.new(
-          manual_id: manual_record.manual_id,
           user: User.gds_editor,
+          manual_id: manual_record.manual_id
         )
         service.call
       rescue Manual::RemovedSectionIdNotFoundError => e

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -80,7 +80,7 @@ private
       user: user,
       section_uuid: context_for_section_edition_update['id'],
       manual_id: context_for_section_edition_update['manual_id'],
-      section_params: context_for_section_edition_update['section']
+      attributes: context_for_section_edition_update['section']
     )
     _manual, section = service.call
     section.latest_edition

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -78,8 +78,8 @@ private
 
     service = Section::UpdateService.new(
       user: user,
-      section_uuid: context_for_section_edition_update['id'],
       manual_id: context_for_section_edition_update['manual_id'],
+      section_uuid: context_for_section_edition_update['id'],
       attributes: context_for_section_edition_update['section']
     )
     _manual, section = service.call
@@ -106,9 +106,9 @@ private
 
   def publish_manual
     service = Manual::PublishService.new(
+      user: user,
       manual_id: manual_record.manual_id,
-      version_number: manual_version_number,
-      user: user
+      version_number: manual_version_number
     )
     service.call
   end

--- a/spec/services/manual/publish_service_spec.rb
+++ b/spec/services/manual/publish_service_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Manual::PublishService do
 
   subject {
     Manual::PublishService.new(
-      manual_id: manual_id,
-      version_number: version_number,
       user: user,
+      manual_id: manual_id,
+      version_number: version_number
     )
   }
 

--- a/spec/services/manual/queue_publish_service_spec.rb
+++ b/spec/services/manual/queue_publish_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Manual::QueuePublishService do
   let(:draft) { true }
   let(:user) { double(:user) }
 
-  subject { Manual::QueuePublishService.new(manual_id: manual_id, user: user) }
+  subject { Manual::QueuePublishService.new(user: user, manual_id: manual_id) }
 
   before do
     allow(Manual).to receive(:find) { manual }

--- a/spec/services/manual/republish_service_spec.rb
+++ b/spec/services/manual/republish_service_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Manual::RepublishService do
 
   subject {
     described_class.new(
-      manual_id: manual_id,
       user: user,
+      manual_id: manual_id
     )
   }
 

--- a/spec/services/manual/update_original_publication_date_service_spec.rb
+++ b/spec/services/manual/update_original_publication_date_service_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Manual::UpdateOriginalPublicationDateService do
 
   subject {
     described_class.new(
+      user: user,
       manual_id: manual_id,
       attributes: {
         originally_published_at: originally_published_at,
         use_originally_published_at_for_public_timestamp: "1",
         title: "hats",
-      },
-      user: user
+      }
     )
   }
 

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Section::RemoveService do
   let(:service) {
     described_class.new(
       user: user,
-      section_uuid: section_uuid,
       manual_id: "ABC",
+      section_uuid: section_uuid,
       attributes: change_note_params
     )
   }

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Section::RemoveService do
       user: user,
       section_uuid: section_uuid,
       manual_id: "ABC",
-      section_params: change_note_params
+      attributes: change_note_params
     )
   }
   let(:publishing_adapter) { spy(PublishingAdapter) }

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Section::RemoveService do
     }
     let(:change_note_params) do
       {
-        "minor_update" => "0",
-        "change_note" => "Make a change"
+        :minor_update => "0",
+        :change_note => "Make a change"
       }
     end
 
@@ -90,8 +90,8 @@ RSpec.describe Section::RemoveService do
     }
     let(:change_note_params) do
       {
-        "minor_update" => "1",
-        "change_note" => "",
+        :minor_update => "1",
+        :change_note => "",
       }
     end
 
@@ -127,8 +127,8 @@ RSpec.describe Section::RemoveService do
   context "with valid change_note params" do
     let(:change_note_params) do
       {
-        "minor_update" => "0",
-        "change_note" => "Make a change"
+        :minor_update => "0",
+        :change_note => "Make a change"
       }
     end
 
@@ -186,7 +186,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "saves the change note to the section" do
-        expect(section).to have_received(:update).with("minor_update" => "0", "change_note" => "Make a change")
+        expect(section).to have_received(:update).with(:minor_update => "0", :change_note => "Make a change")
       end
 
       it "removes the section" do
@@ -222,9 +222,9 @@ RSpec.describe Section::RemoveService do
       }
       let(:change_note_params) do
         {
-          "minor_update" => "0",
-          "change_note" => "Make a change",
-          "title" => "Sneakily try to change this"
+          :minor_update => "0",
+          :change_note => "Make a change",
+          :title => "Sneakily try to change this"
         }
       end
 
@@ -233,7 +233,7 @@ RSpec.describe Section::RemoveService do
       end
 
       it "only saves the change note params to the section ignoring others" do
-        expect(section).to have_received(:update).with(change_note_params.slice("change_note", "minor_update"))
+        expect(section).to have_received(:update).with(change_note_params.slice(:change_note, :minor_update))
       end
     end
   end


### PR DESCRIPTION
This PR addresses most of the feedback to PR #1118. Specifically:

> Using symbols as keys for controller parameters is more idiomatic Rails; we're still using strings in some places.

Addressed in c921239

> I think it would make the division between controller and service clearer if any relevant constructor arguments were suffixed with `_attributes` vs `_params`.

Addressed in 4ac9889, 0a24416, 5e584e7

> If a constructor argument is a `Hash` of the attributes associated with the model that is the main subject of the service, I probably wouldn't include the model name in the argument name, e.g. in an `Attachment` service I'd use `attributes` vs `attachment_attributes` as the constructor argument name.

Addressed in 4ac9889

> It would be nice if all the service constructor arguments had a consistent ordering, e.g. `user` always comes first or last; and `manual_id`, `section_uuid` & `attachment_id` are always in that order.

Addressed in 5025380

> You mention in the PR description that you've kept some form hashes intact and passed them in without splitting them into separate explicit arguments. I think this is a good idea. However, it looks as if in some places you've split them out, e.g. `file` & `title` in `Attachment::CreateService#initialize`. I'm not sure I'm so keen on that.

Addressed in 0a24416, 5e584e7