### PR TITLE
Present previews in controllers

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -131,7 +131,7 @@ class ManualsController < ApplicationController
       manual_id: params[:id],
       attributes: update_manual_params
     )
-    manual = service.call
+    manual = ManualPresenter.new(service.call)
 
     manual.valid? # Force validation check or errors will be empty
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -86,7 +86,7 @@ class SectionsController < ApplicationController
       section_uuid: params.fetch(:id, nil),
       attributes: section_params
     )
-    section = service.call
+    section = SectionPresenter.new(service.call)
 
     section.valid? # Force validation check or errors will be empty
 

--- a/app/services/manual/preview_service.rb
+++ b/app/services/manual/preview_service.rb
@@ -12,8 +12,7 @@ class Manual::PreviewService
                Manual.new(attributes)
              end
     manual.update(attributes)
-
-    ManualPresenter.new(manual)
+    manual
   end
 
 private

--- a/app/services/section/preview_service.rb
+++ b/app/services/section/preview_service.rb
@@ -14,8 +14,7 @@ class Section::PreviewService
                 manual.build_section(attributes)
               end
     section.update(attributes)
-
-    SectionPresenter.new(section)
+    section
   end
 
 private


### PR DESCRIPTION
This PR moves the presentation of manuals and services out of the Preview Services and into the controllers. 

Fixes: #1054