### PR TITLE
Reintroduce Attachment#to_param

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -13,6 +13,10 @@ class Attachment
 
   before_save :upload_file, if: :file_has_changed?
 
+  def to_param
+    id.to_s
+  end
+
   def snippet
     "[InlineAttachment:#{filename}]"
   end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -94,4 +94,37 @@ describe Attachment do
       end
     end
   end
+
+  describe "#to_param" do
+    context "when attachment is not persisted" do
+      it "returns a string ID" do
+        expect(attachment.to_param).to be_an_instance_of(String)
+      end
+    end
+
+    context "when attachment is persisted" do
+      let(:section_edition) { SectionEdition.new }
+
+      before do
+        section_edition.attachments << attachment
+        attachment.save!
+      end
+
+      it "returns a string ID" do
+        expect(attachment.to_param).to be_an_instance_of(String)
+      end
+
+      context "but has been added to a new section edition" do
+        let(:another_section_edition) { SectionEdition.new }
+
+        before do
+          another_section_edition.attachments << attachment
+        end
+
+        it "returns a string ID" do
+          expect(attachment.to_param).to be_an_instance_of(String)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This was originally introduced in [this commit][1], but then removed in [this commit][2] in order to fix a problem in generating a URL for an attachment for [a call to `link_to` in the section form partial][3]:

    NoMethodError: undefined method `empty?' for BSON::ObjectId('590c3b4740f0b60d80000004'):BSON::ObjectId

In the absence of a custom definition, `Attachement#to_param` is provided via [`ActiveModel::Conversion#to_param`][4] which in turn calls [`Mongoid::Document#to_key`][5]. The default behaviour of this is to return a String ID if the object is persisted (or destroyed), but to return `nil` if the object is a new object.

When we attempt to update a published section with an attachment, but validation fails (see #1143), `Section#update` builds a new draft edition of the section and assigns the attachments from the previous edition to it. Unfortunately, because the attachments are "embedded" in the edition, Mongoid treats them as not having been persisted. This kind of makes sense, because they really don't exist in the database at this point; they only exist embedded in the previous edition.

Thus at this point `Attachment#to_param` returns `nil` which causes the `ActionController::UrlGenerationError` exception described in #1143 when the same call to `link_to` is made from the section form partial.

My slightly bodge-y fix is to reintroduce a custom implementation of `Attachment#to_param`, but avoiding the `NoMethodError: undefined method `empty?'` exception by calling `BSON::ObjectId#to_s`. Thus this fixes the problem described in #1143, but does not reintroduce the problem fixed in [this commit][2].

Unfortunately I can't see a way to retain the behaviour where a genuinely new (non-persisted) attachment returns `nil` from `#to_param`, but since all the tests pass, I'm hoping that this won't have any unfortunate consequences.

I can't help feeling that there should be a better way to fix the problem. Perhaps a better solution would be to stop embedding the attachments in the `SectionEdition`, i.e. make them first class documents in the database, and use a `has_and_belongs_to_many` association. That way multiple section editions could reference the same attachments and if a new edition was referencing attachments already added to a previous edition, Mongoid would consider them as persisted and the default implementation of `#to_param` would be sufficient for the problematic call to `link_to`.

Fixes #1143.

[1]: https://github.com/alphagov/manuals-publisher/commit/3b2d5c8ae14c1132a6bf04d702bd663db29408ff
[2]: https://github.com/alphagov/manuals-publisher/commit/c6554adb6e37be9f0ecc0931b03d742ced50545f
[3]: https://github.com/alphagov/manuals-publisher/blob/ab731b371f3d33b966696f72b342b70814477d2a/app/views/sections/_form.html.erb#L66
[4]: https://github.com/rails/rails/blob/v4.2.8/activemodel/lib/active_model/conversion.rb#L58-L73
[5]: https://github.com/mongodb/mongoid/blob/v5.2.1/lib/mongoid/document.rb#L133-L143