### PR TITLE
Improve link checker api callback tests

### DIFF
--- a/spec/controllers/link_checker_api_callback_spec.rb
+++ b/spec/controllers/link_checker_api_callback_spec.rb
@@ -8,29 +8,57 @@ RSpec.describe LinkCheckerApiCallbackController, type: :controller do
     OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), key, body)
   end
 
-  let(:service) { double(:service, call: nil) }
-  let(:link_check_report) { LinkCheckReport.new }
-  let(:post_body) do
-    link_checker_api_batch_report_hash(
-      id: 5,
-      links: [
-        { uri: @link, status: "ok" },
-      ]
-    )
-  end
-
-  before do
-    allow(LinkCheckReport).to receive(:find_by).with(batch_id: 5).and_return(link_check_report)
-    expect(LinkCheckReport::UpdateService).to receive(:new).and_return(service)
-  end
-
-  it "POST :update updates LinkCheckReport" do
+  def set_headers
     headers = {
       "Content-Type": "application/json",
       "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.secrets.link_checker_api_secret_token)
     }
 
     request.headers.merge! headers
-    post :callback, params: post_body
+  end
+
+  let(:link_check_report_batch_id) { 5 }
+  let(:link_check_report) do
+    FactoryGirl.create(:link_check_report, :with_pending_links,
+                                           batch_id: 5,
+                                           manual_id: 1,
+                                           link_uris: ['https://gov.uk'])
+  end
+
+  let(:post_body) do
+    link_checker_api_batch_report_hash(
+      id: link_check_report_batch_id,
+      links: [
+        { uri: @link, status: "ok" },
+      ]
+    )
+  end
+
+  context 'when the report exists' do
+    subject do
+      post :callback, params: post_body
+      link_check_report.reload
+    end
+
+    before do
+      allow(LinkCheckReport).to receive(:find_by).with(batch_id: 5).and_return(link_check_report)
+    end
+
+    it "POST :update updates LinkCheckReport" do
+      set_headers
+
+      expect { subject }.to change { link_check_report.status }.to('completed')
+    end
+  end
+
+  context 'when the report does not exist' do
+    let(:link_check_report_batch_id) { 1 }
+
+    it 'should not throw an error' do
+      set_headers
+      post :callback, params: post_body
+
+      expect(response.status).to eq(204)
+    end
   end
 end


### PR DESCRIPTION
This PR improves the level of trust in the link checker api callback tests by removing the service stub.