### PR TITLE
Construct Sections with previous and latest editions

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -217,7 +217,7 @@ class Manual
   end
 
   def build_section(attributes)
-    section = Section.new(manual: self, uuid: SecureRandom.uuid, editions: [])
+    section = Section.new(manual: self, uuid: SecureRandom.uuid)
 
     defaults = {
       minor_update: false,

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -36,12 +36,17 @@ class Section
   def initialize(manual:, uuid:, previous_edition: nil, latest_edition: nil)
     @slug_generator = SlugGenerator.new(prefix: manual.slug)
     @uuid = uuid
-    @editions = [previous_edition, latest_edition].compact.uniq
-    if @editions.empty?
-      edition = SectionEdition.new(state: "draft", version_number: 1, section_uuid: uuid)
-      @editions.push(edition)
+
+    @previous_edition = previous_edition
+    @latest_edition = latest_edition
+
+    if @previous_edition == @latest_edition
+      @previous_edition = nil
     end
-    @latest_edition = @editions.last
+
+    if @latest_edition.nil?
+      @latest_edition = SectionEdition.new(state: "draft", version_number: 1, section_uuid: uuid)
+    end
   end
 
   def update_slug!(full_new_section_slug)
@@ -53,7 +58,8 @@ class Section
     # think it's safer to save latest two as both are exposed to the and have
     # potential to change. This extra write may save a potential future
     # headache.
-    editions.last(2).each(&:save!)
+    previous_edition && previous_edition.save!
+    latest_edition.save!
   end
 
   def minor_update?
@@ -86,20 +92,20 @@ class Section
           slug: slug,
           attachments: attachments,
         )
+      @previous_edition = latest_edition
       @latest_edition = SectionEdition.new(attributes)
-
-      editions.push(@latest_edition)
     end
 
     nil
   end
 
   def published?
-    editions.any?(&:published?)
+    latest_edition.published? ||
+      (previous_edition && previous_edition.published?)
   end
 
   def has_ever_been_published?
-    return false if @editions.size == 1 && needs_exporting?
+    return false if previous_edition.nil? && needs_exporting?
     published?
   end
 
@@ -152,7 +158,8 @@ class Section
   end
 
   def persisted?
-    editions.any?(&:persisted?)
+    latest_edition.persisted? ||
+      (previous_edition && previous_edition.persisted?)
   end
 
   def eql?(other)
@@ -181,10 +188,14 @@ class Section
 
 private
 
-  attr_reader :slug_generator, :editions, :latest_edition
+  attr_reader :slug_generator, :latest_edition, :previous_edition
 
   def published_edition
-    most_recent_non_draft = editions.reject(&:draft?).last
+    most_recent_non_draft = if !latest_edition.draft?
+                              latest_edition
+                            elsif previous_edition && !previous_edition.draft?
+                              previous_edition
+                            end
 
     if most_recent_non_draft && most_recent_non_draft.published?
       most_recent_non_draft

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -25,7 +25,7 @@ class Section
     if editions.empty?
       raise KeyError.new("key not found #{section_uuid}")
     else
-      Section.new(manual: manual, uuid: section_uuid, editions: editions)
+      Section.new(manual: manual, uuid: section_uuid, previous_edition: editions.first, latest_edition: editions.last)
     end
   end
 
@@ -33,10 +33,10 @@ class Section
 
   attr_reader :uuid
 
-  def initialize(manual:, uuid:, editions:)
+  def initialize(manual:, uuid:, previous_edition: nil, latest_edition: nil)
     @slug_generator = SlugGenerator.new(prefix: manual.slug)
     @uuid = uuid
-    @editions = editions
+    @editions = [previous_edition, latest_edition].compact.uniq
     if @editions.empty?
       edition = SectionEdition.new(state: "draft", version_number: 1, section_uuid: uuid)
       @editions.push(edition)

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -44,7 +44,7 @@ describe PublishingAdapter do
     Section.new(
       manual: manual,
       uuid: section_uuid,
-      editions: [section_edition],
+      latest_edition: section_edition,
     )
   }
 
@@ -543,7 +543,7 @@ describe PublishingAdapter do
       Section.new(
         manual: manual,
         uuid: removed_section_uuid,
-        editions: [removed_section_edition],
+        latest_edition: removed_section_edition,
       )
     }
 

--- a/spec/adapters/search_index_adapter_spec.rb
+++ b/spec/adapters/search_index_adapter_spec.rb
@@ -23,7 +23,7 @@ describe SearchIndexAdapter do
     Section.new(
       manual: manual,
       uuid: "section-id",
-      editions: [section_edition],
+      latest_edition: section_edition,
     )
   }
 
@@ -40,7 +40,7 @@ describe SearchIndexAdapter do
     Section.new(
       manual: manual,
       uuid: "removed-section-id",
-      editions: [removed_section_edition],
+      latest_edition: removed_section_edition,
     )
   }
 

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe SectionsController, type: :controller do
   describe "#create" do
     let(:manual) { Manual.new }
-    let(:section) { Section.new(manual: manual, uuid: 'section-uuid', editions: []) }
+    let(:section) { Section.new(manual: manual, uuid: 'section-uuid') }
     let(:service) { double(:service, call: [manual, section]) }
 
     before do
@@ -29,7 +29,7 @@ describe SectionsController, type: :controller do
 
   describe "#update" do
     let(:manual) { Manual.new }
