### PR TITLE
Accept new framework defaults

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -12,7 +12,7 @@ Rails.application.config.raise_on_unfiltered_parameters = true
 Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -19,4 +19,4 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 ActiveSupport.to_time_preserves_timezone = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true
+ActiveSupport.halt_callback_chains_on_return_false = false

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -9,7 +9,7 @@
 Rails.application.config.raise_on_unfiltered_parameters = true
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
 Rails.application.config.action_controller.forgery_protection_origin_check = false

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -16,7 +16,7 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
 ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
This PR toggles the boolean flags in `config/initializers/new_framework_defaults.rb` so that our application has the same behaviour, with regards to these settings, as a new Rails 5.0.3 application. The only parameter that has not been toggled is Rails.application.config.raise_on_unfiltered_parameters which was already set to the default `true` in 4d2b4931.