### PR TITLE
Extract Manual.find_by_slug! and use Manual vs ManualRecord in a bunch of rake tasks

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -368,5 +368,10 @@ class Manual
     manual_record.editions
   end
 
+  def set(attributes = {})
+    manual_record = ManualRecord.find_by(manual_id: id)
+    manual_record.set(attributes)
+  end
+
   class RemovedSectionIdNotFoundError < StandardError; end
 end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -23,6 +23,7 @@ class Manual
   attr_accessor :publish_tasks
 
   class NotFoundError < StandardError; end
+  class AmbiguousSlugError < StandardError; end
 
   def self.find(id, user)
     collection = user.manual_records
@@ -32,6 +33,19 @@ class Manual
     end
 
     build_manual_for(manual_record)
+  end
+
+  def self.find_by_slug!(slug, user)
+    collection = user.manual_records
+    manual_records = collection.where(slug: slug)
+    case manual_records.length
+    when 0
+      raise NotFoundError.new("Manual slug not found: #{slug}")
+    when 1
+      build_manual_for(manual_records.first)
+    else
+      raise AmbiguousSlugError.new("Multiple manuals found for slug: #{slug}")
+    end
   end
 
   def self.all(user, load_associations: true)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -363,5 +363,10 @@ class Manual
     manual_record.destroy
   end
 
+  def editions
+    manual_record = ManualRecord.find_by(manual_id: id)
+    manual_record.editions
+  end
+
   class RemovedSectionIdNotFoundError < StandardError; end
 end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -632,7 +632,9 @@ module ManualHelpers
   def republish_manuals_without_ui
     logger = Logger.new(nil)
     republisher = ManualsRepublisher.new(logger)
-    republisher.execute
+    user = FactoryGirl.build(:gds_editor)
+    manuals = Manual.all(user)
+    republisher.execute(manuals)
   end
 
   def check_for_slug_clash_warning

--- a/lib/manual_publication_log_filter.rb
+++ b/lib/manual_publication_log_filter.rb
@@ -1,7 +1,7 @@
 class ManualPublicationLogFilter
-  def initialize(manual_record)
-    @manual_record = manual_record
-    @manual_slug = manual_record.slug
+  def initialize(manual)
+    @manual = manual
+    @manual_slug = manual.slug
   end
 
   def delete_logs_and_rebuild_for_major_updates_only!
@@ -54,7 +54,7 @@ private
   end
 
   def build_logs_for_all_other_suitable_section_editions
