### PR TITLE
Add link check reports for manuals and sections

### DIFF
--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,0 +1,18 @@
+class LinkCheckReportsController < ApplicationController
+  def create
+    service = LinkCheckReport::CreateService.new(
+      user: current_user,
+      manual_id: link_reportable_params[:manual_id]
+    )
+
+    service.call
+
+    head :created
+  end
+
+private
+
+  def link_reportable_params
+    params.require(:link_reportable).permit(:manual_id)
+  end
+end

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -2,7 +2,8 @@ class LinkCheckReportsController < ApplicationController
   def create
     service = LinkCheckReport::CreateService.new(
       user: current_user,
-      manual_id: link_reportable_params[:manual_id]
+      manual_id: link_reportable_params[:manual_id],
+      section_id: link_reportable_params[:section_id]
     )
 
     service.call
@@ -13,6 +14,6 @@ class LinkCheckReportsController < ApplicationController
 private
 
   def link_reportable_params
-    params.require(:link_reportable).permit(:manual_id)
+    params.require(:link_reportable).permit(:manual_id, :section_id)
   end
 end

--- a/app/services/link_check_report/create_service.rb
+++ b/app/services/link_check_report/create_service.rb
@@ -1,0 +1,63 @@
+require "services"
+require "govspeak/link_extractor"
+
+class LinkCheckReport::CreateService
+  class InvalidReport < RuntimeError
+    def initialize(original_error)
+      @message = original_error.message
+    end
+  end
+
+  def initialize(user:, manual_id:)
+    @user = user
+    @manual_id = manual_id
+  end
+
+  def call
+    link_report = call_link_checker_api
+
+    report = LinkCheckReport.new(
+      batch_id: link_report.fetch(:batch_id),
+      completed_at: link_report.fetch(:completed_at),
+      status: link_report.fetch(:status),
+      manual_id: manual_id,
+      links: link_report.fetch(:links).map { |link| map_link_attrs(link) }
+    )
+
+    report.save!
+  rescue Mongoid::Errors::Validations => e
+    raise InvalidReport.new(e)
+  end
+
+private
+
+  attr_reader :user, :manual_id
+
+  def manual
+    @manual ||= Manual.find(manual_id, user)
+  end
+
+  def link_reportable
+    manual
+  end
+
+  def uris
+    Govspeak::LinkExtractor.new(link_reportable.body).links
+  end
+
+  def call_link_checker_api
+    Services.link_checker_api.create_batch(uris)
+  end
+
+  def map_link_attrs(link)
+    {
+      uri: link.fetch(:uri),
+      status: link.fetch(:status),
+      checked: link.fetch(:checked),
+      check_warnings: link.fetch(:warnings, []),
+      check_errors: link.fetch(:errors, []),
+      problem_summary: link.fetch(:problem_summary),
+      suggested_fix: link.fetch(:suggested_fix)
+    }
+  end
+end

--- a/app/services/link_check_report/create_service.rb
+++ b/app/services/link_check_report/create_service.rb
@@ -8,9 +8,10 @@ class LinkCheckReport::CreateService
     end
   end
 
-  def initialize(user:, manual_id:)
+  def initialize(user:, manual_id:, section_id: nil)
     @user = user
     @manual_id = manual_id
+    @section_id = section_id
   end
 
   def call
@@ -21,6 +22,7 @@ class LinkCheckReport::CreateService
       completed_at: link_report.fetch(:completed_at),
       status: link_report.fetch(:status),
       manual_id: manual_id,
+      section_id: section_id,
       links: link_report.fetch(:links).map { |link| map_link_attrs(link) }
     )
 
@@ -31,14 +33,27 @@ class LinkCheckReport::CreateService
 
 private
 
-  attr_reader :user, :manual_id
+  attr_reader :user, :manual_id, :section_id
 
   def manual
     @manual ||= Manual.find(manual_id, user)
   end
 
+  def section
+    raise "Not a section" unless is_for_section?
+    @section ||= Section.find(manual, section_id)
+  end
+
+  def is_for_section?
+    section_id.present?
+  end
+
   def link_reportable
-    manual
+    if is_for_section?
+      section
+    else
+      manual
+    end
   end
 
   def uris

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
     put :original_publication_date, on: :member, action: :update_original_publication_date
   end
 
+  resources :link_check_reports
+
   # This is for new manualss
   post "manuals/preview" => "manuals#preview", as: "preview_new_manual"
   # This is for new sections

