### PR TITLE
Remove the conditional for precompiling assets in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-log
+log/*.log
 tmp
 coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-ARG COMPILE_ASSETS=false
-RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
+RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
 CMD bash -c "bundle exec foreman run web"


### PR DESCRIPTION
As part of the work to use the built images pushed up to Docker Hub for E2E testing, where we run the tests in the production RAILS_ENV, we will need the image pushed up to contain the compiled assets.

We can't see a reason to keep the conditional for now as any performance hit will be experienced only as part of CI.