### PR TITLE
Add Dockerfile ARG to conditionally precompile assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
+ARG COMPILE_ASSETS=false
+RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
+
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
The publishing-e2e-tests are being built in production mode now, and as part of that require the assets to be compiled into the image.

This ARG allows us to only compile the assets when we require allowing for easy switching back to development mode and not slowing down any existing usage of this Docker image.