--- a/lib/govspeak/link_extractor.rb
+++ b/lib/govspeak/link_extractor.rb
@@ -1,0 +1,24 @@
+module Govspeak
+  class LinkExtractor
+    def initialize(govspeak)
+      @govspeak = govspeak
+    end
+
+    def links
+      @links ||= extract_links
+    end
+
+  private
+
+    def extract_links
+      processed_govspeak.css('a:not([href^="mailto"])').css('a:not([href^="#"])').map { |link| link['href'] }
+    end
+
+    def processed_govspeak
+      doc = Nokogiri::HTML::Document.new
+      doc.encoding = "UTF-8"
+
+      doc.fragment(Govspeak::Document.new(@govspeak).to_html)
+    end
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,6 +2,7 @@ require "gds_api/asset_manager"
 require "gds_api/content_store"
 require "gds_api/organisations"
 require "gds_api/publishing_api_v2"
+require "gds_api/link_checker_api"
 
 module Services
   def self.attachment_api
@@ -23,6 +24,12 @@ module Services
     @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
+    )
+  end
+
+  def self.link_checker_api
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(
+      Plek.find("link-checker-api"),
     )
   end
 end

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -3,8 +3,9 @@ require "services"
 
 describe LinkCheckReportsController, type: :controller do
   describe "#create" do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { create(:user) }
     let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
+    let(:section) { FactoryGirl.create(:section_edition, id: 1) }
 
     let(:link_checker_api_response) do
       {
@@ -29,10 +30,16 @@ describe LinkCheckReportsController, type: :controller do
       login_as_stub_user
       allow(Services.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
       allow(Manual).to receive(:find).and_return(manual)
+      allow(Section).to receive(:find).and_return(section)
     end
 
     it "returns a created status" do
       post :create, params: { link_reportable: { manual_id: 1 } }
+      expect(response).to have_http_status(:created)
+    end
+
+    it "returns a created status when section_id is also present" do
+      post :create, params: { link_reportable: { manual_id: 1, section_id: 1 } }
       expect(response).to have_http_status(:created)
     end
   end

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+require "services"
+
+describe LinkCheckReportsController, type: :controller do
+  describe "#create" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
+
+    let(:link_checker_api_response) do
+      {
+        batch_id: 1,
+        completed_at: nil,
+        status: "in_progress",
+        links: [
+          {
+            uri: "http://www.example.com",
+            status: "error",
+            checked: Time.parse("2017-12-01"),
+            warnings: ["example check warnings"],
+            errors: ["example check errors"],
+            problem_summary: "example problem",
+            suggested_fix: "example fix"
+          }
+        ]
+      }
+    end
+
+    before do
+      login_as_stub_user
+      allow(Services.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+      allow(Manual).to receive(:find).and_return(manual)
+    end
+
+    it "returns a created status" do
+      post :create, params: { link_reportable: { manual_id: 1 } }
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -102,4 +102,28 @@ FactoryGirl.define do
     abbreviation "CO"
     content_id "d94d63a5-ce8e-40a1-ab4c-4956eab27259"
   end
+
+  factory :link_check_report do
+    batch_id 1
+    status "in_progress"
+    completed_at Time.now
+    links { [FactoryGirl.build(:link)] }
+
+    trait :completed do
+      status "completed"
+    end
+
+    trait :with_broken_links do
+      links { [FactoryGirl.build(:link, :broken)] }
+    end
+  end
+
+  factory :link do
+    uri "http://www.example.com"
+    status "ok"
+
+    trait :broken do
+      status "broken"
+    end
+  end
 end

--- a/spec/services/link_check_report/create_service_spec.rb
+++ b/spec/services/link_check_report/create_service_spec.rb
@@ -1,0 +1,122 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReport::CreateService do
+  let(:user) { FactoryGirl.create(:user) }
+
+  let(:link_check_report) { double(:link_check_report, valid?: nil, save!: nil) }
+
+  let(:link_checker_api_response) do
+    {
+      batch_id: 1,
+      completed_at: nil,
+      status: "in_progress",
+      links: [
+        {
+          uri: "http://www.example.com",
+          status: "error",
+          checked: Time.parse("2017-12-01"),
+          warnings: ["example check warnings"],
+          errors: ["example check errors"],
+          problem_summary: "example problem",
+          suggested_fix: "example fix"
+        }
+      ]
+    }
+  end
+
+  before do
+    allow(Services.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+    allow(LinkCheckReport).to receive(:new).and_return(link_check_report)
+  end
+
+  context "when checking links for manual" do
+    let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
+
+    subject do
+      described_class.new(
+        user: user,
+        manual_id: manual.id
+      )
+    end
+
+    before do
+      allow(Manual).to receive(:find).with(manual.id, user).and_return(manual)
+    end
+
+    context "when the link checker api is called" do
+      it "sets link check api attributes on report" do
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            batch_id: 1,
+            completed_at: nil,
+            status: "in_progress",
+            manual_id: manual.id
+          )
+        )
+        subject.call
+      end
+
+      it "sets link array on report" do
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            links: array_including(
+              hash_including(
+                uri: "http://www.example.com",
+                status: "error",
+                checked: Time.parse("2017-12-01"),
+                check_warnings: ["example check warnings"],
+                check_errors: ["example check errors"],
+                problem_summary: "example problem",
+                suggested_fix: "example fix"
+              )
+            )
+          )
+        )
+        subject.call
+      end
+    end
+
+    context "when the report is valid" do
+      it "saves the report" do
+        expect(link_check_report).to receive(:save!)
+        subject.call
+      end
+    end
+
+    context "when there are no errors" do
+      it "saves errors as an empty array" do
+        link_checker_api_response[:links].first.delete(:errors)
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            links: array_including(
+              hash_including(check_errors: [])
+            )
+          )
+        )
+        subject.call
+      end
+    end
+
+    context "when there are no warnings" do
+      it "saves warnings as an empty array" do
+        link_checker_api_response[:links].first.delete(:warnings)
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            links: array_including(
+              hash_including(check_warnings: [])
+            )
+          )
+        )
+        subject.call
+      end
+    end
+
+    context "when the report is invalid" do
+      it "throws an exception" do
+        fake_validation_error = Mongoid::Errors::Validations.new(double(errors: double(full_messages: [])))
+        expect(link_check_report).to receive(:save!).and_raise(fake_validation_error)
+        expect { subject.call }.to raise_error(LinkCheckReport::CreateService::InvalidReport)
+      end
+    end
+  end
+end

