### PR TITLE
Remove govuk_content_models reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 if ENV["GOVSPEAK_DEV"]
   gem "govspeak", path: "../govspeak"
 else
-  gem "govspeak", "~> 3.1" # can't go higher because govuk_content_models needs this
+  gem "govspeak", "~> 3.1"
 end
 
 gem "govuk_frontend_toolkit", "1.2.0" # we rely on this for correctly previewing govspeak (including interactive elements) - to help with that keep it in sync with the version used in manuals-frontend


### PR DESCRIPTION
This app no longer depends on `govuk_content_models`, so remove
a comment referring to it.

### Trello

https://trello.com/c/9Ho9O9Yo/219-epic-retire-govukcontentmodels