### PR TITLE
Add show endpoint for link check reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test do
   gem "poltergeist", "~> 1.17.0"
   gem "phantomjs", ">= 1.9.7.1"
   gem "rspec"
+  gem "rails-controller-testing"
   gem "rspec-rails"
   gem "simplecov"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.4)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -472,6 +476,7 @@ DEPENDENCIES
   poltergeist (~> 1.17.0)
   pry-byebug
   rails (~> 5.1)
+  rails-controller-testing
   raindrops (>= 0.13.0)
   rspec
   rspec-rails

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -6,9 +6,14 @@ class LinkCheckReportsController < ApplicationController
       section_id: link_reportable_params[:section_id]
     )
 
-    service.call
+    @report = service.call
 
-    head :created
+    @reportable = find_reportable(link_reportable_params)
+
+    respond_to do |format|
+      format.js { render 'admin/link_check_reports/create' }
+      format.html { redirect_to_reportable }
+    end
   end
 
   def show

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -11,9 +11,43 @@ class LinkCheckReportsController < ApplicationController
     head :created
   end
 
+  def show
+    @report = LinkCheckReport::ShowService.new(
+      id: link_reportable_show_params[:id]
+    ).call
+
+    @reportable = find_reportable(section_id: @report.section_id, manual_id: @report.manual_id)
+
+    respond_to do |format|
+      format.js { render 'admin/link_check_reports/show' }
+      format.html { redirect_to_reportable }
+    end
+  end
+
 private
 
   def link_reportable_params
     params.require(:link_reportable).permit(:manual_id, :section_id)
+  end
+
+  def link_reportable_show_params
+    params.permit(:id)
+  end
+
+  def find_reportable(reportable_params)
+    if reportable_params[:section_id] && reportable_params[:manual_id]
+      manual = Manual.find(reportable_params[:manual_id], current_user)
+      Section.find(manual, reportable_params[:manual_id])
+    elsif reportable_params[:manual_id]
+      Manual.find(reportable_params[:manual_id], current_user)
+    end
+  end
+
+  def redirect_to_reportable
+    if @reportable.is_a?(Section)
+      redirect_to manual_section_path(@reportable.manual.to_param, @reportable.to_param)
+    elsif @reportable.is_a?(Manual)
+      redirect_to manual_path(@reportable.to_param)
+    end
   end
 end

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -40,12 +40,11 @@ private
   end
 
   def find_reportable(reportable_params)
-    if reportable_params[:section_id] && reportable_params[:manual_id]
-      manual = Manual.find(reportable_params[:manual_id], current_user)
-      Section.find(manual, reportable_params[:manual_id])
-    elsif reportable_params[:manual_id]
-      Manual.find(reportable_params[:manual_id], current_user)
-    end
+    LinkCheckReport::FindReportableService.new(
+      user: current_user,
+      manual_id: reportable_params[:manual_id],
+      section_id: reportable_params[:section_id]
+    ).call
   end
 
   def redirect_to_reportable

--- a/app/services/link_check_report/create_service.rb
+++ b/app/services/link_check_report/create_service.rb
@@ -41,29 +41,16 @@ private
 
   attr_reader :user, :manual_id, :section_id
 
-  def manual
-    @manual ||= Manual.find(manual_id, user)
-  end
-
-  def section
-    raise "Not a section" unless is_for_section?
-    @section ||= Section.find(manual, section_id)
-  end
-
-  def is_for_section?
-    section_id.present?
-  end
-
-  def link_reportable
-    if is_for_section?
-      section
-    else
-      manual
-    end
+  def reportable
+    @reportable ||= LinkCheckReport::FindReportableService.new(
+      user: user,
+      manual_id: manual_id,
+      section_id: section_id
+    ).call
   end
 
   def uris
-    Govspeak::LinkExtractor.new(link_reportable.body).links
+    Govspeak::LinkExtractor.new(reportable.body).links
   end
 
   def call_link_checker_api

--- a/app/services/link_check_report/find_reportable_service.rb
+++ b/app/services/link_check_report/find_reportable_service.rb
@@ -1,0 +1,32 @@
+class LinkCheckReport::FindReportableService
+  def initialize(user:, manual_id:, section_id: nil)
+    @user = user
+    @manual_id = manual_id
+    @section_id = section_id
+  end
+
+  def call
+    if is_for_section?
+      section
+    else
+      manual
+    end
+  end
+
+private
+
+  attr_reader :user, :manual_id, :section_id
+
+  def manual
+    @manual ||= Manual.find(manual_id, user)
+  end
+
+  def section
+    raise "Not a section" unless is_for_section?
+    @section ||= Section.find(manual, section_id)
+  end
+
+  def is_for_section?
+    section_id.present?
+  end
+end

--- a/app/services/link_check_report/show_service.rb
+++ b/app/services/link_check_report/show_service.rb
@@ -1,0 +1,13 @@
+class LinkCheckReport::ShowService
+  def initialize(id:)
+    @id = id
+  end
+
+  def call
+    LinkCheckReport.find(id)
+  end
+
+private
+
+  attr_reader :id
+end

