### PR TITLE
Remove Section#has_ever_been_published?

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -104,11 +104,6 @@ class Section
       (previous_edition && previous_edition.published?)
   end
 
-  def has_ever_been_published?
-    return false if previous_edition.nil? && needs_exporting?
-    published?
-  end
-
   def draft?
     latest_edition.draft?
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -81,8 +81,8 @@ class Section
       latest_edition.assign_attributes(attributes)
     else
       previous_edition_attributes = latest_edition.attributes
-        .slice(:section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update)
         .symbolize_keys
+        .slice(:section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update)
 
       attributes = previous_edition_attributes
         .merge(attributes)

--- a/app/view_adapters/section_view_adapter.rb
+++ b/app/view_adapters/section_view_adapter.rb
@@ -14,6 +14,10 @@ class SectionViewAdapter < SimpleDelegator
     section.uuid
   end
 
+  def accepts_minor_updates?
+    !(first_edition? && draft?)
+  end
+
   def persisted?
     section.updated_at || section.published?
   end

--- a/app/views/sections/_form.html.erb
+++ b/app/views/sections/_form.html.erb
@@ -11,7 +11,7 @@
       <div class="preview_button add-vertical-margins"></div>
       <div class="preview_container add-vertical-margins" style="display: none;"></div>
 
-      <% if manual.has_ever_been_published? && section.has_ever_been_published? %>
+      <% if manual.has_ever_been_published? && section.accepts_minor_updates? %>
         <div class="checkbox add-vertical-margins">
           <%= f.radio_button :minor_update, 1, class: 'js-update-type-minor', tag_type: :p, label: 'Minor update', checked: section.minor_update %>
           <p class="help-block">Only use for minor changes like fixes to typos, links, GOV.UK style or metadata.</p>

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -224,10 +224,6 @@ describe Section do
     it "is not published" do
       expect(section).not_to be_published
     end
-
-    it "has never been published" do
-      expect(section).not_to have_ever_been_published
-    end
   end
 
   context "with one published edition" do
@@ -240,22 +236,6 @@ describe Section do
     it "is not in draft" do
       expect(section).not_to be_draft
     end
-
-    context "that has been exported" do
-      before { allow(published_edition_v1).to receive(:exported_at).and_return(4.days.ago) }
-
-      it "has ever been published" do
-        expect(section).to have_ever_been_published
-      end
-    end
-
-    context "that has not been exported" do
-      before { allow(published_edition_v1).to receive(:exported_at).and_return(nil) }
-
-      it "has never been published" do
-        expect(section).not_to have_ever_been_published
-      end
-    end
   end
 
   context "with one published edition and one draft edition" do
@@ -265,10 +245,6 @@ describe Section do
     it "is published and in draft" do
       expect(section).to be_draft
       expect(section).to be_published
-    end
-
-    it "has ever been published" do
-      expect(section).to have_ever_been_published
     end
   end
 
@@ -283,10 +259,6 @@ describe Section do
     it "is not published" do
       expect(section).not_to be_published
     end
-
-    it "has never been published" do
-      expect(section).not_to have_ever_been_published
-    end
   end
 
   context "with one draft edition and a withdrawn edition" do
@@ -299,10 +271,6 @@ describe Section do
 
     it "is not published" do
       expect(section).not_to be_published
-    end
-
-    it "has never been published" do
-      expect(section).not_to have_ever_been_published
     end
   end
 

--- a/spec/view_adapters/section_view_adapter_spec.rb
+++ b/spec/view_adapters/section_view_adapter_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+RSpec.describe SectionViewAdapter do
+  let(:manual) { Manual.new(title: 'manual-title') }
+  let(:section) { manual.build_section(title: 'section-title') }
+
+  subject do
+    described_class.new(manual, section)
+  end
+
+  describe '#accepts_minor_updates?' do
+    it 'returns false if section is first edition and draft' do
+      expect(subject).to be_draft
+      expect(subject).to be_first_edition
+      expect(subject.accepts_minor_updates?).to be(false)
+    end
+
+    it 'returns true if section is first edition and published' do
+      section.publish!
+      section.save
+
+      expect(subject).to be_published
+      expect(subject).to be_first_edition
+      expect(subject.accepts_minor_updates?).to be(true)
+    end
+
+    it 'returns true if section is not first edition and is draft' do
+      section.publish!
+      section.save
+      section.update(title: 'new-section-title')
+
+      expect(subject).to be_draft
+      expect(subject).to_not be_first_edition
+      expect(subject.accepts_minor_updates?).to be(true)
+    end
+
+    it 'returns true if section is not first edition and is published' do
+      section.publish!
+      section.save
+      section.update(title: 'new-section-title')
+      section.publish!
+
+      expect(subject).to be_published
+      expect(subject).to_not be_first_edition
+      expect(subject.accepts_minor_updates?).to be(true)
+    end
+  end
+end

--- a/spec/views/sections/_form.html.erb_spec.rb
+++ b/spec/views/sections/_form.html.erb_spec.rb
@@ -6,10 +6,12 @@ describe 'sections/_form.html.erb', type: :view do
     section = Section.new(manual: manual, uuid: 'section-uuid')
 
     allow(manual).to receive(:has_ever_been_published?).and_return(true)
-    allow(section).to receive(:has_ever_been_published?).and_return(true)
+
+    section_view_adapter = SectionViewAdapter.new(manual, section)
+    allow(section_view_adapter).to receive(:accepts_minor_updates?).and_return(true)
 
     allow(view).to receive(:manual).and_return(ManualViewAdapter.new(manual))
-    allow(view).to receive(:section).and_return(SectionViewAdapter.new(manual, section))
+    allow(view).to receive(:section).and_return(section_view_adapter)
 
     render
 


### PR DESCRIPTION
This follows on from PR #1159 and replaces the final use of `Section#has_ever_been_published?` before then removing the method.
