### PR TITLE
Extract Manual#find_section

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -212,6 +212,10 @@ class Manual
     sections.select(&:needs_exporting?).all? { |s| s.version_type == :minor }
   end
 
+  def find_section(section_uuid)
+    sections.find { |section| section.uuid == section_uuid }
+  end
+
   def build_section(attributes)
     section = Section.new(manual: self, uuid: SecureRandom.uuid, editions: [])
 
@@ -238,7 +242,7 @@ class Manual
   end
 
   def remove_section(section_uuid)
-    found_section = sections.find { |d| d.uuid == section_uuid }
+    found_section = find_section(section_uuid)
 
     return if found_section.nil?
 

--- a/app/services/attachment/create_service.rb
+++ b/app/services/attachment/create_service.rb
@@ -19,7 +19,7 @@ private
   attr_reader :user, :manual_id, :section_uuid, :attributes
 
   def section
-    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
+    @section ||= manual.find_section(section_uuid)
   end
 
   def manual

--- a/app/services/attachment/new_service.rb
+++ b/app/services/attachment/new_service.rb
@@ -18,7 +18,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
+    @section ||= manual.find_section(section_uuid)
   end
 
   def manual

--- a/app/services/attachment/show_service.rb
+++ b/app/services/attachment/show_service.rb
@@ -19,7 +19,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
+    @section ||= manual.find_section(section_uuid)
   end
 
   def manual

--- a/app/services/attachment/update_service.rb
+++ b/app/services/attachment/update_service.rb
@@ -24,7 +24,7 @@ private
   end
 
   def section
-    @section ||= manual.sections.find { |s| s.uuid == section_uuid }
+    @section ||= manual.find_section(section_uuid)
   end
 
   def manual

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -9,9 +9,7 @@ class Section::PreviewService
   def call
     manual = Manual.find(manual_id, user)
     section = if section_uuid
-                manual.sections.find { |sec|
-                  sec.uuid == section_uuid
-                }
+                manual.find_section(section_uuid)
               else
                 manual.build_section(attributes)
               end

--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -15,7 +15,7 @@ class Section::RemoveService
       raise ManualNotFoundError.new(manual_id)
     end
 
-    section = manual.sections.find { |s| s.uuid == section_uuid }
+    section = manual.find_section(section_uuid)
     raise SectionNotFoundError.new(section_uuid) unless section.present?
 
     change_note_params = {

--- a/app/services/section/show_service.rb
+++ b/app/services/section/show_service.rb
@@ -7,7 +7,7 @@ class Section::ShowService
 
   def call
     manual = Manual.find(manual_id, user)
-    section = manual.sections.find { |s| s.uuid == section_uuid }
+    section = manual.find_section(section_uuid)
     [manual, section]
   end
 

--- a/app/services/section/update_service.rb
+++ b/app/services/section/update_service.rb
@@ -10,7 +10,7 @@ class Section::UpdateService
 
   def call
     manual = Manual.find(manual_id, user)
-    section = manual.sections.find { |s| s.uuid == section_uuid }
+    section = manual.find_section(section_uuid)
     section.update(attributes)
 
     if section.valid?

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -36,6 +36,23 @@ describe Manual do
     expect(manual.id).to be_present
   end
 
+  describe '#find_section' do
+    it 'returns the section if found' do
+      manual = Manual.new
+      section = manual.build_section({})
+
+      found_manual = manual.find_section(section.uuid)
+      expect(found_manual).to eql(section)
+    end
+
+    it "returns nil if the section can't be found" do
+      manual = Manual.new
+
+      found_manual = manual.find_section('made-up-uuid')
+      expect(found_manual).to eql(nil)
+    end
+  end
+
   describe "#eql?" do
     it "is considered the same as another manual instance if they have the same id" do
       expect(manual).to eql(manual)

--- a/spec/services/section/remove_service_spec.rb
+++ b/spec/services/section/remove_service_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Section::RemoveService do
   let(:manual) {
     double(
       draft: nil,
-      sections: [
-        section,
-      ],
       remove_section: nil,
+      find_section: section
     )
   }
 
@@ -40,6 +38,7 @@ RSpec.describe Section::RemoveService do
         draft: nil,
         sections: [],
         remove_section: nil,
+        find_section: nil
       )
     }
     let(:change_note_params) do


### PR DESCRIPTION
We remove a certain amount of duplication by extracting this method and
using it instead of manually iterating over the `Manual#sections`.