### PR TITLE
Various minor improvements to Manual

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -33,7 +33,7 @@ class ManualsController < ApplicationController
   end
 
   def new
-    service = ->() { Manual.new(title: "") }
+    service = ->() { Manual.new({}) }
     manual = service.call
 
     render(:new, locals: { manual: manual_form(manual) })

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -33,7 +33,7 @@ class ManualsController < ApplicationController
   end
 
   def new
-    service = ->() { Manual.new({}) }
+    service = ->() { Manual.new }
     manual = service.call
 
     render(:new, locals: { manual: manual_form(manual) })

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -154,14 +154,14 @@ class Manual
   end
 
   def update(attributes)
-    @slug = attributes.fetch(:slug) { slug }
-    @title = attributes.fetch(:title) { title }
-    @summary = attributes.fetch(:summary) { summary }
-    @body = attributes.fetch(:body) { body }
-    @organisation_slug = attributes.fetch(:organisation_slug) { organisation_slug }
-    @state = attributes.fetch(:state) { state }
-    @originally_published_at = attributes.fetch(:originally_published_at) { originally_published_at }
-    @use_originally_published_at_for_public_timestamp = attributes.fetch(:use_originally_published_at_for_public_timestamp) { use_originally_published_at_for_public_timestamp }
+    @slug = attributes.fetch(:slug, slug)
+    @title = attributes.fetch(:title, title)
+    @summary = attributes.fetch(:summary, summary)
+    @body = attributes.fetch(:body, body)
+    @organisation_slug = attributes.fetch(:organisation_slug, organisation_slug)
+    @state = attributes.fetch(:state, state)
+    @originally_published_at = attributes.fetch(:originally_published_at, originally_published_at)
+    @use_originally_published_at_for_public_timestamp = attributes.fetch(:use_originally_published_at_for_public_timestamp, use_originally_published_at_for_public_timestamp)
   end
 
   def draft

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -116,7 +116,7 @@ class Manual
     }
 
     manual_attrs = default_attrs.merge(attributes)
-    manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title))
+    manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title, ""))
 
     @id = manual_attrs.fetch(:id, SecureRandom.uuid)
     @updated_at = manual_attrs.fetch(:updated_at, nil)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -103,7 +103,7 @@ class Manual
     }
   end
 
