### PR TITLE
Avoid persisting updated sections when saving to Publishing API fails

### DIFF
--- a/app/services/section/update_service.rb
+++ b/app/services/section/update_service.rb
@@ -15,9 +15,9 @@ class Section::UpdateService
 
     if section.valid?
       manual.draft
-      manual.save(user)
       Adapters.publishing.save(manual, include_sections: false)
       Adapters.publishing.save_section(section, manual)
+      manual.save(user)
     end
 
     [manual, section]

--- a/spec/services/section/update_service_spec.rb
+++ b/spec/services/section/update_service_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+RSpec.describe Section::UpdateService do
+  let(:user) { User.gds_editor }
+  let(:manual) { Manual.new(title: 'manual-title') }
+  let(:section_uuid) { 'section-uuid' }
+  let(:publishing_api_adapter) { double(:publishing_api) }
+  let(:section) {
+    Section.new(manual: manual, uuid: section_uuid, editions: [])
+  }
+
+  subject do
+    described_class.new(
+      user: user,
+      manual_id: manual.id,
+      section_uuid: section_uuid,
+      attributes: {}
+    )
+  end
+
+  before do
+    allow(manual).to receive(:sections).and_return([section])
+    allow(manual).to receive(:save)
+    allow(Manual)
+      .to receive(:find).with(manual.id, user)
+      .and_return(manual)
+    allow(Adapters).to receive(:publishing)
+      .and_return(publishing_api_adapter)
+    allow(publishing_api_adapter).to receive(:save)
+    allow(publishing_api_adapter).to receive(:save_section)
+  end
+
+  context 'when the new section is valid' do
+    before do
+      allow(section).to receive(:valid?).and_return(true)
+    end
+
+    it 'marks the manual as draft' do
+      expect(manual).to receive(:draft)
+
+      subject.call
+    end
+
+    it 'saves the draft' do
+      expect(manual).to receive(:save).with(user)
+
+      subject.call
+    end
+
+    it 'saves the draft manual to the publishing api' do
+      expect(publishing_api_adapter)
+        .to receive(:save).with(manual, include_sections: false)
+
+      subject.call
+    end
+
+    it 'saves the new section to the publishing api' do
+      expect(publishing_api_adapter)
+        .to receive(:save_section).with(section, manual)
+
+      subject.call
+    end
+  end
+
+  context 'when the new section is invalid' do
+    before do
+      allow(section).to receive(:valid?).and_return(false)
+    end
+
+    it 'does not mark the manual as draft' do
+      expect(manual).to_not receive(:draft)
+
+      subject.call
+    end
+
+    it 'saves the draft' do
+      expect(manual).to_not receive(:save)
+
+      subject.call
+    end
+
+    it 'saves the draft manual to the publishing api' do
+      expect(publishing_api_adapter)
+        .to_not receive(:save)
+
+      subject.call
+    end
+
+    it 'saves the new section to the publishing api' do
+      expect(publishing_api_adapter)
+        .to_not receive(:save_section)
+
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
Avoid persisting updated section when saving to Publishing API fails

This fixes a specific problem when updating a section and giving it the
same title as another section in the same manual. The changed section
would be saved to the local database but would fail to save to
Publishing API because the slug of the section would already be in use.

The user will continue to see an error page when attempting to save a
section with a duplicate title. A further improvement will be to either
avoid trying to save the section in the first place (i.e. because we've
determined that the title is already in use) or to handle the validation
errors we get back from the Publication API.

This should get us closer to being able to remove the following classes
that detect different sections sharing the same slug (i.e. the same
title):

* DuplicateDocumentFinder
* DuplicateDraftDeleter