### PR TITLE
Avoid persisting new sections when saving to Publishing API fails

### DIFF
--- a/app/services/section/create_service.rb
+++ b/app/services/section/create_service.rb
@@ -13,9 +13,9 @@ class Section::CreateService
 
     if new_section.valid?
       manual.draft
-      manual.save(user)
       Adapters.publishing.save(manual, include_sections: false)
       Adapters.publishing.save_section(new_section, manual)
+      manual.save(user)
     end
 
     [manual, new_section]

--- a/spec/services/section/create_service_spec.rb
+++ b/spec/services/section/create_service_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+RSpec.describe Section::CreateService do
+  let(:user) { User.gds_editor }
+  let(:manual) { Manual.new(title: 'manual-title') }
+  let(:section_attributes) { double(:section_attributes) }
+  let(:publishing_api_adapter) { double(:publishing_api) }
+  let(:new_section) {
+    Section.new(manual: manual, uuid: 'uuid', editions: [])
+  }
+
+  subject do
+    described_class.new(
+      user: user,
+      manual_id: manual.id,
+      attributes: section_attributes
+    )
+  end
+
+  before do
+    allow(Manual)
+      .to receive(:find).with(manual.id, user)
+      .and_return(manual)
+    allow(manual)
+      .to receive(:build_section).with(section_attributes)
+      .and_return(new_section)
+    allow(Adapters).to receive(:publishing)
+      .and_return(publishing_api_adapter)
+    allow(publishing_api_adapter).to receive(:save)
+    allow(publishing_api_adapter).to receive(:save_section)
+  end
+
+  context 'when the new section is valid' do
+    before do
+      allow(new_section).to receive(:valid?).and_return(true)
+    end
+
+    it 'marks the manual as draft' do
+      expect(manual).to receive(:draft)
+
+      subject.call
+    end
+
+    it 'saves the draft' do
+      expect(manual).to receive(:save).with(user)
+
+      subject.call
+    end
+
+    it 'saves the draft manual to the publishing api' do
+      expect(publishing_api_adapter)
+        .to receive(:save).with(manual, include_sections: false)
+
+      subject.call
+    end
+
+    it 'saves the new section to the publishing api' do
+      expect(publishing_api_adapter)
+        .to receive(:save_section).with(new_section, manual)
+
+      subject.call
+    end
+  end
+
+  context 'when the new section is invalid' do
+    before do
+      allow(new_section).to receive(:valid?).and_return(false)
+    end
+
+    it 'does not mark the manual as draft' do
+      expect(manual).to_not receive(:draft)
+
+      subject.call
+    end
+
+    it 'saves the draft' do
+      expect(manual).to_not receive(:save)
+
+      subject.call
+    end
+
+    it 'saves the draft manual to the publishing api' do
+      expect(publishing_api_adapter)
+        .to_not receive(:save)
+
+      subject.call
+    end
+
+    it 'saves the new section to the publishing api' do
+      expect(publishing_api_adapter)
+        .to_not receive(:save_section)
+
+      subject.call
+    end
+  end
+end

--- a/spec/services/section/create_service_spec.rb
+++ b/spec/services/section/create_service_spec.rb
@@ -62,6 +62,74 @@ RSpec.describe Section::CreateService do
     end
   end
 
+  context 'when the new section is valid but saving the manual to the publishing api fails' do
+    let(:gds_api_exception) { GdsApi::HTTPErrorResponse.new(422) }
+
+    before do
+      allow(new_section).to receive(:valid?).and_return(true)
+      allow(publishing_api_adapter)
+        .to receive(:save)
+        .and_raise(gds_api_exception)
+    end
+
+    it 'raises the exception from the gds api' do
+      expect { subject.call }.to raise_error(gds_api_exception)
+    end
+
+    it 'marks the manual as draft' do
+      expect(manual).to receive(:draft)
+
+      subject.call rescue gds_api_exception
+    end
+
+    it 'does not save the manual' do
+      expect(manual).to_not receive(:save).with(user)
+
+      subject.call rescue gds_api_exception
+    end
+
+    it 'does not save the section to the publishing api' do
+      expect(publishing_api_adapter)
+        .to_not receive(:save_section)
+
+      subject.call rescue gds_api_exception
+    end
+  end
+
+  context 'when the new section is valid but saving the section to the publishing api fails' do
+    let(:gds_api_exception) { GdsApi::HTTPErrorResponse.new(422) }
+
+    before do
+      allow(new_section).to receive(:valid?).and_return(true)
+      allow(publishing_api_adapter)
+        .to receive(:save_section)
+        .and_raise(gds_api_exception)
+    end
+
+    it 'raises the exception from the gds api' do
+      expect { subject.call }.to raise_error(gds_api_exception)
+    end
+
+    it 'marks the manual as draft' do
+      expect(manual).to receive(:draft)
+
+      subject.call rescue gds_api_exception
+    end
+
+    it 'does not save the manual' do
+      expect(manual).to_not receive(:save).with(user)
+
+      subject.call rescue gds_api_exception
+    end
+
+    it 'saves the draft manual to the publishing api' do
+      expect(publishing_api_adapter)
+        .to receive(:save).with(manual, include_sections: false)
+
+      subject.call rescue gds_api_exception
+    end
+  end
+
   context 'when the new section is invalid' do
     before do
       allow(new_section).to receive(:valid?).and_return(false)


### PR DESCRIPTION
This fixes a specific problem when creating multiple sections in a
manual with the same title. The sections would be saved to the local
database but would fail to save to Publishing API because the slug of
the section would already be in use.

The user will continue to see an error page when attempting to save a
section with a duplicate title. A further improvement will be to either
avoid trying to save the section in the first place (i.e. because we've
determined that it's a duplicate) or to handle the validation errors we
get back from the Publication API.

It's possible that this change will allow us to remove the following
classes that detect different sections sharing the same slug (i.e. the
same title):

* DuplicateDocumentFinder
* DuplicateDraftDeleter