### PR TITLE
Add UI for broken link check reports

### DIFF
--- a/app/assets/stylesheets/_broken-links-report.scss
+++ b/app/assets/stylesheets/_broken-links-report.scss
@@ -1,0 +1,41 @@
+.broken-links-report {
+  .issue-summary {
+    font-weight: normal;
+  }
+
+  .issue-list {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      margin-top: 5px;
+    }
+  }
+
+  .issue-status-description {
+    margin-top: 10px;
+  }
+
+  .issue-list + .issue-status-description {
+    margin: 15px 0;
+  }
+
+  .display-issue-details {
+    display: block;
+    font-weight: bold;
+    padding-top: 5px;
+  }
+
+  .display-issue-details::-webkit-details-marker {
+    display: none;
+  }
+
+  .display-issue-details::before {
+    content: '\25B6';
+    padding-right: 3px;
+  }
+
+  details[open] > .display-issue-details::before {
+    content: '\25BC';
+  }
+}

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -30,6 +30,7 @@
 @import "navbar";
 @import "header";
 @import "ordered_lists";
+@import "broken-links-report";
 
 p.no-content-message {
   @include core-19;

--- a/app/models/link_check_report.rb
+++ b/app/models/link_check_report.rb
@@ -16,4 +16,20 @@ class LinkCheckReport
   validates :status, presence: true
   validates :links, presence: true
   validates :manual_id, presence: true
+
+  def completed?
+    status == "completed"
+  end
+
+  def in_progress?
+    !completed?
+  end
+
+  def broken_links
+    links.select { |l| l.status == "broken" }
+  end
+
+  def caution_links
+    links.select { |l| l.status == "caution" }
+  end
 end

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -350,5 +350,9 @@ class Manual
     manual_record.set(attributes)
   end
 
+  def link_check_report
+    @link_check_report ||= LinkCheckReport.where(manual_id: id).last
+  end
+
   class RemovedSectionIdNotFoundError < StandardError; end
 end

--- a/app/views/admin/link_check_reports/_form.html.erb
+++ b/app/views/admin/link_check_reports/_form.html.erb
@@ -1,0 +1,3 @@
+<%= form_tag link_check_reports_path(link_reportable: { type: "manual", manual_id: reportable.id }), remote: true do %>
+  <%= submit_tag button_text, class: "btn btn-default add-top-margin remove-bottom-margin" %>
+<% end %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,0 +1,44 @@
+<div class="broken-links-report">
+  <% if !report.present? %>
+    <section class="alert alert-info">
+      <p>Check this document for broken links. The report will take a few moments to complete.</p>
+      <%= render 'admin/link_check_reports/form', reportable: reportable, button_text: 'Check for broken links' %>
+    </section>
+  <% elsif report.in_progress? %>
+    <section class="alert alert-info">
+      Broken link report in progress.<br />Please wait.
+      <%= link_to "Refresh",
+                  link_check_report_path(report.id),
+                  class: 'js-broken-links-refresh js-hidden',
+                  remote: true %>
+    </section>
+  <% elsif report.broken_links.any? || report.caution_links.any? %>
+    <section class="alert alert-warning">
+      <h3 class="remove-top-margin">Links</h3>
+      <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
+        <% next unless %w(broken caution).include? status %>
+        <p class="issue-status-description"><%= status.capitalize %></p>
+        <ul class="issue-list">
+          <% links.each do |link| %>
+            <li>
+              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: 'link-inherit' %>
+              <details>
+                <summary class="display-issue-details">See more details about this link</summary>
+                <p class="issue-summary"><%= link.problem_summary %></p>
+                <% if link.suggested_fix %>
+                  <p class="issue-summary">Suggested fix: <%= link.suggested_fix %></p>
+                <% end %>
+              </details>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <%= render 'admin/link_check_reports/form', reportable: reportable, button_text: 'Check again' %>
+    </section>
+  <% else %>
+    <section class='alert alert-success'>
+      <p><span class="glyphicon glyphicon-ok add-right-margin"></span> This document contains no broken links.</p>
+      <%= render 'admin/link_check_reports/form', reportable: reportable, button_text: 'Check again' %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -7,97 +7,99 @@
 
 <div class="row">
   <div class="col-md-8">
-
-    <% unless clashing_sections.empty? %>
-      <p>Warning: There are duplicate section slugs in this manual.</p>
-      <ul>
-        <% clashing_sections.each do |slug, sections| %>
-          <li><%= slug %></li>
-        <% end %>
-      </ul>
-    <% end %>
-  </div>
-  <div class="col-md-8">
-    <h2>Summary</h2>
-    <p class="lead"><%= manual.summary %></p>
-  </div>
-</div>
-
-<% if manual.body.present? %>
-  <div class="row">
-    <div class=" col-md-8">
-      <h2>Body</h2>
-      <pre class="body-pre add-bottom-margin"><%= manual.body %></pre>
-    </div>
-  </div>
-<% end %>
-
-<div class="row add-bottom-margin">
-  <div class="col-md-8">
-    <h2>Metadata</h2>
-    <dl class="metadata-list">
-      <dt>State</dt>
-      <dd><%= state(manual) %></dd>
-    </dl>
-    <% if manual.publish_tasks.any? %>
-      <dl class="metadata-list">
-        <dt>Last published</dt>
-        <dd><%= publication_task_state(manual.publish_tasks.first) %></dd>
-      </dl>
-    <% end %>
-    <% if current_user_is_gds_editor? %>
-      <dl class="metadata-list">
-        <dt>From</dt>
-        <dd><%= link_to manual.organisation_slug, url_for_public_org(manual.organisation_slug) %></dd>
-      </dl>
-    <% end %>
-    <% if manual.originally_published_at.present? %>
-      <dl class="metadata-list">
-        <dt>Originally published</dt>
-        <dd><%= nice_time_format(manual.originally_published_at) %><% if manual.use_originally_published_at_for_public_timestamp? %><br/>This will be used as the public updated at timestamp on GOV.UK.<% end %></dd>
-      </dl>
-    <% end %>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-8">
-    <h2>Sections</h2>
-    <div class="well add-bottom-margin">
-      <%= link_to 'Reorder sections', reorder_manual_sections_path(manual), class: 'btn btn-default add-right-margin' %>
-      <%= link_to 'Add section', new_manual_section_path(manual), class: 'btn btn-default' %>
-    </div>
-    <% if manual.sections.any? %>
-    <ul class="document-list">
-     <% manual.sections.each do |section| %>
-        <li class="document">
-          <%= link_to(section.title, manual_section_path(manual, section), class: 'document-title') %>
-          <ul class="metadata">
-            <li class="text-muted">Updated <%= time_ago_in_words(section.updated_at) %> ago</li>
+    <div class="row">
+      <div class="col-md-12">
+        <% unless clashing_sections.empty? %>
+          <p>Warning: There are duplicate section slugs in this manual.</p>
+          <ul>
+            <% clashing_sections.each do |slug, sections| %>
+              <li><%= slug %></li>
+            <% end %>
           </ul>
-        </li>
-      <% end %>
-    </ul>
-    <% else %>
-      <p class='no-content-message'>You haven&rsquo;t added any sections to this manual yet.</p>
-    <% end %>
-
-    <h2>Actions</h2>
-    <div class="well">
-      <%= link_to 'Edit manual', edit_manual_path(manual), class: 'btn btn-success add-right-margin' %>
-      <%= link_to 'Edit first publication date', original_publication_date_manual_path(manual), class: 'btn btn-default' %>
-    </div>
-
-    <div class="panel panel-default">
-      <div class="panel-heading"><h3>Publish manual</h3></div>
-      <div class="panel-body">
-        <%= publish_text(manual, slug_unique) %>
-        <% if manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique %>
-          <%= form_tag(publish_manual_path(manual), method: :post) do %>
-            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
-          <% end -%>
         <% end %>
       </div>
+
+      <div class="col-md-12">
+        <h2>Summary</h2>
+        <p class="lead"><%= manual.summary %></p>
+      </div>
+
+      <% if manual.body.present? %>
+        <div class=" col-md-12">
+          <h2>Body</h2>
+          <pre class="body-pre add-bottom-margin"><%= manual.body %></pre>
+        </div>
+      <% end %>
+
+      <div class="col-md-12 add-bottom-margin">
+        <h2>Metadata</h2>
+        <dl class="metadata-list">
+          <dt>State</dt>
+          <dd><%= state(manual) %></dd>
+        </dl>
+        <% if manual.publish_tasks.any? %>
+          <dl class="metadata-list">
+            <dt>Last published</dt>
+            <dd><%= publication_task_state(manual.publish_tasks.first) %></dd>
+          </dl>
+        <% end %>
+        <% if current_user_is_gds_editor? %>
+          <dl class="metadata-list">
+            <dt>From</dt>
+            <dd><%= link_to manual.organisation_slug, url_for_public_org(manual.organisation_slug) %></dd>
+          </dl>
+        <% end %>
+        <% if manual.originally_published_at.present? %>
+          <dl class="metadata-list">
+            <dt>Originally published</dt>
+            <dd><%= nice_time_format(manual.originally_published_at) %><% if manual.use_originally_published_at_for_public_timestamp? %><br/>This will be used as the public updated at timestamp on GOV.UK.<% end %></dd>
+          </dl>
+        <% end %>
+      </div>
+
+      <div class="col-md-12">
+        <h2>Sections</h2>
+        <div class="well add-bottom-margin">
+          <%= link_to 'Reorder sections', reorder_manual_sections_path(manual), class: 'btn btn-default add-right-margin' %>
+          <%= link_to 'Add section', new_manual_section_path(manual), class: 'btn btn-default' %>
+        </div>
+        <% if manual.sections.any? %>
+        <ul class="document-list">
+         <% manual.sections.each do |section| %>
+            <li class="document">
+              <%= link_to(section.title, manual_section_path(manual, section), class: 'document-title') %>
+              <ul class="metadata">
+                <li class="text-muted">Updated <%= time_ago_in_words(section.updated_at) %> ago</li>
+              </ul>
+            </li>
+          <% end %>
+        </ul>
+        <% else %>
+          <p class='no-content-message'>You haven&rsquo;t added any sections to this manual yet.</p>
+        <% end %>
+
+        <h2>Actions</h2>
+        <div class="well">
+          <%= link_to 'Edit manual', edit_manual_path(manual), class: 'btn btn-success add-right-margin' %>
+          <%= link_to 'Edit first publication date', original_publication_date_manual_path(manual), class: 'btn btn-default' %>
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading"><h3>Publish manual</h3></div>
+          <div class="panel-body">
+            <%= publish_text(manual, slug_unique) %>
+            <% if manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique %>
+              <%= form_tag(publish_manual_path(manual), method: :post) do %>
+                <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
+              <% end -%>
+            <% end %>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
+
+  <div class="col-md-4">
+    <%= render 'admin/link_check_reports/link_check_report', reportable: manual, report: manual.link_check_report %>
   </div>
 </div>

--- a/spec/features/check_broken_links_spec.rb
+++ b/spec/features/check_broken_links_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe "Checking broken links on manuals", type: :feature do
+  before do
+    login_as(:gds_editor)
+  end
+
+  let(:manual) { create_manual_without_ui(title: "A manual", summary: "A manual summary", body: "[link](http://www.example.com)") }
+
+  context "when no link check report exists" do
+    it "should display a link check button if there are links in the manual" do
+      visit "/manuals/#{manual.id}"
+      expect(page).to have_content("Check this document for broken links")
+    end
+
+    it "should display a link check in progress if the button has been clicked" do
+      create(:link_check_report, manual_id: manual.id)
+      visit "/manuals/#{manual.id}"
+      expect(page).to have_content("Broken link report in progress.")
+    end
+  end
+
+  context "when a link check with no broken links exists" do
+    it "should display that there are no broken links" do
+      create(:link_check_report, :completed, manual_id: manual.id)
+      visit "/manuals/#{manual.id}"
+      expect(page).to have_content("This document contains no broken links.")
+    end
+  end
+
+  context "when a link check with broken links exists" do
+    it "should display that there are broken links" do
+      create(:link_check_report, :completed, :with_broken_links, manual_id: manual.id)
+      visit "/manuals/#{manual.id}"
+      expect(page).to have_content("See more details about this link")
+    end
+  end
+end


### PR DESCRIPTION
- Include the Link Checker button on the Manuals show page
- Include suggested fix and summary of link problems with the broken links

This leads on from https://github.com/alphagov/manuals-publisher/pull/1230

![screen shot 2017-12-19 at 09 13 08](https://user-images.githubusercontent.com/8478978/34164464-835009ce-e4d1-11e7-8510-4d7340de7707.png)
![screen shot 2017-12-19 at 09 41 48](https://user-images.githubusercontent.com/8478978/34164475-8d47fa18-e4d1-11e7-9ff3-7cc1cbb81730.png)
