### PR TITLE
Add `/lib` to eager_load_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module ManualsPublisher
     config.autoload_paths << "#{Rails.root}/app/services/manual"
     config.autoload_paths << "#{Rails.root}/app/services/section"
     config.autoload_paths << "#{Rails.root}/app/services/attachment"
+
+    config.eager_load_paths << "#{Rails.root}/lib"
   end
 end


### PR DESCRIPTION
The app currently isn't running as the classes in `/lib` are not being loaded. We've used this approach on other apps e.g. publishing-api but we could also just put them into `/app` where they probably belong in any case. This will get the app running while the Rails upgrade is ongoing.