-    edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual_record.latest_edition.section_uuids)
+    edition_ordering = EditionOrdering.new(section_editions_for_rebuild, @manual.sections.map(&:uuid))
 
     edition_ordering.sort_by_section_uuids_and_created_at.each do |edition|
       PublicationLog.create!(
@@ -73,7 +73,7 @@ private
   end
 
   def first_manual_edition
-    @first_manual_edition ||= @manual_record.editions.where(version_number: 1).first
+    @first_manual_edition ||= @manual.editions.where(version_number: 1).first
   end
 
   def section_editions_for_rebuild

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -15,18 +15,18 @@ class ManualRelocator
   end
 
   def move!
-    validate_manuals
+    validate_manual_records
     redirect_and_remove
     reslug
     redraft_and_republish
   end
 
   def old_manual_record
-    @old_manual_record ||= fetch_manual(to_slug)
+    @old_manual_record ||= fetch_manual_record(to_slug)
   end
 
   def new_manual_record
-    @new_manual_record ||= fetch_manual(from_slug)
+    @new_manual_record ||= fetch_manual_record(from_slug)
   end
 
   def old_manual
@@ -39,11 +39,11 @@ class ManualRelocator
 
 private
 
-  def fetch_manual(slug)
-    manuals = ManualRecord.where(slug: slug)
-    raise "No manual found for slug '#{slug}'" if manuals.count == 0
-    raise "More than one manual found for slug '#{slug}'" if manuals.count > 1
-    manuals.first
+  def fetch_manual_record(slug)
+    manual_records = ManualRecord.where(slug: slug)
+    raise "No manual found for slug '#{slug}'" if manual_records.count == 0
+    raise "More than one manual found for slug '#{slug}'" if manual_records.count > 1
+    manual_records.first
   end
 
   def old_section_uuids
@@ -54,18 +54,18 @@ private
     @new_section_uuids ||= new_manual_record.editions.flat_map(&:section_uuids).uniq
   end
 
-  def validate_manuals
+  def validate_manual_records
     raise "Manual to remove (#{to_slug}) should be published" unless manual_is_currently_published?(old_manual_record)
     raise "Manual to reslug (#{from_slug}) should be published" unless manual_is_currently_published?(new_manual_record)
   end
 
-  def manual_is_currently_published?(manual)
+  def manual_is_currently_published?(manual_record)
     # to be currently published either...
     # 1. the latest edition is published
-    (manual.latest_edition.state == "published") ||
+    (manual_record.latest_edition.state == "published") ||
     # or
     # 2. the last two editions are published and draft
-      (manual.editions.order_by([:version_number, :desc]).limit(2).map(&:state) == %w(draft published))
+      (manual_record.editions.order_by([:version_number, :desc]).limit(2).map(&:state) == %w(draft published))
   end
 
   def redirect_and_remove

--- a/lib/manual_relocator.rb
+++ b/lib/manual_relocator.rb
@@ -155,7 +155,7 @@ private
     # Reslug the existing publication logs
     puts "Reslugging publication logs for #{from_slug} to #{to_slug}"
     new_manual.publication_logs.each do |publication_log|
-      publication_log.set(:slug, publication_log.slug.gsub(from_slug, to_slug))
+      publication_log.set(slug: publication_log.slug.gsub(from_slug, to_slug))
     end
 
     # Clean up manual sections belonging to the temporary manual path

--- a/lib/manuals_republisher.rb
+++ b/lib/manuals_republisher.rb
@@ -5,21 +5,21 @@ class ManualsRepublisher
     @logger = logger
   end
 
-  def execute(manual_records = ManualRecord.all)
-    count = manual_records.count
+  def execute(manuals)
+    count = manuals.count
 
     logger.info "Republishing #{count} manuals..."
 
-    manual_records.to_a.each.with_index do |manual_record, i|
+    manuals.to_a.each.with_index do |manual, i|
       begin
-        logger.info("[ #{i} / #{count} ] id=#{manual_record.manual_id} slug=#{manual_record.slug}]")
+        logger.info("[ #{i} / #{count} ] id=#{manual.id} slug=#{manual.slug}]")
         service = Manual::RepublishService.new(
-          manual_id: manual_record.manual_id,
+          manual_id: manual.id,
           user: User.gds_editor,
         )
         service.call
       rescue Manual::RemovedSectionIdNotFoundError => e
-        logger.error("Did not publish manual with id=#{manual_record.manual_id} slug=#{manual_record.slug}. It has at least one removed document which was not found: #{e.message}")
+        logger.error("Did not publish manual with id=#{manual.id} slug=#{manual.slug}. It has at least one removed document which was not found: #{e.message}")
         next
       end
     end

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -68,8 +68,7 @@ private
   end
 
   def new_edition_for_slug_change
-    manual_records = ManualRecord.all
-    user = OpenStruct.new(manual_records: manual_records)
+    user = User.gds_editor
 
     service = Section::UpdateService.new(
       user: user,

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -78,26 +78,18 @@ private
 
     service = Section::UpdateService.new(
       user: user,
-      section_uuid: context_for_section_edition_update['id'],
-      manual_id: context_for_section_edition_update['manual_id'],
-      section_params: context_for_section_edition_update['section']
-    )
-    _manual, section = service.call
-    section.latest_edition
-  end
-
-  def context_for_section_edition_update
-    {
-      "id" => old_section_edition.section_uuid,
-      "section" => {
+      section_uuid: old_section_edition.section_uuid,
+      manual_id: manual_record.manual_id,
+      section_params: {
         title: old_section_edition.title,
         summary: old_section_edition.summary,
         body: old_section_edition.body,
         minor_update: false,
         change_note: change_note
-      },
-      "manual_id" => manual_record.manual_id,
-    }
+      }
+    )
+    _manual, section = service.call
+    section.latest_edition
   end
 
   def change_note

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -79,7 +79,7 @@ private
     service = Section::UpdateService.new(
       user: user,
       section_uuid: old_section_edition.section_uuid,
-      manual_id: manual_record.manual_id,
+      manual_id: manual.id,
       section_params: {
         title: old_section_edition.title,
         summary: old_section_edition.summary,
@@ -98,7 +98,7 @@ private
 
   def publish_manual
     service = Manual::PublishService.new(
-      manual_id: manual_record.manual_id,
+      manual_id: manual.id,
       version_number: manual_version_number,
       user: user
     )
@@ -150,7 +150,7 @@ private
   end
 
   def full_section_slug(slug)
-    "#{manual_record.slug}/#{slug}"
+    "#{manual.slug}/#{slug}"
   end
 
   def remove_from_search_index(section)

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -25,13 +25,8 @@ class SectionReslugger
 private
 
   def validate
-    validate_manual
     validate_old_section
     validate_new_section
-  end
-
-  def validate_manual
-    raise Error.new("Manual not found for manual_slug `#{@manual_slug}`") if manual_record.nil?
   end
 
   def validate_old_section
@@ -109,12 +104,10 @@ private
     User.gds_editor
   end
 
-  def manual_record
-    @manual_record ||= ManualRecord.where(slug: @manual_slug).last
-  end
-
   def manual
-    Manual.find(manual_record.manual_id, user)
+    Manual.find_by_slug!(@manual_slug, user)
+  rescue Manual::NotFoundError, Manual::AmbiguousSlugError => e
+    raise Error.new(e.message)
   end
 
   def manual_version_number

--- a/lib/section_slug_synchroniser.rb
+++ b/lib/section_slug_synchroniser.rb
@@ -3,8 +3,7 @@ class SectionSlugSynchroniser
 
   def initialize(manual_slug, logger = STDOUT)
     @logger = logger
-    manual_record = ManualRecord.where(slug: manual_slug).last
-    @manual = Manual.find(manual_record.manual_id, User.gds_editor)
+    @manual = Manual.find_by_slug!(manual_slug, User.gds_editor)
     @sections = manual.sections
   end
 

--- a/lib/tasks/rebuild_major_publication_logs_for_manuals.rake
+++ b/lib/tasks/rebuild_major_publication_logs_for_manuals.rake
@@ -6,17 +6,17 @@ task :rebuild_major_publication_logs_for_manuals, [:slug] => :environment do |_,
   logger = Logger.new(STDOUT)
   logger.formatter = Logger::Formatter.new
 
-  manual_records = if args.has_key?(:slug)
-                     ManualRecord.where(slug: args[:slug])
-                   else
-                     ManualRecord.all
-                   end
+  manuals = if args.has_key?(:slug)
+              [Manual.find_by_slug!(args[:slug], user)]
+            else
+              Manual.all(user)
+            end
 
-  count = manual_records.count
+  count = manual.count
 
   logger.info "Deleting publication logs and rebuilding for major updates only for #{count} manuals"
 
-  manual_records.to_a.each.with_index(1) do |manual, i|
+  manuals.each.with_index(1) do |manual, i|
     manual_publication_log_filter = ManualPublicationLogFilter.new(manual)
     logger.info("[% 3d/% 3d] id=%s slug=%s" % [i, count, manual.id, manual.slug])
     manual_publication_log_filter.delete_logs_and_rebuild_for_major_updates_only!

--- a/lib/tasks/republish_manuals.rake
+++ b/lib/tasks/republish_manuals.rake
@@ -6,12 +6,12 @@ task :republish_manuals, [:slug] => :environment do |_, args|
   logger = Logger.new(STDOUT)
   logger.formatter = Logger::Formatter.new
 
-  manual_records = if args.has_key?(:slug)
-                     ManualRecord.where(slug: args[:slug])
-                   else
-                     ManualRecord.all
-                   end
+  manuals = if args.has_key?(:slug)
+              [Manual.find_by_slug!(args[:slug], user)]
+            else
+              Manual.all(user)
+            end
 
   republisher = ManualsRepublisher.new(logger)
-  republisher.execute(manual_records)
+  republisher.execute(manuals)
 end

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -123,8 +123,10 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
     )
   }
 
+  let(:manual) { Manual.find(manual_record.manual_id, User.gds_editor) }
+
   before do
-    described_class.new(manual_record).delete_logs_and_rebuild_for_major_updates_only!
+    described_class.new(manual).delete_logs_and_rebuild_for_major_updates_only!
   end
 
   it "deletes all existing publication logs for the supplied manual slug only" do

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -111,25 +111,37 @@ describe ManualRelocator do
         }.not_to raise_error
       end
 
