### PR TITLE
Upgrade mongoid_rails_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "generic_form_builder"
 gem "govuk_admin_template"
 gem "logstasher", "0.4.8"
 gem "mongoid", "~> 6.0"
-gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code"
+gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.0.0"
 gem "plek"
 gem "raindrops", ">= 0.13.0" # we need a version > 0.13.0 for ruby 2.2
 gem "sidekiq", "3.2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "generic_form_builder"
 gem "govuk_admin_template"
 gem "logstasher", "0.4.8"
 gem "mongoid", "~> 6.0"
-gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.0.0"
+gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 gem "plek"
 gem "raindrops", ">= 0.13.0" # we need a version > 0.13.0 for ruby 2.2
 gem "sidekiq", "3.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 GIT
   remote: https://github.com/alphagov/mongoid_rails_migrations
   revision: 4db234408a335d336a45f840e0f72c585031859b
-  branch: avoid-calling-bundler-require-in-library-code
+  branch: avoid-calling-bundler-require-in-library-code-v1.0.0
   specs:
     mongoid_rails_migrations (1.0.0)
       activesupport (>= 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,14 +10,15 @@ GIT
 
 GIT
   remote: https://github.com/alphagov/mongoid_rails_migrations
-  revision: 4db234408a335d336a45f840e0f72c585031859b
-  branch: avoid-calling-bundler-require-in-library-code-v1.0.0
+  revision: 7dc2c19549698f5666d2a91e89a9845480e852c4
+  branch: avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix
   specs:
-    mongoid_rails_migrations (1.0.0)
-      activesupport (>= 3.2.0)
+    mongoid_rails_migrations (1.1.0)
+      activesupport (>= 4.2.0)
       bundler (>= 1.0.0)
-      rails (>= 3.2.0)
-      railties (>= 3.2.0)
+      mongoid (>= 4.0.0)
+      rails (>= 4.2.0)
+      railties (>= 4.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/db/migrate/20170320160403_rename_specialist_document_editions_collection_to_section_editions.rb
+++ b/db/migrate/20170320160403_rename_specialist_document_editions_collection_to_section_editions.rb
@@ -8,7 +8,7 @@ class RenameSpecialistDocumentEditionsCollectionToSectionEditions < Mongoid::Mig
   end
 
   def self.rename_collection(source, target)
-    db = Mongoid.database
+    db = connection.database
     if db.collection_names.include?(target)
       if db.collection(target).count == 0
         db.drop_collection(target)


### PR DESCRIPTION
This upgrades the gem to make it compatible with the current versions of Mongoid (v6) and Rails (v5). Unfortunately it wasn't possible to use the latest release version (v1.1.0) directly and the problem described in #816 still exists.

So I've had to construct a [new branch in the alphagov fork](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.1.0...alphagov:avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix) which incorporates the following:

* The one unreleased commit from the master branch of the canonical repo.
* One commit from an open PR on the canonical repo.
* My original fix commit for #816.

See the 2nd commit note for more details.

While this definitely isn't ideal, I think it leaves us in a better state than we were, because we can now write migrations again post the Rails upgrade.

Given that the maintainer of the canonical repo doesn't seem to be responding and/or sympathetic to the requested changes, I think we should definitely investigate alternatives.