--- a/app/views/admin/link_check_reports/create.js.erb
+++ b/app/views/admin/link_check_reports/create.js.erb
@@ -1,0 +1,1 @@
+$('.broken-links-report').replaceWith('<%=escape_javascript render("admin/link_check_reports/link_check_report", report: @report, reportable: @reportable ) %>');

--- a/app/views/admin/link_check_reports/show.js.erb
+++ b/app/views/admin/link_check_reports/show.js.erb
@@ -1,0 +1,3 @@
+<% if @report.completed? %>
+  $('.broken-links-report').replaceWith('<%=escape_javascript render("admin/link_check_reports/link_check_report", report: @report, reportable: @reportable ) %>');
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     put :original_publication_date, on: :member, action: :update_original_publication_date
   end
 
-  resources :link_check_reports
+  resources :link_check_reports, only: [:create, :show]
 
   post "/link-checker-api-callback" => "link_checker_api_callback#callback", as: "link_checker_api_callback"
 

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -43,4 +43,11 @@ describe LinkCheckReportsController, type: :controller do
       expect(response).to have_http_status(:created)
     end
   end
+
+  describe "#show" do
+    it "shows the report" do
+      get :show, params: {} 
+      expect(response).to have_http_status(:success)
+    end
+  end
 end

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
-require "services"
+require "gds_api/test_helpers/link_checker_api"
 
 describe LinkCheckReportsController, type: :controller do
+  include GdsApi::TestHelpers::LinkCheckerApi
+
   let(:user) { FactoryGirl.create(:user) }
   let(:manual) { FactoryGirl.build(:manual, id: 538, body: "[link](http://[www.example.com)") }
   let(:section) { FactoryGirl.create(:section_edition, id: 53880, body: "[link](http://[www.example.com/section)") }
@@ -16,40 +18,44 @@ describe LinkCheckReportsController, type: :controller do
   end
 
   describe "#create" do
-    let(:link_checker_api_response) do
-      {
-        id: 1,
-        completed_at: nil,
-        status: "in_progress",
-        links: [
-          {
-            uri: "http://www.example.com",
-            status: "error",
-            checked: Time.parse("2017-12-01"),
-            warnings: ["example check warnings"],
-            errors: ["example check errors"],
-            problem_summary: "example problem",
-            suggested_fix: "example fix"
-          }
-        ]
-      }
-    end
-
     before do
