### PR TITLE
Improve CliManualDeleter

### DIFF
--- a/features/deleting-a-manual.feature
+++ b/features/deleting-a-manual.feature
@@ -12,13 +12,6 @@ Feature: Rake task to delete a manual
     And I confirm deletion
     Then the manual and its sections are deleted
 
-  Scenario: Not confirming manual deletion
-    Given a draft manual exists without any sections
-    And a draft section exists for the manual
-    When I run the deletion script
-    And I refuse deletion
-    Then the manual and its sections still exist
-
   Scenario: Deleting a published manual
     Given a published manual exists
     When I run the deletion script

--- a/features/step_definitions/deleting_manuals_steps.rb
+++ b/features/step_definitions/deleting_manuals_steps.rb
@@ -12,11 +12,6 @@ When(/^I confirm deletion/) do
   @deleter.call
 end
 
-When(/^I refuse deletion/) do
-  allow(@stdin).to receive(:gets).and_return("No")
-  expect { @deleter.call }.to raise_error(RuntimeError, /Quitting/)
-end
-
 Then(/^the script raises an error/) do
   expect { @deleter.call }.to raise_error(RuntimeError, /Cannot delete/)
 end

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -59,14 +59,16 @@ private
   end
 
   def complete_removal(manual)
-    Adapters.publishing.discard(manual)
+    begin
+      Adapters.publishing.discard(manual)
+    rescue GdsApi::HTTPNotFound
+      log "Draft for #{manual.id} or its sections already discarded."
+    end
 
     manual.destroy
 
     log "Manual destroyed."
     log "--------------------------------------------------------"
-  rescue GdsApi::HTTPNotFound
-    log "Draft for #{manual.id} or its sections already discarded."
   end
 
   def log(message)

--- a/lib/cli_manual_deleter.rb
+++ b/lib/cli_manual_deleter.rb
@@ -17,8 +17,6 @@ class CliManualDeleter
   def call
     manual = find_manual
 
-    user_must_confirm(manual)
-
     complete_removal(manual)
   end
 
@@ -41,20 +39,6 @@ private
   def validate_never_published(manual)
     unless manual.editions.all? { |e| e.state == "draft" }
       raise "Cannot delete; is published or has been previously published."
-    end
-  end
-
-  def user_must_confirm(manual)
-    number_of_sections = manual.sections.count
-    log "### PLEASE CONFIRM -------------------------------------"
-    log "Manual to be deleted: #{manual.slug}"
-    log "Organisation: #{manual.organisation_slug}"
-    log "This manual has #{number_of_sections} sections, and was last edited at #{manual.updated_at}"
-    log "Type 'y' to proceed and delete this manual or anything else to exit:"
-
-    response = stdin.gets
-    unless response.strip.casecmp("y").zero?
-      raise "Quitting"
     end
   end
 


### PR DESCRIPTION
These changes:

1. Allow us to run the `delete_draft_manual` Rake task via Jenkins.
2. Ensure we delete the draft manual from the local database even when it's not present in the Publishing API.
