### PR TITLE
Avoid exposing editions from Section

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -333,7 +333,7 @@ class Manual
 
   def destroy
     sections.each do |section|
-      section.editions.each(&:destroy)
+      section.all_editions.each(&:destroy)
     end
 
     manual_record = ManualRecord.find_by(manual_id: id)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -44,6 +44,10 @@ class Section
     @latest_edition = @editions.last
   end
 
+  def update_slug!(full_new_section_slug)
+    latest_edition.update_attribute(:slug, full_new_section_slug)
+  end
+
   def save
     # It is actually only necessary to save the latest edition, however, I
     # think it's safer to save latest two as both are exposed to the and have

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -31,7 +31,7 @@ class Section
 
   def_delegators :latest_edition, :title, :slug, :summary, :body, :updated_at, :version_number, :change_note, :minor_update
 
-  attr_reader :uuid, :editions, :latest_edition
+  attr_reader :uuid, :latest_edition
 
   def initialize(manual:, uuid:, editions:)
     @slug_generator = SlugGenerator.new(prefix: manual.slug)
@@ -173,7 +173,7 @@ class Section
 
 private
 
-  attr_reader :slug_generator
+  attr_reader :slug_generator, :editions
 
   def published_edition
     most_recent_non_draft = editions.reject(&:draft?).last

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -31,7 +31,7 @@ class Section
 
   def_delegators :latest_edition, :title, :slug, :summary, :body, :updated_at, :version_number, :change_note, :minor_update, :exported_at
 
-  attr_reader :uuid, :latest_edition
+  attr_reader :uuid
 
   def initialize(manual:, uuid:, editions:)
     @slug_generator = SlugGenerator.new(prefix: manual.slug)
@@ -181,7 +181,7 @@ class Section
 
 private
 
-  attr_reader :slug_generator, :editions
+  attr_reader :slug_generator, :editions, :latest_edition
 
   def published_edition
     most_recent_non_draft = editions.reject(&:draft?).last

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -29,7 +29,7 @@ class Section
     end
   end
 
-  def_delegators :latest_edition, :title, :slug, :summary, :body, :updated_at, :version_number, :change_note, :minor_update
+  def_delegators :latest_edition, :title, :slug, :summary, :body, :updated_at, :version_number, :change_note, :minor_update, :exported_at
 
   attr_reader :uuid, :latest_edition
 
@@ -135,6 +135,10 @@ class Section
 
   def needs_exporting?
     latest_edition.exported_at.nil?
+  end
+
+  def reload
+    latest_edition.reload
   end
 
   def mark_as_exported!(exported_at = Time.zone.now)

--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -64,7 +64,7 @@ private
   end
 
   def update_slug
-    new_edition_for_slug_change.update_attribute(:slug, full_new_section_slug)
+    new_edition_for_slug_change.update_slug!(full_new_section_slug)
   end
 
   def new_edition_for_slug_change
@@ -83,7 +83,7 @@ private
       }
     )
     _manual, section = service.call
-    section.latest_edition
+    section
   end
 
   def change_note

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Publishing manuals", type: :feature do
     end
 
     it "sets the exported_at timestamp on the section" do
-      expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of publish_time
+      expect(@sections.first.reload.exported_at).to be_within(1.second).of publish_time
     end
   end
 end

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not change the exported timestamp" do
-      expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
+      expect(@sections.first.reload.exported_at).to be_within(1.second).of original_publish_time
     end
   end
 
@@ -106,7 +106,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not change the exported timestamp" do
-      expect(@sections.first.latest_edition.reload.exported_at).to be_nil
+      expect(@sections.first.reload.exported_at).to be_nil
     end
   end
 
@@ -159,11 +159,11 @@ RSpec.describe "Republishing manuals", type: :feature do
     end
 
     it "does not set the exported timestamp of the draft version of the section" do
-      expect(@edited_sections.first.latest_edition.reload.exported_at).to be_nil
+      expect(@edited_sections.first.reload.exported_at).to be_nil
     end
 
     it "does not set the exported timestamp of the previously published version of the section" do
-      expect(@sections.first.latest_edition.reload.exported_at).to be_within(1.second).of original_publish_time
+      expect(@sections.first.reload.exported_at).to be_within(1.second).of original_publish_time
     end
   end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -110,6 +110,21 @@ describe Section do
     allow(SlugGenerator).to receive(:new).with(prefix: manual_slug).and_return(slug_generator)
   end
 
+  describe '#update_slug!' do
+    it 'updates the slug of the section' do
+      allow(SlugGenerator).to receive(:new).and_call_original
+
+      manual = Manual.new(title: 'manual-title')
+      section = manual.build_section(title: 'section-title')
+      manual.save(User.gds_editor)
+
+      updated_slug = 'guidance/manual-title/new-section-slug'
+      section.update_slug!(updated_slug)
+
+      expect(section.reload.slug).to eq(updated_slug)
+    end
+  end
+
   describe '#exported_at' do
     it 'returns the date and time that the section was marked as exported' do
       exported_at = Time.zone.now

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -110,6 +110,23 @@ describe Section do
     allow(SlugGenerator).to receive(:new).with(prefix: manual_slug).and_return(slug_generator)
   end
 
+  describe '#exported_at' do
+    it 'returns the date and time that the section was marked as exported' do
+      exported_at = Time.zone.now
+      subject.mark_as_exported!(exported_at)
+      expect(subject.exported_at).to eq(exported_at)
+    end
+  end
+
+  describe '#reload' do
+    let(:editions) { [draft_edition_v1] }
+
+    it 'reloads the latest edition of this section' do
+      expect(draft_edition_v1).to receive(:reload)
+      subject.reload
+    end
+  end
+
   describe '.find' do
     context 'when there are associated section editions' do
       let(:section_edition) { FactoryGirl.build(:section_edition) }


### PR DESCRIPTION
The `SectionEdition`s are an implementation detail of `Section` and shouldn't be accessed from outside that class. This branch removes uses of `Section#editions` and `Section#latest_edition` and makes these methods private.