### PR TITLE
[Do not merge] Only unpublish sections which have been previously published

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -279,7 +279,12 @@ private
 
   def unpublish_section(section, manual, republish:)
     if !section.withdrawn? || republish
-      Services.publishing_api.unpublish(section.uuid, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+      if section.published?
+        Services.publishing_api.unpublish(section.uuid,
+                                          type: "redirect",
+                                          alternative_path: "/#{manual.slug}",
+                                          discard_drafts: true)
+      end
       section.withdraw_and_mark_as_exported! if !republish
     end
   end

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -561,6 +561,7 @@ describe PublishingAdapter do
       manual.removed_sections = [removed_section]
 
       allow(removed_section).to receive(:withdrawn?).and_return(false)
+      allow(removed_section).to receive(:published?).and_return(true)
 
       allow(publishing_api).to receive(:publish).with(anything, anything)
       allow(publishing_api).to receive(:unpublish).with(anything, anything)

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -47,4 +47,72 @@ RSpec.describe "Publishing manuals", type: :feature do
       expect(@sections.first.reload.exported_at).to be_within(1.second).of publish_time
     end
   end
+
+  # https://trello.com/c/OmstjgzY/30-investigate-manuals-publisher-bug-which-prevented-publish
+  # There's a problem with draft sections which have not been previously published.
+  # On removing a section the draft is discarded in the Publishing API and the
+  # section is added to Manual#removed_sections, the publishing adapter then tries
+  # to unpublish these removed sections. This results in a GdsApi::HTTPNotFound exception
+  # from the Publishing API as the section does not exist there.
+  describe "publishing a manual after a section which has never been published is removed" do
+    before do
+      @manual = create_manual_without_ui(manual_fields)
+      create_section_without_ui(@manual, title: "First Section", summary: "First Section", body: "## First Section")
+
+      go_to_manual_page(@manual.title)
+      publish_manual
+
+      click_on "Add section"
+
+      fill_in("Section title", with: "Second Section")
+      fill_in("summary", with: "Second Section")
+      fill_in("body", with: "## Second Section")
+
+      save_as_draft
+
+      withdraw_section(@manual.title, "Second Section")
+
+      # Reload Manual to get up-to-date sections
+      @manual = Manual.find(@manual.id, User.gds_editor)
+    end
+
+    it "doesn't attempt to unpublish the section" do
+      uuid = @manual.removed_sections.find { |s| s.title == "Second Section" }.uuid
+      expect(Services.publishing_api).not_to receive(:unpublish)
+        .with(uuid,
+              type: "redirect",
+              alternative_path: "/#{@manual.slug}",
+              discard_drafts: true)
+
+      go_to_manual_page(@manual.title)
+      publish_manual
+    end
+  end
+
+  describe "publishing a manual after a section which has been published is removed" do
+    before do
+      @manual = create_manual_without_ui(manual_fields)
+      create_section_without_ui(@manual, title: "First Section", summary: "First Section", body: "## First Section")
+      create_section_without_ui(@manual, title: "Second Section", summary: "Second Section", body: "## Second Section")
+
+      go_to_manual_page(@manual.title)
+
+      publish_manual
+
+      withdraw_section(@manual.title, "Second Section")
+
+      @manual = Manual.find(@manual.id, User.gds_editor)
+    end
+
+    it "unpublishes the section" do
+      uuid = @manual.removed_sections.find { |s| s.title == "Second Section" }.uuid
+      expect(Services.publishing_api).to receive(:unpublish)
+        .with(uuid,
+              type: "redirect",
+              alternative_path: "/#{@manual.slug}",
+              discard_drafts: true)
+
+      publish_manual
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/OmstjgzY/30-investigate-manuals-publisher-bug-which-prevented-publish

There's a problem when a draft section which hasn't been published and
is then removed, the publishing API will discard the draft section but
the section is also added to `Manual#removed_sections` which is processed
on publishing the manual, attempting to unpublish an non-existent section
from the publishing API and resulting in a `GdsApi::HTTPNotFound` error.

So only attempt to unpublish previously published sections, drafts are
already discarded at the removal workflow step.