-      allow(Services.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+      stub_link_checker_api
     end
 
-    it "returns a created status" do
-      post :create, params: { link_reportable: { manual_id: 1 } }
-      expect(response).to have_http_status(:created)
+    context "manual" do
+      it "POST returns a redirects to the manual show page" do
+        post :create, params: { link_reportable: { manual_id: manual.id } }
+
+        expected_path = manual_path(manual.to_param)
+        expect(response).to redirect_to(expected_path)
+        expect(LinkCheckReport.count).to eq(1)
+      end
+
+      it "AJAX POST renders the create template and creates a link check report" do
+        post :create, xhr: true, params: { link_reportable: { manual_id: manual.id } }
+
+        expect(response).to render_template("admin/link_check_reports/create")
+        expect(LinkCheckReport.count).to eq(1)
+      end
     end
 
-    it "returns a created status when section_id is also present" do
-      post :create, params: { link_reportable: { manual_id: 1, section_id: 1 } }
-      expect(response).to have_http_status(:created)
+    context "section" do
+      it "POST returns redirects to the section show page" do
+        post :create, params: { link_reportable: { manual_id: manual.id, section_id: section.id } }
+
+        expected_path = manual_section_path(manual.to_param, section.to_param)
+        expect(response).to redirect_to(expected_path)
+        expect(LinkCheckReport.count).to eq(1)
+      end
+
+      it "AJAX POST renders the create template and creates a link check report" do
+        post :create, xhr: true, params: { link_reportable: { manual_id: manual.id, section_id: section.id } }
+
+        expect(response).to render_template("admin/link_check_reports/create")
+        expect(LinkCheckReport.count).to eq(1)
+      end
     end
   end
-
 
   describe "#show" do
     context "manual" do
@@ -98,5 +104,21 @@ describe LinkCheckReportsController, type: :controller do
         expect(assigns(:reportable)).to eq(section)
       end
     end
+  end
+
+private
+
+  def stub_link_checker_api
+    body = link_checker_api_batch_report_hash(
+      id: 5,
+      links: [{ uri: "http://www.example.com" }],
+    )
+
+    stub_request(:post, %r{\A#{Plek.find('link-checker-api')}\/batch})
+      .to_return(
+        body: body.to_json,
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      )
   end
 end

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -2,11 +2,20 @@ require "spec_helper"
 require "services"
 
 describe LinkCheckReportsController, type: :controller do
-  describe "#create" do
-    let(:user) { create(:user) }
-    let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
-    let(:section) { FactoryGirl.create(:section_edition, id: 1) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:manual) { FactoryGirl.build(:manual, id: 538, body: "[link](http://[www.example.com)") }
+  let(:section) { FactoryGirl.create(:section_edition, id: 53880, body: "[link](http://[www.example.com/section)") }
 
+  before do
+    login_as_stub_user
+    allow(Manual).to receive(:find).and_return(manual)
+    allow(Section).to receive(:find).and_return(section)
+    allow(section).to receive(:manual).and_return(manual)
+    # This is needed as the real section will be_a Section
+    allow(section).to receive(:is_a?).and_return(Section)
+  end
+
+  describe "#create" do
     let(:link_checker_api_response) do
       {
         id: 1,
@@ -27,10 +36,7 @@ describe LinkCheckReportsController, type: :controller do
     end
 
     before do
-      login_as_stub_user
       allow(Services.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
-      allow(Manual).to receive(:find).and_return(manual)
-      allow(Section).to receive(:find).and_return(section)
     end
 
     it "returns a created status" do
@@ -44,10 +50,53 @@ describe LinkCheckReportsController, type: :controller do
     end
   end
 
+
   describe "#show" do
-    it "shows the report" do
-      get :show, params: {} 
-      expect(response).to have_http_status(:success)
+    context "manual" do
+      let(:link_check_report) do
+        FactoryGirl.create(:link_check_report, :with_broken_links,
+                                                manual_id: manual.id,
+                                                batch_id: 1)
+      end
+
+      it "GET redirects back to the manual page" do
+        get :show, params: { id: link_check_report.id }
+
+        expected_path = manual_path(manual.to_param)
+        expect(response).to redirect_to(expected_path)
+      end
+
+      it "AJAX GET assigns the LinkCheckReport and renders the show template" do
+        get :show, xhr: true, params: { id: link_check_report.id }
+
+        expect(response).to render_template("admin/link_check_reports/show")
+        expect(assigns(:report)).to eq(link_check_report)
+        expect(assigns(:reportable)).to eq(manual)
+      end
+    end
+
+    context "section" do
+      let(:link_check_report) do
+        FactoryGirl.create(:link_check_report, :with_broken_links,
+                                                manual_id: manual.id,
+                                                section_id: section.id,
+                                                batch_id: 1)
+      end
+
+      it "GET redirects back to the section page" do
+        get :show, params: { id: link_check_report.id }
+
+        expected_path = manual_section_path(manual.to_param, section.to_param)
+        expect(response).to redirect_to(expected_path)
+      end
+
+      it "AJAX GET assigns the LinkCheckReport and renders the show template" do
+        get :show, xhr: true, params: { id: link_check_report.id }
+
+        expect(response).to render_template("admin/link_check_reports/show")
+        expect(assigns(:report)).to eq(link_check_report)
+        expect(assigns(:reportable)).to eq(section)
+      end
     end
   end
 end

--- a/spec/services/link_check_report/find_reportable_service_spec.rb
+++ b/spec/services/link_check_report/find_reportable_service_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReport::FindReportableService do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
+
+  before do
+    allow(Manual).to receive(:find).with(manual.id, user).and_return(manual)
+  end
+
+  context "when looking for a manual" do
+    subject do
+      described_class.new(
+        user: user,
+        manual_id: manual.id
+      ).call
+    end
+
+    it { is_expected.to be(manual) }
+
+    it 'should look up a manual' do
+      expect(Manual).to receive(:find).with(manual.id, user)
+      subject
+    end
+  end
+
+  context "when looking for a section" do
+    let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
+    let(:section) { double(:section, id: 1, body: "[link](http://www.example.com)") }
+
+    subject do
+      described_class.new(
+        user: user,
+        manual_id: manual.id,
+        section_id: section.id
+      ).call
+    end
+
+    before do
+      allow(Section).to receive(:find).with(manual, section.id).and_return(section)
+    end
+
+    it 'should look up a manual and a section' do
+      expect(Manual).to receive(:find).with(manual.id, user)
+      expect(Section).to receive(:find).with(manual, section.id)
+      subject
+    end
+  end
+end

--- a/spec/services/link_check_report/show_service_spec.rb
+++ b/spec/services/link_check_report/show_service_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReport::ShowService do
+  let(:link_check_report) do
+    FactoryGirl.create(:link_check_report, :with_broken_links,
+                                            manual_id: 1,
+                                            batch_id: 1)
+  end
+
+  let(:link_check_report_id) { link_check_report.id }
+
+  context "when the link checker api is called with a manual" do
+    subject { described_class.new(id: link_check_report_id) }
+
+    it "returns the report" do
+      expect(subject.call).to be_a_kind_of(LinkCheckReport)
+    end
+  end
+end

--- a/spec/support/controller_testing.rb
+++ b/spec/support/controller_testing.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.include ::Rails::Controller::Testing::TestProcess, type: :controller
+  config.include ::Rails::Controller::Testing::TemplateAssertions, type: :controller
+  config.include ::Rails::Controller::Testing::Integration, type: :controller
+end


### PR DESCRIPTION
This PR adds the ability to get the status of a link check report based using its `id`. It provides both a JS and an HTML response for the show endpoint.

In addition to this, this PR also updates the `#create` specs to use Webmock and the gds api adapter helpers for the Link Checker API and it applies the same response options (JS and HTML) as `#show`