-      it "does not raises an error if the existing manual is currently published, regardless of the previous edition state" do
-        previous_edition = ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "withdrawn")
-        existing_manual.editions << previous_edition
-        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 2, state: "published")
-        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+      context "if the existing manual is currently published" do
+        let(:previous_edition) do
+          ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1)
+        end
 
-        expect {
-          subject.move!
-        }.not_to raise_error
+        before do
+          existing_manual.editions << previous_edition
+          existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 2, state: "published")
+          temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+        end
 
-        previous_edition.set(state: "published")
-        expect {
-          subject.move!
-        }.not_to raise_error
+        it "does not raises an error even if previous edition is withdrawn" do
+          previous_edition.set(state: "withdrawn")
+          expect {
+            subject.move!
+          }.not_to raise_error
+        end
 
-        previous_edition.set(state: "draft")
-        expect {
-          subject.move!
-        }.not_to raise_error
+        it "does not raises an error even if previous edition is published" do
+          previous_edition.set(state: "published")
+          expect {
+            subject.move!
+          }.not_to raise_error
+        end
+
+        it "does not raises an error even if previous edition is draft" do
+          previous_edition.set(state: "draft")
+          expect {
+            subject.move!
+          }.not_to raise_error
+        end
       end
 
       it "does not raises an error if the existing manual has previously been published, but is currently draft" do