-    let(:section) { Section.new(manual: manual, uuid: 'section-uuid', editions: []) }
+    let(:section) { Section.new(manual: manual, uuid: 'section-uuid') }
     let(:service) { double(:service, call: [manual, section]) }
 
     before do
@@ -55,7 +55,7 @@ describe SectionsController, type: :controller do
 
   describe "#preview" do
     let(:manual) { Manual.new }
-    let(:section) { Section.new(manual: manual, uuid: 'section-uuid', editions: []) }
+    let(:section) { Section.new(manual: manual, uuid: 'section-uuid') }
     let(:service) { double(:service, call: section) }
 
     before do
@@ -144,7 +144,7 @@ describe SectionsController, type: :controller do
 
   context 'for a user that can withdraw' do
     let(:manual) { Manual.new }
-    let(:section) { Section.new(manual: manual, uuid: 'section-uuid', editions: []) }
+    let(:section) { Section.new(manual: manual, uuid: 'section-uuid') }
     let(:service) { double(:service, call: [manual, section]) }
 
     before do

--- a/spec/lib/publication_logger_spec.rb
+++ b/spec/lib/publication_logger_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe PublicationLogger do
   let(:manual) { double(:manual, slug: 'manual-slug', removed_sections: []) }
   let(:sections) { [section] }
-  let(:section) { Section.new(manual: manual, uuid: "section-id-1", editions: [section_edition]) }
+  let(:section) { Section.new(manual: manual, uuid: "section-id-1", latest_edition: section_edition) }
   let(:section_edition) { FactoryGirl.create(:section_edition) }
 
   before do
@@ -20,7 +20,7 @@ RSpec.describe PublicationLogger do
     # It's possible to pass a nil change_note, this indicates that the section
     # update is not to be logged by the PublicationLogger
     context "when a section edition has no change note" do
-      let(:cloned_section) { Section.new(manual: manual, uuid: "section-id-2", editions: [cloned_section_edition]) }
+      let(:cloned_section) { Section.new(manual: manual, uuid: "section-id-2", latest_edition: cloned_section_edition) }
       let(:cloned_section_edition) { FactoryGirl.create(:section_edition, change_note: nil) }
       let(:sections) { [section, cloned_section] }
       it "does not create a PublicationLog for a cloned Section" do

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -985,17 +985,17 @@ describe Manual do
       let(:section_2_edition_2) { FactoryGirl.create(:section_edition, section_uuid: "section-2") }
 
       let(:section_1) do
-        Section.new(manual: manual, uuid: "section-1", editions: [
-          section_1_edition_1,
-          section_1_edition_2
-        ])
+        Section.new(manual: manual, uuid: "section-1",
+          previous_edition: section_1_edition_1,
+          latest_edition: section_1_edition_2
+        )
       end
 
       let(:section_2) do
-        Section.new(manual: manual, uuid: "section-2", editions: [
-          section_2_edition_1,
-          section_2_edition_2
-        ])
+        Section.new(manual: manual, uuid: "section-2",
+          previous_edition: section_2_edition_1,
+          latest_edition: section_2_edition_2
+        )
       end
 
       before do

--- a/spec/services/section/create_service_spec.rb
+++ b/spec/services/section/create_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Section::CreateService do
   let(:section_attributes) { double(:section_attributes) }
   let(:publishing_api_adapter) { double(:publishing_api) }
   let(:new_section) {
-    Section.new(manual: manual, uuid: 'uuid', editions: [])
+    Section.new(manual: manual, uuid: 'uuid')
   }
 
   subject do

--- a/spec/services/section/update_service_spec.rb
+++ b/spec/services/section/update_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Section::UpdateService do
   let(:section_uuid) { 'section-uuid' }
   let(:publishing_api_adapter) { double(:publishing_api) }
   let(:section) {
-    Section.new(manual: manual, uuid: section_uuid, editions: [])
+    Section.new(manual: manual, uuid: section_uuid)
   }
 
   subject do

--- a/spec/views/sections/_form.html.erb_spec.rb
+++ b/spec/views/sections/_form.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'sections/_form.html.erb', type: :view do
   it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
     manual = FactoryGirl.build(:manual, id: 'manual-id')
-    section = Section.new(manual: manual, uuid: 'section-uuid', editions: [])
+    section = Section.new(manual: manual, uuid: 'section-uuid')
 
     allow(manual).to receive(:has_ever_been_published?).and_return(true)
     allow(section).to receive(:has_ever_been_published?).and_return(true)

--- a/spec/views/sections/withdraw.html.erb_spec.rb
+++ b/spec/views/sections/withdraw.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'sections/withdraw.html.erb', type: :view do
   it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
     manual = FactoryGirl.build(:manual, id: 'manual-id')
-    section = Section.new(manual: manual, uuid: 'section-uuid', editions: [])
+    section = Section.new(manual: manual, uuid: 'section-uuid')
 
     allow(view).to receive(:manual).and_return(ManualViewAdapter.new(manual))
     allow(view).to receive(:section).and_return(SectionViewAdapter.new(manual, section))


### PR DESCRIPTION
Outside of the tests we'd only ever construct a `Section` with a maximum of the 2 latest editions (in `Section.find`). Explicitly passing the previous and latest editions doesn't change the behaviour but does aim to make that behaviour more explicit.