### PR TITLE
Add missing require statement to SearchIndexAdapter

### DIFF
--- a/app/adapters/search_index_adapter.rb
+++ b/app/adapters/search_index_adapter.rb
@@ -1,5 +1,6 @@
 require "services"
 require "gds_api_constants"
+require "markdown_attachment_processor"
 
 class SearchIndexAdapter
   def add(manual)


### PR DESCRIPTION
This class is defined in a file in the `lib` directory and so it needs to be explicitly required.