@@ -151,25 +163,37 @@ describe ManualRelocator do
         }.not_to raise_error
       end
 
-      it "does not raises an error if the temp manual is currently published, regardless of the previous edition state" do
-        existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
-        previous_edition = ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1, state: "withdrawn")
-        temp_manual.editions << previous_edition
-        temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+      context "if the temp manual is currently published" do
+        let(:previous_edition) do
+          ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 1)
+        end
 
-        expect {
-          subject.move!
-        }.not_to raise_error
+        before do
+          existing_manual.editions << ManualRecord::Edition.new(section_uuids: %w(12345 23456 34567), version_number: 1, state: "published")
+          temp_manual.editions << previous_edition
+          temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg cdefgh), version_number: 2, state: "published")
+        end
 
-        previous_edition.set(state: "published")
-        expect {
-          subject.move!
-        }.not_to raise_error
+        it "does not raises an error even if previous edition is withdrawn" do
+          previous_edition.set(state: "withdrawn")
+          expect {
+            subject.move!
+          }.not_to raise_error
+        end
 
-        previous_edition.set(state: "draft")
-        expect {
-          subject.move!
-        }.not_to raise_error
+        it "does not raises an error even if previous edition is published" do
+          previous_edition.set(state: "published")
+          expect {
+            subject.move!
+          }.not_to raise_error
+        end
+
+        it "does not raises an error even if previous edition is draft" do
+          previous_edition.set(state: "draft")
+          expect {
+            subject.move!
+          }.not_to raise_error
+        end
       end
 
       it "does not raises an error if the temp manual has previously been published, but is currently draft" do

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -11,38 +11,6 @@ describe ManualRelocator do
   let(:temp_slug) { "guidance/temporary-slug" }
   subject { described_class.new(temp_slug, existing_slug) }
 
