### PR TITLE
Ignore BlockLength as jenkins doesn’t care

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.2
-
+Metrics/BlockLength:
+  Enabled: false
 Lint/HandleExceptions:
   Exclude:
     - 'spec/**/*'


### PR DESCRIPTION
We have removed the lint check for block length from rubocop as the configuration on jenkins indicates that when we explicitly ignore it for a single block that in fact it's not necessary at all:

```
spec/models/link_check_report_spec.rb:3:1: W: Lint/UnneededDisable: Unnecessary disabling of Metrics/BlockLength.
# rubocop:disable Metrics/BlockLength
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/link_spec.rb:3:1: W: Lint/UnneededDisable: Unnecessary disabling of Metrics/BlockLength.
# rubocop:disable Metrics/BlockLength
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```