### PR TITLE
Fix payload in LinkCheckReport::CreateService

### DIFF
--- a/app/services/link_check_report/create_service.rb
+++ b/app/services/link_check_report/create_service.rb
@@ -15,10 +15,10 @@ class LinkCheckReport::CreateService
   end
 
   def call
-    link_report = call_link_checker_api
+    link_report = call_link_checker_api.deep_symbolize_keys
 
     report = LinkCheckReport.new(
-      batch_id: link_report.fetch(:batch_id),
+      batch_id: link_report.fetch(:id),
       completed_at: link_report.fetch(:completed_at),
       status: link_report.fetch(:status),
       manual_id: manual_id,
@@ -27,6 +27,8 @@ class LinkCheckReport::CreateService
     )
 
     report.save!
+
+    report
   rescue Mongoid::Errors::Validations => e
     raise InvalidReport.new(e)
   end

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -9,7 +9,7 @@ describe LinkCheckReportsController, type: :controller do
 
     let(:link_checker_api_response) do
       {
-        batch_id: 1,
+        id: 1,
         completed_at: nil,
         status: "in_progress",
         links: [

--- a/spec/services/link_check_report/create_service_spec.rb
+++ b/spec/services/link_check_report/create_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LinkCheckReport::CreateService do
 
   let(:link_checker_api_response) do
     {
-      batch_id: 1,
+      id: 1,
       completed_at: nil,
       status: "in_progress",
       links: [


### PR DESCRIPTION
This better replicates the callback from the link checker api. The response from the API uses `id` not `batch_id` for the ID of the batch.