-  describe "#old_manual_record" do
-    it "raises an error if the existing slug doesn't result in a manual" do
-      expect {
-        subject.old_manual_record
-      }.to raise_error(RuntimeError, "No manual found for slug '#{existing_slug}'")
-    end
-
-    it "raises an error if the existing slug maps to more than one manual" do
-      ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug)
-      ManualRecord.create(slug: existing_slug)
-      expect {
-        subject.old_manual_record
-      }.to raise_error(RuntimeError, "More than one manual found for slug '#{existing_slug}'")
-    end
-  end
-
-  describe "#new_manual_record" do
-    it "raises an error if the existing slug doesn't result in a manual" do
-      expect {
-        subject.new_manual_record
-      }.to raise_error(RuntimeError, "No manual found for slug '#{temp_slug}'")
-    end
-
-    it "raises an error if the existing slug maps to more than one manual" do
-      ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug)
-      ManualRecord.create(slug: temp_slug)
-      expect {
-        subject.new_manual_record
-      }.to raise_error(RuntimeError, "More than one manual found for slug '#{temp_slug}'")
-    end
-  end
-
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -1074,4 +1074,13 @@ describe Manual do
       expect(manual.editions).to eq(manual_record.editions)
     end
   end
+
+  describe "#set" do
+    let!(:manual_record) { FactoryGirl.create(:manual_record, manual_id: manual.id) }
+
+    it "sets attributes on underlying manual record" do
+      manual.set(slug: "new-slug")
+      expect(manual_record.reload.slug).to eq("new-slug")
+    end
+  end
 end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -1066,4 +1066,12 @@ describe Manual do
       end
     end
   end
+
+  describe "#editions" do
+    let!(:manual_record) { FactoryGirl.create(:manual_record, manual_id: manual.id) }
+
+    it "returns editions from underlying manual record" do
+      expect(manual.editions).to eq(manual_record.editions)
+    end
+  end
 end

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -20,15 +20,15 @@ describe Manual do
   }
 
   let(:id) { "0123-4567-89ab-cdef" }
-  let(:updated_at) { double(:updated_at) }
-  let(:originally_published_at) { double(:originally_published_at) }
-  let(:use_originally_published_at_for_public_timestamp) { double(:use_originally_published_at_for_public_timestamp) }
-  let(:title) { double(:title) }
-  let(:summary) { double(:summary) }
-  let(:body) { double(:body) }
-  let(:organisation_slug) { double(:organisation_slug) }
-  let(:state) { double(:state) }
-  let(:slug) { double(:slug) }
+  let(:updated_at) { Time.parse("2001-01-01") }
+  let(:originally_published_at) { DateTime.parse("2002-02-02") }
+  let(:use_originally_published_at_for_public_timestamp) { false }
+  let(:title) { "manual-title" }
+  let(:summary) { "manual-summary" }
+  let(:body) { "manual-body" }
+  let(:organisation_slug) { "organisation-slug" }
+  let(:state) { "manual-state" }
+  let(:slug) { "manual-slug" }
 
   it "rasies an error without an ID" do
     expect {
@@ -172,10 +172,10 @@ describe Manual do
     end
 
     context "with allowed attirbutes" do
-      let(:new_title) { double(:new_title) }
-      let(:new_summary) { double(:new_summary) }
-      let(:new_organisation_slug) { double(:new_organisation_slug) }
-      let(:new_state) { double(:new_state) }
+      let(:new_title) { "new-manual-title" }
+      let(:new_summary) { "new-manual-summary" }
+      let(:new_organisation_slug) { "new-organisation-slug" }
+      let(:new_state) { "new-manual-state" }
 
       it "updates with the given attributes" do
         manual.update(
@@ -202,8 +202,8 @@ describe Manual do
     end
 
     context "with disallowed attributes" do
-      let(:new_id) { double(:new_id) }
-      let(:new_updated_at) { double(:new_updated_at) }
+      let(:new_id) { "new-manual-id" }
+      let(:new_updated_at) { Time.parse("2003-03-03") }
 
       it "does not update the attributes" do
         manual.update(


### PR DESCRIPTION
This started off as an attempt to reduce duplication where a `Manual` was being looked up by its `slug` via a `ManualRecord` query. However, it has also led me into using `Manual` vs `ManualRecord` in a bunch of Rake tasks and extracting `Manual#set` & `Manual#editions`.

The higher level goal of preferring `Manual` over `ManualRecord` is that the latter should be an implementation detail of the former and ideally shouldn't be accessed from outside the former.