### PR TITLE
Inline Manual.build into Manual#initialize

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -33,7 +33,7 @@ class ManualsController < ApplicationController
   end
 
   def new
-    service = ->() { Manual.build(title: "") }
+    service = ->() { Manual.new(title: "") }
     manual = service.call
 
     render(:new, locals: { manual: manual_form(manual) })

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -107,7 +107,6 @@ class Manual
     slug_generator = SlugGenerator.new(prefix: "guidance")
 
     default_attrs = {
-      id: SecureRandom.uuid,
       summary: "",
       body: "",
       state: "draft",
@@ -120,7 +119,7 @@ class Manual
     manual_attrs = default_attrs.merge(attributes)
     manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title))
 
-    @id = manual_attrs.fetch(:id)
+    @id = manual_attrs.fetch(:id, SecureRandom.uuid)
     @updated_at = manual_attrs.fetch(:updated_at, nil)
     @version_number = manual_attrs.fetch(:version_number, 0)
     @ever_been_published = !!manual_attrs.fetch(:ever_been_published, false)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -56,29 +56,6 @@ class Manual
     }
   end
 
-  def self.build(attributes)
-    slug_generator = SlugGenerator.new(prefix: "guidance")
-
-    default_attrs = {
-      id: SecureRandom.uuid,
-      summary: "",
-      body: "",
-      state: "draft",
-      organisation_slug: "",
-      updated_at: "",
-      originally_published_at: nil,
-      use_originally_published_at_for_public_timestamp: true,
-    }
-
-    manual_attrs = default_attrs.merge(attributes)
-    manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title))
-
-    manual = Manual.new(manual_attrs)
-    manual.sections = manual_attrs.fetch(:sections, [])
-    manual.removed_sections = manual_attrs.fetch(:removed_sections, [])
-    manual
-  end
-
   def slug_unique?(user)
     user.manual_records.where(
       :slug => slug,
@@ -127,15 +104,31 @@ class Manual
   end
 
   def initialize(attributes)
-    @id = attributes.fetch(:id)
-    @updated_at = attributes.fetch(:updated_at, nil)
-    @version_number = attributes.fetch(:version_number, 0)
-    @ever_been_published = !!attributes.fetch(:ever_been_published, false)
+    slug_generator = SlugGenerator.new(prefix: "guidance")
 
-    update(attributes)
+    default_attrs = {
+      id: SecureRandom.uuid,
+      summary: "",
+      body: "",
+      state: "draft",
+      organisation_slug: "",
+      updated_at: "",
+      originally_published_at: nil,
+      use_originally_published_at_for_public_timestamp: true,
+    }
 
-    @sections = []
-    @removed_sections = []
+    manual_attrs = default_attrs.merge(attributes)
+    manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title))
+
+    @id = manual_attrs.fetch(:id)
+    @updated_at = manual_attrs.fetch(:updated_at, nil)
+    @version_number = manual_attrs.fetch(:version_number, 0)
+    @ever_been_published = !!manual_attrs.fetch(:ever_been_published, false)
+
+    update(manual_attrs)
+
+    @sections = manual_attrs.fetch(:sections, [])
+    @removed_sections = manual_attrs.fetch(:removed_sections, [])
   end
 
   def to_param

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -111,7 +111,6 @@ class Manual
       body: "",
       state: "draft",
       organisation_slug: "",
-      updated_at: "",
       originally_published_at: nil,
       use_originally_published_at_for_public_timestamp: true,
     }

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -61,7 +61,6 @@ class Manual
 
     default_attrs = {
       id: SecureRandom.uuid,
-      slug: slug_generator.call(attributes.fetch(:title)),
       summary: "",
       body: "",
       state: "draft",
@@ -72,6 +71,8 @@ class Manual
     }
 
     manual_attrs = default_attrs.merge(attributes)
+    manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title))
+
     manual = Manual.new(manual_attrs)
     manual.sections = manual_attrs.fetch(:sections, [])
     manual.removed_sections = manual_attrs.fetch(:removed_sections, [])

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -23,7 +23,7 @@ private
   )
 
   def manual
-    @manual ||= Manual.build(attributes)
+    @manual ||= Manual.new(attributes)
   end
 
   def persist

--- a/app/services/manual/preview_service.rb
+++ b/app/services/manual/preview_service.rb
@@ -24,7 +24,7 @@ private
   end
 
   def ephemeral_manual
