### PR TITLE
Remove reference to static from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Publishing app for manuals.
 
 ## Dependencies
 
-* [alphagov/static](http://github.com/alphagov/static): provides static assets (JS/CSS)
 * [alphagov/asset-manager](http://github.com/alphagov/asset-manager): provides uploading for static files
 * [alphagov/publishing-api](http://github.com/alphagov/publishing-api): allows documents to be published to the Publishing queue
 


### PR DESCRIPTION
This application has no dependency on static.  Remove reference in README to remove confusion.