### PR TITLE
Add callback for Link Checker API

### DIFF
--- a/app/controllers/link_checker_api_callback_controller.rb
+++ b/app/controllers/link_checker_api_callback_controller.rb
@@ -1,0 +1,34 @@
+class LinkCheckerApiCallbackController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :require_signin_permission!
+  skip_before_action :set_authenticated_user_header
+  before_action :verify_signature
+
+  def callback
+    report = LinkCheckReport.find_by(batch_id: params.require(:id))
+
+    if report
+      LinkCheckReport::UpdateService.new(
+        report: report,
+        params: params
+      ).call
+    end
+
+    head :no_content
+  end
+
+private
+
+  def verify_signature
+    return unless webhook_secret_token
+    given_signature = request.headers["X-LinkCheckerApi-Signature"]
+    return head :bad_request unless given_signature
+    body = request.raw_post
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), webhook_secret_token, body)
+    head :bad_request unless Rack::Utils.secure_compare(signature, given_signature)
+  end
+
+  def webhook_secret_token
+    Rails.application.secrets.link_checker_api_secret_token
+  end
+end

--- a/app/services/link_check_report/create_service.rb
+++ b/app/services/link_check_report/create_service.rb
@@ -2,6 +2,10 @@ require "services"
 require "govspeak/link_extractor"
 
 class LinkCheckReport::CreateService
+  include Rails.application.routes.url_helpers
+
+  CALLBACK_HOST = Plek.find('manuals-publisher')
+
   class InvalidReport < RuntimeError
     def initialize(original_error)
       @message = original_error.message
@@ -63,7 +67,13 @@ private
   end
 
   def call_link_checker_api
-    Services.link_checker_api.create_batch(uris)
+    callback = link_checker_api_callback_url(host: CALLBACK_HOST)
+
+    Services.link_checker_api.create_batch(
+      uris,
+      webhook_uri: callback,
+      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+    )
   end
 
   def map_link_attrs(link)

--- a/app/services/link_check_report/update_service.rb
+++ b/app/services/link_check_report/update_service.rb
@@ -1,0 +1,53 @@
+class LinkCheckReport::UpdateService
+  class InvalidReport < RuntimeError
+    def initialize(original_error)
+      @message = original_error.message
+    end
+  end
+
+  def initialize(report:, payload:)
+    @report = report
+    @payload = payload
+  end
+
+  def call
+    update_report!
+    links = payload.fetch("links", [])
+    update_links!(links)
+  rescue Mongoid::Errors::Validations => e
+    raise InvalidReport.new(e)
+  end
+
+private
+
+  attr_reader :report, :payload
+
+  def update_report!
+    report.update!(
+      status: payload.fetch("status"),
+      completed_at: payload.fetch("completed_at"),
+    )
+  end
+
+  def update_links!(links_payload)
+    links_payload.each do |link_payload|
+      link = report.links.find_by(uri: link_payload.fetch("uri"))
+
+      attributes = link_attributes(link_payload)
+
+      link.update!(attributes)
+    end
+  end
+
+  def link_attributes(link)
+    {
+      uri: link.fetch(:uri),
+      status: link.fetch(:status),
+      checked: link.fetch(:checked),
+      check_warnings: link.fetch(:warnings, []),
+      check_errors: link.fetch(:errors, []),
+      problem_summary: link.fetch(:problem_summary),
+      suggested_fix: link.fetch(:suggested_fix)
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
 
   resources :link_check_reports
 
+  post "/link-checker-api-callback" => "link_checker_api_callback#callback", as: "link_checker_api_callback"
+
   # This is for new manualss
   post "manuals/preview" => "manuals#preview", as: "preview_new_manual"
   # This is for new sections

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,14 @@
 
 development:
   secret_key_base: 575d1ff900b8efcf99c89980371365dc659ac3b3b8d6ee034ff27147a312a39c994eb2c189f06cf875bbcc645c7916080b95173b8dfe2b7063a34637a4a46541
+  link_checker_api_secret_token: KWceiCFx6GjzvKQh28EiRiUE
 
 test:
   secret_key_base: 46dbb3ca836e2c15ed6e4cb4b1d30c9b3e99ec83d472be4973c43fa5d6eaea84e49baeb5167bb77c82dde54edadda7d1abfa0b73c4d2d1f547542e804156612d
+  link_checker_api_secret_token: KWceiCFx6GjzvKQh28EiRiUE
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_TOKEN"] %>
+  link_checker_api_secret_token: <%= ENV["LINK_CHECKER_API_SECRET_TOKEN"] %>

--- a/spec/controllers/link_checker_api_callback_spec.rb
+++ b/spec/controllers/link_checker_api_callback_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+RSpec.describe LinkCheckerApiCallbackController, type: :controller do
+  include GdsApi::TestHelpers::LinkCheckerApi
+
+  def generate_signature(body, key)
+    OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), key, body)
+  end
+
+  let(:service) { double(:service, call: nil) }
+  let(:link_check_report) { LinkCheckReport.new }
+  let(:post_body) do
+    link_checker_api_batch_report_hash(
+      id: 5,
+      links: [
+        { uri: @link, status: "ok" },
+      ]
+    )
+  end
+
+  before do
+    allow(LinkCheckReport).to receive(:find_by).with(batch_id: 5).and_return(link_check_report)
+    expect(LinkCheckReport::UpdateService).to receive(:new).and_return(service)
+  end
+
+  it "POST :update updates LinkCheckReport" do
+    headers = {
+      "Content-Type": "application/json",
+      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.secrets.link_checker_api_secret_token)
+    }
+
+    request.headers.merge! headers
+    post :callback, params: post_body
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -116,6 +116,16 @@ FactoryGirl.define do
     trait :with_broken_links do
       links { [FactoryGirl.build(:link, :broken)] }
     end
