### PR TITLE
Add discard draft manual functionality to ui

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -125,6 +125,26 @@ class ManualsController < ApplicationController
     )
   end
 
+  def discard_draft
+    service = Manual::DiscardDraftService.new(
+      user: current_user,
+      manual_id: manual_id
+    )
+    result = service.call
+
+    if result.successful?
+      redirect_to(
+        manuals_path,
+        flash: { notice: "Discarded draft of #{result.manual_title}" }
+      )
+    else
+      redirect_to(
+        manual_path(manual_id),
+        flash: { notice: "Unable to discard draft of #{result.manual_title}" }
+      )
+    end
+  end
+
   def preview
     service = Manual::PreviewService.new(
       user: current_user,

--- a/app/services/manual/discard_draft_service.rb
+++ b/app/services/manual/discard_draft_service.rb
@@ -1,0 +1,53 @@
+require "adapters"
+
+class Manual::DiscardDraftService
+  def initialize(user:, manual_id:)
+    @user = user
+    @manual_id = manual_id
+  end
+
+  def call
+    manual = Manual.find(manual_id, user)
+
+    if manual.has_ever_been_published?
+      Result.failure(manual)
+    else
+      begin
+        Adapters.publishing.discard(manual)
+      rescue GdsApi::HTTPNotFound # rubocop:disable Lint/HandleExceptions
+        # this is fine, the manual has already been discarded from the
+        # publishing API and the next line will clean it up in our DB
+      end
+
+      manual.destroy
+      Result.success(manual)
+    end
+  end
+
+private
+
+  attr_reader :user, :manual_id
+
+  class Result
+    def self.success(manual)
+      new(successful: true, manual: manual)
+    end
+
+    def self.failure(manual)
+      new(successful: false, manual: manual)
+    end
+
+    def initialize(successful:, manual:)
+      @successful = successful
+      @manual = manual
+    end
+
+    def successful?
+      @successful
+    end
+
+    def manual_title
+      @manual.title
+    end
+  end
+end

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -99,5 +99,16 @@
         <% end %>
       </div>
     </div>
+
+    <% unless manual.has_ever_been_published? %>
+      <div class="panel panel-default">
+        <div class="panel-heading"><h3>Discard draft manual</h3></div>
+        <div class="panel-body">
+          <%= form_tag(discard_draft_manual_path(manual), method: :delete) do %>
+            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to discard this draft manual?">Discard draft manual</button>
+          <% end -%>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
     # This is for persisted manuals
     post :preview, on: :member
 
+    # This is for drafts that have never been published
+    delete :discard_draft, on: :member
+
     get :original_publication_date, on: :member, action: :edit_original_publication_date
     put :original_publication_date, on: :member, action: :update_original_publication_date
   end

--- a/features/deleting-a-manual.feature
+++ b/features/deleting-a-manual.feature
@@ -12,6 +12,12 @@ Feature: Rake task to delete a manual
     And I confirm deletion
     Then the manual and its sections are deleted
 
+  Scenario: Deleting a manual from the UI
+    Given a draft manual exists without any sections
+    And a draft section exists for the manual
+    When I discard the draft manual
+    Then the manual and its sections are deleted
+
   Scenario: Deleting a published manual
     Given a published manual exists
     When I run the deletion script

--- a/features/step_definitions/deleting_manuals_steps.rb
+++ b/features/step_definitions/deleting_manuals_steps.rb
@@ -25,3 +25,7 @@ end
 Then(/^the manual and its sections still exist$/) do
   check_manual_exists_with(@manual_fields)
 end
+
+When(/^I discard the draft manual$/) do
+  discard_draft_manual(@manual.title)
+end

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -112,6 +112,12 @@ module ManualHelpers
     save_as_draft
   end
 
+  def discard_draft_manual(manual_title)
+    go_to_manual_page(manual_title)
+
+    click_on "Discard draft"
+  end
+
   def withdraw_section(manual_title, section_title, change_note: nil, minor_update: true)
     go_to_manual_page(manual_title)
     click_on section_title

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -33,4 +33,40 @@ describe ManualsController, type: :controller do
       end
     end
   end
+
+  describe '#discard_draft' do
+    let(:manual_id) { 'manual-1' }
+    let(:service) { double(Manual::DiscardDraftService, call: result) }
+    let(:result) { double(:result, successful?: discard_success, manual_title: 'My manual') }
+
+    before do
+      login_as_stub_user
+      allow(Manual::DiscardDraftService).to receive(:new).and_return(service)
+      delete :discard_draft, params: { id: manual_id }
+    end
+
+    context 'when the manual is discarded successfully' do
+      let(:discard_success) { true }
+
+      it 'sets a flash message indicating success' do
+        expect(flash[:notice]).to include("Discarded draft of My manual")
+      end
+
+      it 'redirects to the manuals index' do
+        expect(response).to redirect_to manuals_path
+      end
+    end
+
+    context 'when the manual cannot be discarded' do
+      let(:discard_success) { false }
+
+      it 'sets a flash message indicating failure' do
+        expect(flash[:notice]).to include("Unable to discard draft of My manual")
+      end
+
+      it 'redirects to the show page for the manual' do
+        expect(response).to redirect_to manual_path(manual_id)
+      end
+    end
+  end
 end

--- a/spec/services/manual/discard_draft_service_spec.rb
+++ b/spec/services/manual/discard_draft_service_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe Manual::DiscardDraftService do
+  let(:manual_id) { double(:manual_id) }
+  let(:manual) { double(:manual, id: manual_id, has_ever_been_published?: has_ever_been_published, destroy: nil) }
+  let(:publishing_adapter) { double(:publishing_adapter) }
+  let(:user) { double(:user) }
+
+  subject {
+    described_class.new(
+      user: user,
+      manual_id: manual_id
+    )
+  }
+
+  before do
+    allow(Manual).to receive(:find) { manual }
+    allow(Adapters).to receive(:publishing) { publishing_adapter }
+    allow(publishing_adapter).to receive(:discard)
+  end
+
+  context "when the manual has never been published" do
+    let(:has_ever_been_published) { false }
+
+    it "returns a successful result" do
+      result = subject.call
+      expect(result).to be_successful
+    end
+
+    it "discards the manual via the publishing-api" do
+      subject.call
+      expect(publishing_adapter).to have_received(:discard).with(manual)
+    end
+
+    it "destroys the manual in the local db" do
+      subject.call
+      expect(manual).to have_received(:destroy)
+    end
+  end
+
+  context "when the manual has been published" do
+    let(:has_ever_been_published) { true }
+
+    it "returns a failure result" do
+      result = subject.call
+      expect(result).not_to be_successful
+    end
+
+    it "does not discard the manual via the publishing-api" do
+      subject.call
+      expect(publishing_adapter).not_to have_received(:discard).with(manual)
+    end
+
+    it "does not destroy the manual in the local db" do
+      subject.call
+      expect(manual).not_to have_received(:destroy)
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/PnoMy4LK/87-discard-manual

This adds a "Discard draft" button to manuals that have never been published.  Giving users access to functionality previously only available to devs using the console.