### PR TITLE
Use unicorn over WEBrick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ADD . $APP_HOME
 ARG COMPILE_ASSETS=false
 RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
 
-CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"
+CMD bash -c "bundle exec foreman run web"

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rails s -p 3205
+web: bundle exec unicorn -p ${PORT:-3205}
 worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3205
+PORT=3205 bundle exec foreman start


### PR DESCRIPTION
We wanted to use unicorn as it brings the environment closer to
what is used inside of production.

This also makes `startup.sh` boot the sidekiq workers.