-  def initialize(attributes)
+  def initialize(attributes = {})
     slug_generator = SlugGenerator.new(prefix: "guidance")
 
     default_attrs = {

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -107,12 +107,6 @@ class Manual
     slug_generator = SlugGenerator.new(prefix: "guidance")
 
     default_attrs = {
-      summary: "",
-      body: "",
-      state: "draft",
-      organisation_slug: "",
-      originally_published_at: nil,
-      use_originally_published_at_for_public_timestamp: true,
     }
 
     manual_attrs = default_attrs.merge(attributes)
@@ -124,6 +118,15 @@ class Manual
     @ever_been_published = !!manual_attrs.fetch(:ever_been_published, false)
 
     update(manual_attrs)
+
+    @summary ||= ""
+    @body ||= ""
+    @state ||= "draft"
+    @organisation_slug ||= ""
+
+    if @use_originally_published_at_for_public_timestamp.nil?
+      @use_originally_published_at_for_public_timestamp = true
+    end
 
     @sections = manual_attrs.fetch(:sections, [])
     @removed_sections = manual_attrs.fetch(:removed_sections, [])

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -162,8 +162,6 @@ class Manual
     @state = attributes.fetch(:state) { state }
     @originally_published_at = attributes.fetch(:originally_published_at) { originally_published_at }
     @use_originally_published_at_for_public_timestamp = attributes.fetch(:use_originally_published_at_for_public_timestamp) { use_originally_published_at_for_public_timestamp }
-
-    self
   end
 
   def draft

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -270,7 +270,7 @@ class Manual
     def build_manual_for(manual_record, edition: nil, load_associations: true, published: false)
       edition ||= manual_record.latest_edition
 
-      base_manual = Manual.new(
+      base_manual = self.new(
         id: manual_record.manual_id,
         slug: manual_record.slug,
         title: edition.title,
@@ -317,16 +317,16 @@ class Manual
   def current_draft_version(manual_record)
     return nil unless manual_record.latest_edition.state == "draft"
 
-    Manual.build_manual_for(manual_record)
+    self.class.build_manual_for(manual_record)
   end
 
   def current_published_version(manual_record)
     if manual_record.latest_edition.state == "published"
-      Manual.build_manual_for(manual_record)
+      self.class.build_manual_for(manual_record)
     elsif manual_record.latest_edition.state == "draft"
       previous_edition = manual_record.previous_edition
       if previous_edition.state == "published"
-        Manual.build_manual_for(manual_record, edition: previous_edition, published: true)
+        self.class.build_manual_for(manual_record, edition: previous_edition, published: true)
       else
         # This means the previous edition is withdrawn so we shouldn't
         # expose it as it's not actually published (we've got a new

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -137,22 +137,6 @@ class Manual
     id.eql? other.id
   end
 
-  def attributes
-    {
-      id: id,
-      slug: slug,
-      title: title,
-      summary: summary,
-      body: body,
-      organisation_slug: organisation_slug,
-      state: state,
-      version_number: version_number,
-      updated_at: updated_at,
-      originally_published_at: originally_published_at,
-      use_originally_published_at_for_public_timestamp: use_originally_published_at_for_public_timestamp,
-    }
-  end
-
   def update(attributes)
     @slug = attributes.fetch(:slug, slug)
     @title = attributes.fetch(:title, title)

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -106,18 +106,14 @@ class Manual
   def initialize(attributes = {})
     slug_generator = SlugGenerator.new(prefix: "guidance")
 
-    default_attrs = {
-    }
+    attributes[:slug] ||= slug_generator.call(attributes.fetch(:title, ""))
 
-    manual_attrs = default_attrs.merge(attributes)
-    manual_attrs[:slug] ||= slug_generator.call(attributes.fetch(:title, ""))
+    @id = attributes.fetch(:id, SecureRandom.uuid)
+    @updated_at = attributes.fetch(:updated_at, nil)
+    @version_number = attributes.fetch(:version_number, 0)
+    @ever_been_published = !!attributes.fetch(:ever_been_published, false)
 
-    @id = manual_attrs.fetch(:id, SecureRandom.uuid)
-    @updated_at = manual_attrs.fetch(:updated_at, nil)
-    @version_number = manual_attrs.fetch(:version_number, 0)
-    @ever_been_published = !!manual_attrs.fetch(:ever_been_published, false)
-
-    update(manual_attrs)
+    update(attributes)
 
     @summary ||= ""
     @body ||= ""
@@ -128,8 +124,8 @@ class Manual
       @use_originally_published_at_for_public_timestamp = true
     end
 
-    @sections = manual_attrs.fetch(:sections, [])
-    @removed_sections = manual_attrs.fetch(:removed_sections, [])
+    @sections = attributes.fetch(:sections, [])
+    @removed_sections = attributes.fetch(:removed_sections, [])
   end
 
   def to_param

--- a/app/services/manual/preview_service.rb
+++ b/app/services/manual/preview_service.rb
@@ -20,11 +20,7 @@ private
   end
 
   def ephemeral_manual
-    Manual.new(
-      attributes.reverse_merge(
-        title: ""
-      )
-    )
+    Manual.new(attributes)
   end
 
   def existing_manual

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -32,7 +32,7 @@ describe Manual do
   let(:slug) { "manual-slug" }
 
   it "generates an ID if none is provided" do
-    manual = Manual.new({})
+    manual = Manual.new
     expect(manual.id).to be_present
   end
 

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -104,24 +104,6 @@ describe Manual do
     end
   end
 
-  describe "#attributes" do
-    it "returns a hash of attributes" do
-      expect(manual.attributes).to eq(
-        id: id,
-        title: title,
-        slug: slug,
-        summary: summary,
-        body: body,
-        organisation_slug: organisation_slug,
-        state: state,
-        updated_at: updated_at,
-        version_number: 10,
-        originally_published_at: originally_published_at,
-        use_originally_published_at_for_public_timestamp: use_originally_published_at_for_public_timestamp,
-      )
-    end
-  end
-
   describe "#publication_state" do
     context "for a manual in the draft state" do
       let(:state) { "draft" }

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -32,7 +32,7 @@ describe Manual do
   let(:slug) { "manual-slug" }
 
   it "generates an ID if none is provided" do
-    manual = Manual.new(title: "manual-title")
+    manual = Manual.new({})
     expect(manual.id).to be_present
   end
 

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -167,10 +167,6 @@ describe Manual do
   end
 
   describe "#update" do
-    it "returns self" do
-      expect(manual.update({})).to be(manual)
-    end
-
     context "with allowed attirbutes" do
       let(:new_title) { "new-manual-title" }
       let(:new_summary) { "new-manual-summary" }


### PR DESCRIPTION
This is a rather miscellaneous set of changes which aim to simplify the `Manual` class, more specifically the `#initialize` & `#update` methods. My motivation was to move `Manual` towards being more like a `Mongoid::Document` class.

@chrislo & I are also hoping this will help us fix a deprecation warning which is triggered when we upgrade to Rails v5, because of the use of `HashWithIndifferentAccess#symbolize_keys`.