### PR TITLE
Gemfile-related changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "rails", "~> 5.0.0"
 
 # Alphabetical order please :)
-gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
+gem 'airbrake', git: 'https://github.com/alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem "faraday", "0.9.0"
 gem "gds-sso"
 gem "generic_form_builder", "0.11.0"

--- a/Gemfile
+++ b/Gemfile
@@ -17,11 +17,6 @@ gem "sidekiq-statsd", "0.1.5"
 gem "state_machine", "1.2.0"
 gem "unicorn", "4.8.2"
 
-# We only need this for tests and rails 3.2 and ruby 2.2
-# however, it can't be in a gem group that isn't installed
-# on production environments or the console won't load
-gem 'test-unit', require: false
-
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "rails", "~> 5.0.0"
 # Alphabetical order please :)
 gem 'airbrake', git: 'https://github.com/alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem "gds-sso"
-gem "generic_form_builder", "0.11.0"
+gem "generic_form_builder"
 gem "govuk_admin_template"
 gem "logstasher", "0.4.8"
 gem "mongoid", "~> 6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "mongoid", "~> 6.0"
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code"
 gem "plek", "1.12.0"
 gem "raindrops", ">= 0.13.0" # we need a version > 0.13.0 for ruby 2.2
-gem "rake"
 gem "sidekiq", "3.2.1"
 gem "sidekiq-statsd", "0.1.5"
 gem "state_machine", "1.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem "rails", "~> 5.0.0"
 
 # Alphabetical order please :)
 gem 'airbrake', git: 'https://github.com/alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
-gem "faraday", "0.9.0"
 gem "gds-sso"
 gem "generic_form_builder", "0.11.0"
 gem "govuk_admin_template"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "govuk_admin_template"
 gem "logstasher", "0.4.8"
 gem "mongoid", "~> 6.0"
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code"
-gem "plek", "1.12.0"
+gem "plek"
 gem "raindrops", ">= 0.13.0" # we need a version > 0.13.0 for ruby 2.2
 gem "sidekiq", "3.2.1"
 gem "sidekiq-statsd", "0.1.5"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "govuk_admin_template"
 gem "logstasher", "0.4.8"
 gem "mongoid", "~> 6.0"
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code"
-gem "multi_json", "1.10.0"
 gem "plek", "1.12.0"
 gem "raindrops", ">= 0.13.0" # we need a version > 0.13.0 for ruby 2.2
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,7 +422,6 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mongoid (~> 6.0)
   mongoid_rails_migrations!
-  multi_json (= 1.10.0)
   phantomjs (>= 1.9.7.1)
   plek (= 1.12.0)
   poltergeist (~> 1.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,6 @@ GEM
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    power_assert (1.0.1)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -362,8 +361,6 @@ GEM
       sprockets (>= 3.0.0)
     state_machine (1.2.0)
     statsd-ruby (1.2.1)
-    test-unit (3.2.3)
-      power_assert
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -435,7 +432,6 @@ DEPENDENCIES
   simplecov
   sinatra (~> 2.0)
   state_machine (= 1.2.0)
-  test-unit
   timecop
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       rails (>= 4.2.4)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    generic_form_builder (0.11.0)
+    generic_form_builder (0.13.0)
     gherkin3 (3.1.2)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -407,7 +407,7 @@ DEPENDENCIES
   foreman
   gds-api-adapters (~> 45.0)
   gds-sso
-  generic_form_builder (= 0.11.0)
+  generic_form_builder
   govspeak (~> 3.1)
   govuk-content-schema-test-helpers (= 1.4.0)
   govuk-lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/alphagov/airbrake.git
+  remote: https://github.com/alphagov/airbrake
   revision: ad9c926a56535c48f95c33824a76e10bc8f91179
   branch: silence-dep-warnings-for-rails-5
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,6 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.0.0)
   raindrops (>= 0.13.0)
-  rake
   rspec
   rspec-rails
   sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     phantomjs (2.1.1.0)
-    plek (1.12.0)
+    plek (2.0.0)
     poltergeist (1.13.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -419,7 +419,7 @@ DEPENDENCIES
   mongoid (~> 6.0)
   mongoid_rails_migrations!
   phantomjs (>= 1.9.7.1)
-  plek (= 1.12.0)
+  plek
   poltergeist (~> 1.13.0)
   pry-byebug
   rails (~> 5.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,7 +407,6 @@ DEPENDENCIES
   cucumber-rails (~> 1.4.0)
   database_cleaner
   factory_girl_rails
-  faraday (= 0.9.0)
   foreman
   gds-api-adapters (~> 45.0)
   gds-sso


### PR DESCRIPTION
* Avoid bundler warning
* Remove explicit dependencies on multi_json & rake gems
* Remove redundant faraday & test-unit gems
* Upgrade generic_form_builder & plek gems to latest version

There is still more work that can be done here, but at least this is a start.