### PR TITLE
Stop talking about the design principles style guide

### DIFF
--- a/app/views/shared/_govspeak_help.html.erb
+++ b/app/views/shared/_govspeak_help.html.erb
@@ -1,7 +1,7 @@
 <div class="govspeak-help">
 
 <h2>Writing style</h2>
-<p>For style, see the <a href="https://www.gov.uk/designprinciples/styleguide">style guide</a></p>
+<p>For style, see the <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing">style guide</a></p>
 
 <h2>Formatting help</h2>
 <%= yield :format_specific_help %>


### PR DESCRIPTION
For: https://trello.com/c/M45WyUGZ/261-retire-design-principles

That route has been retired in favour of a new one and we might as well
save a redirect.