### PR TITLE
Avoid persisting new manuals when saving to Publishing API fails

### DIFF
--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -10,8 +10,8 @@ class Manual::CreateService
     manual = Manual.new(attributes)
 
     if manual.valid?
-      manual.save(user)
       Adapters.publishing.save(manual)
+      manual.save(user)
     end
 
     manual

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -11,8 +11,7 @@ class Manual::CreateService
 
     if manual.valid?
       manual.save(user)
-      reloaded_manual = Manual.find(manual.id, user)
-      Adapters.publishing.save(reloaded_manual)
+      Adapters.publishing.save(manual)
     end
 
     manual

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -7,6 +7,8 @@ class Manual::CreateService
   end
 
   def call
+    manual = Manual.new(attributes)
+
     if manual.valid?
       manual.save(user)
       reloaded_manual = Manual.find(manual.id, user)
@@ -19,8 +21,4 @@ class Manual::CreateService
 private
 
   attr_reader :user, :attributes
-
-  def manual
-    @manual ||= Manual.new(attributes)
-  end
 end

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -9,7 +9,8 @@ class Manual::CreateService
   def call
     if manual.valid?
       manual.save(user)
-      export_draft_to_publishing_api
+      reloaded_manual = Manual.find(manual.id, user)
+      Adapters.publishing.save(reloaded_manual)
     end
 
     manual
@@ -21,10 +22,5 @@ private
 
   def manual
     @manual ||= Manual.new(attributes)
-  end
-
-  def export_draft_to_publishing_api
-    reloaded_manual = Manual.find(manual.id, user)
-    Adapters.publishing.save(reloaded_manual)
   end
 end

--- a/app/services/manual/create_service.rb
+++ b/app/services/manual/create_service.rb
@@ -8,7 +8,7 @@ class Manual::CreateService
 
   def call
     if manual.valid?
-      persist
+      manual.save(user)
       export_draft_to_publishing_api
     end
 
@@ -21,10 +21,6 @@ private
 
   def manual
     @manual ||= Manual.new(attributes)
-  end
-
-  def persist
-    manual.save(user)
   end
 
   def export_draft_to_publishing_api

--- a/spec/services/manual/create_service_spec.rb
+++ b/spec/services/manual/create_service_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+RSpec.describe Manual::CreateService do
+  let(:user) { double(:user) }
+  let(:manual) { double(:manual, valid?: nil, save: nil) }
+  let(:publishing_api_adapter) { double(:publishing_api_adapter, save: nil) }
+
+  subject do
+    described_class.new(
+      user: user,
+      attributes: {}
+    )
+  end
+
+  before do
+    allow(Manual).to receive(:new).and_return(manual)
+    allow(Adapters)
+      .to receive(:publishing).and_return(publishing_api_adapter)
+  end
+
+  context 'when the manual is valid' do
+    before do
+      allow(manual).to receive(:valid?).and_return(true)
+    end
+
+    it 'saves the manual' do
+      expect(manual).to receive(:save)
+      subject.call
+    end
+
+    it 'saves the manual to the Publishing API' do
+      expect(publishing_api_adapter).to receive(:save).with(manual)
+      subject.call
+    end
+  end
+
+  context 'when the manual is not valid' do
+    before do
+      allow(manual).to receive(:valid?).and_return(false)
+    end
+
+    it 'does not save the manual' do
+      expect(manual).to_not receive(:save)
+      subject.call
+    end
+
+    it 'does not save the manual to the Publishing API' do
+      expect(publishing_api_adapter).to_not receive(:save).with(manual)
+      subject.call
+    end
+  end
+end

--- a/spec/services/manual/create_service_spec.rb
+++ b/spec/services/manual/create_service_spec.rb
@@ -34,6 +34,25 @@ RSpec.describe Manual::CreateService do
     end
   end
 
+  context 'when the manual is valid but saving it to the Publishing API fails' do
+    let(:gds_api_exception) { GdsApi::HTTPErrorResponse.new(422) }
+
+    before do
+      allow(manual).to receive(:valid?).and_return(true)
+      allow(publishing_api_adapter)
+        .to receive(:save).and_raise(gds_api_exception)
+    end
+
+    it 'raises the exception' do
+      expect { subject.call }.to raise_error(gds_api_exception)
+    end
+
+    it 'does not save the manual' do
+      expect(manual).to_not receive(:save)
+      subject.call rescue gds_api_exception
+    end
+  end
+
   context 'when the manual is not valid' do
     before do
       allow(manual).to receive(:valid?).and_return(false)


### PR DESCRIPTION
This fixes a specific problem when creating a manual and giving it the
same title as another manual. The new manual would be saved to the
local database but would fail to save to Publishing API because the slug
of the manual would already be in use.

The user will continue to see an error page when attempting to save a
manual with a duplicate title. A further improvement will be to either
avoid trying to save the manual in the first place (i.e. because we've
determined that the title is already in use) or to handle the validation
errors we get back from the Publication API.