-    Manual.build(
+    Manual.new(
       attributes.reverse_merge(
         title: ""
       )

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -27,7 +27,8 @@ describe PublishingAdapter do
   let(:manual_id) { "a55242ed-178f-4716-8bb3-5d4f82d38531" }
 
   let(:manual) {
-    Manual.build(
+    FactoryGirl.build(
+      :manual,
       id: manual_id,
       slug: "manual-slug",
       organisation_slug: "organisation-slug",

--- a/spec/adapters/search_index_adapter_spec.rb
+++ b/spec/adapters/search_index_adapter_spec.rb
@@ -9,7 +9,8 @@ describe SearchIndexAdapter do
   let(:rummager_document_type_for_section) { GdsApiConstants::Rummager::SECTION_DOCUMENT_TYPE }
 
   let(:manual) {
-    Manual.build(
+    FactoryGirl.build(
+      :manual,
       id: "manual-id",
       slug: "manual-slug",
       title: "manual-title",

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -54,7 +54,7 @@ FactoryGirl.define do
     slug "manual-slug"
 
     initialize_with do
-      Manual.build(attributes)
+      Manual.new(attributes)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,6 +50,14 @@ FactoryGirl.define do
     sequence(:change_note) { |n| "Change note #{n}" }
   end
 
+  factory :manual do
+    slug "manual-slug"
+
+    initialize_with do
+      Manual.build(attributes)
+    end
+  end
+
   factory :manual_record do
     slug 'slug'
     manual_id 'abc-123'

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -4,7 +4,8 @@ require "manual"
 
 describe Manual do
   subject(:manual) {
-    Manual.new(
+    FactoryGirl.build(
+      :manual,
       id: id,
       slug: slug,
       title: title,
@@ -39,26 +40,26 @@ describe Manual do
   describe "#eql?" do
     it "is considered the same as another manual instance if they have the same id" do
       expect(manual).to eql(manual)
-      expect(manual).to eql(Manual.new(id: manual.id))
-      expect(manual).not_to eql(Manual.new(id: manual.id.reverse))
+      expect(manual).to eql(FactoryGirl.build(:manual, id: manual.id))
+      expect(manual).not_to eql(FactoryGirl.build(:manual, id: manual.id.reverse))
     end
 
     it "is considered the same as another manual instance with the same id even if the version number is different" do
-      expect(manual).to eql(Manual.new(id: manual.id, version_number: manual.version_number + 1))
+      expect(manual).to eql(FactoryGirl.build(:manual, id: manual.id, version_number: manual.version_number + 1))
     end
   end
 
   describe "#has_ever_been_published?" do
     it "is false if not told at initialize time" do
-      expect(Manual.new(id: "1234-5678-9012-3456")).not_to have_ever_been_published
+      expect(FactoryGirl.build(:manual, id: "1234-5678-9012-3456")).not_to have_ever_been_published
     end
 
     it "is false if told so at initialize time" do
-      expect(Manual.new(id: "1234-5678-9012-3456", ever_been_published: false)).not_to have_ever_been_published
+      expect(FactoryGirl.build(:manual, id: "1234-5678-9012-3456", ever_been_published: false)).not_to have_ever_been_published
     end
 
     it "is true if told so at initialize time" do
-      expect(Manual.new(id: "1234-5678-9012-3456", ever_been_published: true)).to have_ever_been_published
+      expect(FactoryGirl.build(:manual, id: "1234-5678-9012-3456", ever_been_published: true)).to have_ever_been_published
     end
   end
 
@@ -100,7 +101,7 @@ describe Manual do
     end
 
     it "defaults to 0 if not supplied in the initalizer attributes" do
-      expect(Manual.new(id: "1234-5678").version_number).to eq 0
+      expect(FactoryGirl.build(:manual, id: "1234-5678").version_number).to eq 0
     end
   end
 
@@ -400,7 +401,8 @@ describe Manual do
     let(:user) { FactoryGirl.create(:gds_editor) }
 
     subject(:manual) {
-      Manual.new(
+      FactoryGirl.build(
+        :manual,
         id: 'id',
         slug: 'manual-slug',
         title: 'title',

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -31,10 +31,9 @@ describe Manual do
   let(:state) { "manual-state" }
   let(:slug) { "manual-slug" }
 
-  it "rasies an error without an ID" do
-    expect {
-      Manual.new({})
-    }.to raise_error(KeyError)
+  it "generates an ID if none is provided" do
+    manual = Manual.new(title: "manual-title")
+    expect(manual.id).to be_present
   end
 
   describe "#eql?" do

--- a/spec/views/sections/_form.html.erb_spec.rb
+++ b/spec/views/sections/_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'sections/_form.html.erb', type: :view do
   it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
-    manual = Manual.new(id: 'manual-id')
+    manual = FactoryGirl.build(:manual, id: 'manual-id')
     section = Section.new(manual: manual, uuid: 'section-uuid', editions: [])
 
     allow(manual).to receive(:has_ever_been_published?).and_return(true)

--- a/spec/views/sections/withdraw.html.erb_spec.rb
+++ b/spec/views/sections/withdraw.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'sections/withdraw.html.erb', type: :view do
   it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
-    manual = Manual.new(id: 'manual-id')
+    manual = FactoryGirl.build(:manual, id: 'manual-id')
     section = Section.new(manual: manual, uuid: 'section-uuid', editions: [])
 
     allow(view).to receive(:manual).and_return(ManualViewAdapter.new(manual))


### PR DESCRIPTION
This makes `Manual` more like a standard `ActiveModel`-type class which should make it easier to convert into a `Mongoid::Document`.

This change was made easier by the extraction of a factory for `Manual`. The factory is a bit non-standard, because `Manual` does not implement attribute writer methods which is what `FactoryGirl` uses by default to set the attributes.

There is also a small change in the behaviour of `Manual#new`. Previously if no ID was supplied, a `KeyError` would be raised; whereas now an ID is generated. As I explain in more detail in the commit note, this is closer to standard `Mongoid::Document` behaviour an so I'm happy to make the change.

I'm sure there is further simplification we could do to `Manual#initialize`, but I think this is a sufficient step forward to merit a PR.