+
+    trait :with_pending_links do
+      transient do
+        link_uris []
+      end
+
+      links do
+        link_uris.map { |uri| FactoryGirl.build(:link, :pending, uri: uri) }
+      end
+    end
   end
 
   factory :link do
@@ -123,6 +133,10 @@ FactoryGirl.define do
     status "ok"
 
     trait :broken do
+      status "broken"
+    end
+
+    trait :pending do
       status "broken"
     end
   end

--- a/spec/services/link_check_report/create_service_spec.rb
+++ b/spec/services/link_check_report/create_service_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe LinkCheckReport::CreateService do
       allow(Manual).to receive(:find).with(manual.id, user).and_return(manual)
     end
 
+    it 'should call the link checker api with a callback url and secret token' do
+      expect(Services.link_checker_api).to receive(:create_batch)
+
+      subject.call
+    end
+
     context "when the link checker api is called" do
       it "sets link check api attributes on report" do
         expect(LinkCheckReport).to receive(:new).with(

--- a/spec/services/link_check_report/update_service_spec.rb
+++ b/spec/services/link_check_report/update_service_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReport::UpdateService do
+  let(:link_check_report) do
+    FactoryGirl.create(:link_check_report, :with_pending_links,
+                                           batch_id: 1,
+                                           manual_id: 1,
+                                           link_uris: ['http://www.example.com', 'http://www.gov.com'])
+  end
+
+  let(:completed_at) { Time.now }
+
+  let(:payload) do
+    {
+      status: 'complete',
+      completed_at: completed_at,
+      links: links_payload
+    }.with_indifferent_access
+  end
+
+  let(:links_payload) do
+    [{
+      uri: "http://www.example.com",
+      status: "ok",
+      checked: completed_at.try(:iso8601),
+      problem_summary: nil,
+      suggested_fix: nil
+    }, {
+      uri: "http://www.gov.com",
+      status: "broken",
+      checked: completed_at.try(:iso8601),
+      problem_summary: "Page Not Found",
+      suggested_fix: "Contact site administrator"
+    }]
+  end
+
+  subject do
+    described_class.new(report: link_check_report, payload: payload)
+  end
+
+  it 'should update the link check report' do
+    subject.call
+
+    expect(link_check_report.status).to eq("complete")
+    expect(link_check_report.completed_at).to eq(completed_at)
+  end
+
+  it 'should update the links status' do
+    subject.call
+
+    expect(link_check_report.links.first.status).to eq("ok")
+    expect(link_check_report.links.first.checked).to eq(completed_at.try(:iso8601))
+
+    expect(link_check_report.links.last.status).to eq("broken")
+    expect(link_check_report.links.last.checked).to eq(completed_at.try(:iso8601))
+    expect(link_check_report.links.last.problem_summary).to eq("Page Not Found")
+  end
+end


### PR DESCRIPTION
This PR adds:

- [x] LinkCheckReports::UpdateService service class to update link check reports
- [x] Controller action to be used by the batch endpoint callback that will update a link check report

This closed the loop for link check report creation, by updating created link reports with the results from the API