--- a/spec/services/link_check_report/create_service_spec.rb
+++ b/spec/services/link_check_report/create_service_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe LinkCheckReport::CreateService do
   let(:user) { FactoryGirl.create(:user) }
 
-  let(:link_check_report) { double(:link_check_report, valid?: nil, save!: nil) }
+  let(:link_check_report) { FactoryGirl.create(:link_check_report, manual_id: manual.id) }
 
   let(:link_checker_api_response) do
     {
@@ -51,6 +51,101 @@ RSpec.describe LinkCheckReport::CreateService do
             completed_at: nil,
             status: "in_progress",
             manual_id: manual.id
+          )
+        )
+        subject.call
+      end
+
+      it "sets link array on report" do
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            links: array_including(
+              hash_including(
+                uri: "http://www.example.com",
+                status: "error",
+                checked: Time.parse("2017-12-01"),
+                check_warnings: ["example check warnings"],
+                check_errors: ["example check errors"],
+                problem_summary: "example problem",
+                suggested_fix: "example fix"
+              )
+            )
+          )
+        )
+        subject.call
+      end
+    end
+
+    context "when the report is valid" do
+      it "saves the report" do
+        expect(link_check_report).to receive(:save!)
+        subject.call
+      end
+    end
+
+    context "when there are no errors" do
+      it "saves errors as an empty array" do
+        link_checker_api_response[:links].first.delete(:errors)
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            links: array_including(
+              hash_including(check_errors: [])
+            )
+          )
+        )
+        subject.call
+      end
+    end
+
+    context "when there are no warnings" do
+      it "saves warnings as an empty array" do
+        link_checker_api_response[:links].first.delete(:warnings)
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            links: array_including(
+              hash_including(check_warnings: [])
+            )
+          )
+        )
+        subject.call
+      end
+    end
+
+    context "when the report is invalid" do
+      it "throws an exception" do
+        fake_validation_error = Mongoid::Errors::Validations.new(double(errors: double(full_messages: [])))
+        expect(link_check_report).to receive(:save!).and_raise(fake_validation_error)
+        expect { subject.call }.to raise_error(LinkCheckReport::CreateService::InvalidReport)
+      end
+    end
+  end
+
+  context "when checking links for section" do
+    let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
+    let(:section) { double(:section, id: 1, body: "[link](http://www.example.com)") }
+
+    subject do
+      described_class.new(
+        user: user,
+        manual_id: manual.id,
+        section_id: section.id
+      )
+    end
+
+    before do
+      allow(Manual).to receive(:find).with(manual.id, user).and_return(manual)
+      allow(Section).to receive(:find).with(manual, section.id).and_return(section)
+    end
+
+    context "when the link checker api is called" do
+      it "sets link check api attributes on report" do
+        expect(LinkCheckReport).to receive(:new).with(
+          hash_including(
+            batch_id: 1,
+            completed_at: nil,
+            status: "in_progress",
+            manual_id: manual.id,
+            section_id: section.id
           )
         )
         subject.call


### PR DESCRIPTION
- Add link checker api to Services
- Copy govspeak link extractor from whitehall
- Implement service class for creating link check reports for manuals
- Add link check report controller
- Add link check reports for sections