### PR TITLE
Fix dep warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :test do
   gem "cucumber", "~> 3.1.0"
   gem "cucumber-rails", require: false
   gem "database_cleaner"
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   gem "govuk-lint"
   gem "govuk-content-schema-test-helpers", "1.6.0"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,10 +134,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -457,7 +457,7 @@ DEPENDENCIES
   cucumber (~> 3.1.0)
   cucumber-rails
   database_cleaner
-  factory_girl_rails
+  factory_bot_rails
   foreman
   gds-api-adapters (~> 50.8.0)
   gds-sso

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
   before_action :set_authenticated_user_header
 
   rescue_from("Manual::NotFoundError") do

--- a/app/controllers/link_checker_api_callback_controller.rb
+++ b/app/controllers/link_checker_api_callback_controller.rb
@@ -1,6 +1,6 @@
 class LinkCheckerApiCallbackController < ApplicationController
   skip_before_action :verify_authenticity_token
-  skip_before_action :require_signin_permission!
+  skip_before_action :authenticate_user!
   skip_before_action :set_authenticated_user_header
   before_action :verify_signature
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -6,7 +6,7 @@ class Link
 
   field :uri, type: String
   field :status, type: String
-  field :checked, type: DateTime
+  field :checked, type: Time
   field :check_warnings, type: Array
   field :check_errors, type: Array
   field :problem_summary, type: String

--- a/app/models/link_check_report.rb
+++ b/app/models/link_check_report.rb
@@ -10,7 +10,7 @@ class LinkCheckReport
   field :status, type: String
   field :manual_id, type: String
   field :section_id, type: String
-  field :completed_at, type: DateTime
+  field :completed_at, type: Time
 
   validates :batch_id, presence: true
   validates :status, presence: true

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -77,7 +77,7 @@ private
     field :version_number, type: Integer
     field :section_uuids, type: Array
     field :removed_section_uuids, type: Array
-    field :originally_published_at, type: DateTime
+    field :originally_published_at, type: Time
     field :use_originally_published_at_for_public_timestamp, type: Boolean
 
     # We don't make use of the relationship but Mongoid can't save the

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -15,7 +15,7 @@ class SectionEdition
   field :state, type: String
   field :change_note, type: String
   field :minor_update, type: Boolean
-  field :exported_at, type: DateTime
+  field :exported_at, type: Time
 
   validates :section_uuid, presence: true
   validates :slug, presence: true

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -2,10 +2,10 @@
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 def std_opts(default)
-  "--format #{ENV['CUCUMBER_FORMAT'] || default} --strict --tags ~@wip"
+  "--format #{ENV['CUCUMBER_FORMAT'] || default} --strict --tags 'not @wip'"
 end
 %>
 default: <%= std_opts('pretty') %> features
 build: <%= std_opts('progress') %> features
 wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
+rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'

--- a/features/step_definitions/previously_published_manual_steps.rb
+++ b/features/step_definitions/previously_published_manual_steps.rb
@@ -7,7 +7,7 @@ Given(/^I create a manual that was previously published elsewhere$/) do
   }
   @manual_slug = "guidance/example-manual-title"
 
-  @originally_published_at = DateTime.parse("14-Dec-#{Date.today.year - 10} 09:30")
+  @originally_published_at = Time.zone.parse("14-Dec-#{Date.today.year - 10} 09:30")
 
   create_manual(@manual_fields) do
     choose("has previously been published on another website.")
@@ -32,7 +32,7 @@ end
 When(/^I update the previously published date to a new one$/) do
   WebMock::RequestRegistry.instance.reset!
 
-  @new_originally_published_at = DateTime.parse("25-Mar-#{Date.today.year - 8} 12:57")
+  @new_originally_published_at = Time.zone.parse("25-Mar-#{Date.today.year - 8} 12:57")
 
   edit_manual_original_publication_date(@manual.title) do
     select_datetime @new_originally_published_at.to_s, from: "First publication date:"

--- a/features/support/gds_sso_helpers.rb
+++ b/features/support/gds_sso_helpers.rb
@@ -2,7 +2,7 @@ require "warden/test/helpers"
 
 module GdsSsoHelpers
   include Warden::Test::Helpers
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   def login_as(user_type)
     user = create(user_type.to_sym)

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -19,7 +19,7 @@ module ManualHelpers
   def create_manual_without_ui(fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
 
-    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
+    user = FactoryBot.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = Manual::CreateService.new(
       user: user,
@@ -27,7 +27,7 @@ module ManualHelpers
     )
     manual = service.call
 
-    Manual.find(manual.id, FactoryGirl.build(:gds_editor))
+    Manual.find(manual.id, FactoryBot.build(:gds_editor))
   end
 
   def create_section(manual_title, fields)
@@ -42,7 +42,7 @@ module ManualHelpers
   end
 
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
-    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
+    user = FactoryBot.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = Section::CreateService.new(
       user: user,
@@ -66,7 +66,7 @@ module ManualHelpers
   def edit_manual_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     stub_organisation_details(organisation_slug)
 
-    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
+    user = FactoryBot.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = Manual::UpdateService.new(
       user: user,
@@ -90,7 +90,7 @@ module ManualHelpers
   end
 
   def edit_section_without_ui(manual, section, fields, organisation_slug: "ministry-of-tea")
-    user = FactoryGirl.build(:generic_editor, organisation_slug: organisation_slug)
+    user = FactoryBot.build(:generic_editor, organisation_slug: organisation_slug)
 
     service = Section::UpdateService.new(
       user: user,
@@ -149,7 +149,7 @@ module ManualHelpers
     stub_manual_publication_observers(organisation_slug)
 
     service = Manual::PublishService.new(
-      user: FactoryGirl.build(:gds_editor),
+      user: FactoryBot.build(:gds_editor),
       manual_id: manual.id,
       version_number: manual.version_number
     )
@@ -176,13 +176,13 @@ module ManualHelpers
   end
 
   def check_section_exists(manual_id, section_uuid)
-    manual = Manual.find(manual_id, FactoryGirl.build(:gds_editor))
+    manual = Manual.find(manual_id, FactoryBot.build(:gds_editor))
 
     manual.sections.any? { |section| section.uuid == section_uuid }
   end
 
   def check_section_was_removed(manual_id, section_uuid)
-    manual = Manual.find(manual_id, FactoryGirl.build(:gds_editor))
+    manual = Manual.find(manual_id, FactoryBot.build(:gds_editor))
 
     manual.removed_sections.any? { |section| section.uuid == section_uuid }
   end
@@ -423,7 +423,7 @@ module ManualHelpers
   end
 
   def most_recently_created_manual
-    Manual.all(FactoryGirl.build(:gds_editor)).first
+    Manual.all(FactoryBot.build(:gds_editor)).first
   end
 
   def section_fields(section)
@@ -538,7 +538,7 @@ module ManualHelpers
   def republish_manuals_without_ui
     logger = Logger.new(nil)
     republisher = ManualsRepublisher.new(logger)
-    user = FactoryGirl.build(:gds_editor)
+    user = FactoryBot.build(:gds_editor)
     manuals = Manual.all(user)
     republisher.execute(manuals)
   end

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -27,7 +27,7 @@ describe PublishingAdapter do
   let(:manual_id) { "a55242ed-178f-4716-8bb3-5d4f82d38531" }
 
   let(:manual) {
-    FactoryGirl.build(
+    FactoryBot.build(
       :manual,
       id: manual_id,
       slug: "manual-slug",

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -4,9 +4,9 @@ require "gds_api/test_helpers/link_checker_api"
 describe LinkCheckReportsController, type: :controller do
   include GdsApi::TestHelpers::LinkCheckerApi
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:manual) { FactoryGirl.build(:manual, id: 538, body: "[link](http://[www.example.com)") }
-  let(:section) { FactoryGirl.create(:section_edition, id: 53880, body: "[link](http://[www.example.com/section)") }
+  let(:user) { FactoryBot.create(:user) }
+  let(:manual) { FactoryBot.build(:manual, id: 538, body: "[link](http://[www.example.com)") }
+  let(:section) { FactoryBot.create(:section_edition, id: 53880, body: "[link](http://[www.example.com/section)") }
 
   before do
     login_as_stub_user
@@ -60,9 +60,9 @@ describe LinkCheckReportsController, type: :controller do
   describe "#show" do
     context "manual" do
       let(:link_check_report) do
-        FactoryGirl.create(:link_check_report, :with_broken_links,
-                                                manual_id: manual.id,
-                                                batch_id: 1)
+        FactoryBot.create(:link_check_report, :with_broken_links,
+                                              manual_id: manual.id,
+                                              batch_id: 1)
       end
 
       it "GET redirects back to the manual page" do
@@ -83,10 +83,10 @@ describe LinkCheckReportsController, type: :controller do
 
     context "section" do
       let(:link_check_report) do
-        FactoryGirl.create(:link_check_report, :with_broken_links,
-                                                manual_id: manual.id,
-                                                section_id: section.id,
-                                                batch_id: 1)
+        FactoryBot.create(:link_check_report, :with_broken_links,
+                                              manual_id: manual.id,
+                                              section_id: section.id,
+                                              batch_id: 1)
       end
 
       it "GET redirects back to the section page" do

--- a/spec/controllers/link_checker_api_callback_spec.rb
+++ b/spec/controllers/link_checker_api_callback_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe LinkCheckerApiCallbackController, type: :controller do
 
   let(:link_check_report_batch_id) { 5 }
   let(:link_check_report) do
-    FactoryGirl.create(:link_check_report, :with_pending_links,
+    FactoryBot.create(:link_check_report, :with_pending_links,
                                            batch_id: 5,
                                            manual_id: 1,
                                            link_uris: ['https://gov.uk'])

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }
@@ -64,13 +64,13 @@ FactoryGirl.define do
     organisation_slug 'organisation_slug'
 
     after(:build) do |manual_record|
-      manual_record.editions << FactoryGirl.build(:manual_record_edition)
+      manual_record.editions << FactoryBot.build(:manual_record_edition)
     end
 
     trait :with_sections do
       after(:build) do |manual_record|
         manual_record.editions.each do |edition|
-          section = FactoryGirl.create(:section_edition)
+          section = FactoryBot.create(:section_edition)
           edition.section_uuids = [section.section_uuid]
         end
       end
@@ -79,7 +79,7 @@ FactoryGirl.define do
     trait :with_removed_sections do
       after(:build) do |manual_record|
         manual_record.editions.each do |edition|
-          section = FactoryGirl.create(:section_edition)
+          section = FactoryBot.create(:section_edition)
           edition.removed_section_uuids = [section.section_uuid]
         end
       end
@@ -107,14 +107,14 @@ FactoryGirl.define do
     batch_id 1
     status "in_progress"
     completed_at Time.now
-    links { [FactoryGirl.build(:link)] }
+    links { [FactoryBot.build(:link)] }
 
     trait :completed do
       status "completed"
     end
 
     trait :with_broken_links do
-      links { [FactoryGirl.build(:link, :broken)] }
+      links { [FactoryBot.build(:link, :broken)] }
     end
 
     trait :with_pending_links do
@@ -123,7 +123,7 @@ FactoryGirl.define do
       end
 
       links do
-        link_uris.map { |uri| FactoryGirl.build(:link, :pending, uri: uri) }
+        link_uris.map { |uri| FactoryBot.build(:link, :pending, uri: uri) }
       end
     end
   end

--- a/spec/features/publishing_manuals_spec.rb
+++ b/spec/features/publishing_manuals_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishing manuals", type: :feature do
   let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
 
   describe "publishing a manual with major and minor updates" do
-    let(:publish_time) { DateTime.now }
+    let(:publish_time) { Time.zone.now }
 
     before do
       manual = create_manual_without_ui(manual_fields)

--- a/spec/features/republishing_manuals_spec.rb
+++ b/spec/features/republishing_manuals_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Republishing manuals", type: :feature do
     stub_organisation_details(GDS::SSO.test_user.organisation_slug)
   end
 
-  let(:original_publish_time) { DateTime.now - 1.day }
+  let(:original_publish_time) { Time.zone.now - 1.day }
   let(:manual_fields) { { title: "Example manual title", summary: "A summary" } }
   let(:edited_manual_fields) { { title: "Editted manual title", summary: "A changed summary" } }
 

--- a/spec/lib/attachment_reporting_spec.rb
+++ b/spec/lib/attachment_reporting_spec.rb
@@ -12,7 +12,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
 
   # one published before the start date with a PDF
   let!(:early_section_edition_with_pdf) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       exported_at: start_date - 1.day,
@@ -26,7 +26,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
 
   # one published before the start date with a non-PDF attachment
   let!(:early_section_edition_with_non_pdf) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       exported_at: start_date - 1.day,
@@ -40,7 +40,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
 
   # one only drafted before the start date with a PDF attachment
   let!(:early_section_edition_draft_with_pdf) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "draft",
       exported_at: start_date - 1.day,
@@ -54,7 +54,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
 
   # one created between the start date and the last time period
   let!(:more_recent_section_edition) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       exported_at: (Date.today - last_time_period_days) - 1.day,
@@ -68,7 +68,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
 
   # one created after the last time period
   let!(:very_recent_section_edition) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       exported_at: (Date.today - last_time_period_days) + 1.day,
@@ -99,7 +99,7 @@ describe AttachmentReporting, '#create_organisation_attachment_count_hash' do
   let!(:patent_manual_record) { ManualRecord.create(slug: patent_manual_slug, organisation_slug: patent_manual_organisation_slug) }
 
   let!(:very_recent_draft_patent_section_edition) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "draft",
       exported_at: Date.today,

--- a/spec/lib/duplicate_document_finder_spec.rb
+++ b/spec/lib/duplicate_document_finder_spec.rb
@@ -14,8 +14,8 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with different slugs' do
     before {
-      FactoryGirl.create(:section_edition, slug: 'slug-1')
-      FactoryGirl.create(:section_edition, slug: 'slug-2')
+      FactoryBot.create(:section_edition, slug: 'slug-1')
+      FactoryBot.create(:section_edition, slug: 'slug-2')
     }
 
     it "doesn't report them as duplicates" do
@@ -27,8 +27,8 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with the same slug and same section id' do
     before {
-      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 1)
-      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 1)
+      FactoryBot.create(:section_edition, slug: 'slug', section_uuid: 1)
+      FactoryBot.create(:section_edition, slug: 'slug', section_uuid: 1)
     }
 
     it "doesn't report them as duplicates" do
@@ -40,10 +40,10 @@ describe DuplicateDocumentFinder do
 
   context 'when there are multiple editions with the same slug and different section ids' do
     let!(:edition_1) {
-      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 1)
+      FactoryBot.create(:section_edition, slug: 'slug', section_uuid: 1)
     }
     let!(:edition_2) {
-      FactoryGirl.create(:section_edition, slug: 'slug', section_uuid: 2)
+      FactoryBot.create(:section_edition, slug: 'slug', section_uuid: 2)
     }
 
     it "reports them as duplicates" do

--- a/spec/lib/duplicate_draft_deleter_spec.rb
+++ b/spec/lib/duplicate_draft_deleter_spec.rb
@@ -7,7 +7,7 @@ describe DuplicateDraftDeleter do
 
   it "deletes duplicate editions that aren't present in Publishing API" do
     original_content_id = SecureRandom.uuid
-    FactoryGirl.create(:section_edition,
+    FactoryBot.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
       section_uuid: original_content_id,
       state: "draft",
@@ -15,12 +15,12 @@ describe DuplicateDraftDeleter do
     publishing_api_has_item(content_id: original_content_id)
 
     duplicate_content_id = SecureRandom.uuid
-    FactoryGirl.create(:section_edition,
+    FactoryBot.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
       section_uuid: duplicate_content_id,
       state: "draft",
     )
-    FactoryGirl.create(:section_edition,
+    FactoryBot.create(:section_edition,
       slug: "guidance/manual-slug/section-slug",
       section_uuid: duplicate_content_id,
       state: "archived",
@@ -36,12 +36,12 @@ describe DuplicateDraftDeleter do
 
   it "leaves non-duplicated editions alone" do
     content_id = SecureRandom.uuid
-    FactoryGirl.create(:section_edition,
+    FactoryBot.create(:section_edition,
      section_uuid: content_id,
     )
 
     another_content_id = SecureRandom.uuid
-    FactoryGirl.create(:section_edition,
+    FactoryBot.create(:section_edition,
       section_uuid: another_content_id,
     )
 

--- a/spec/lib/manual_publication_log_filter_spec.rb
+++ b/spec/lib/manual_publication_log_filter_spec.rb
@@ -8,7 +8,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   let(:section_edition_exported_time) { Time.current }
 
   let(:section_a_edition_published_version_1_major_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       slug: "#{manual_slug}/first-further-info",
@@ -18,7 +18,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   let(:section_a_edition_published_version_2_major_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       slug: section_a_edition_published_version_1_major_update.slug,
@@ -29,7 +29,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   let(:section_b_edition_published_version_1_major_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       slug: "#{manual_slug}/second-further-info",
@@ -39,7 +39,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   let(:section_b_edition_published_version_2_minor_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       slug: section_b_edition_published_version_1_major_update.slug,
@@ -51,7 +51,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   let(:section_c_edition_archived_version_1_major_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "archived",
       slug: "#{manual_slug}/additional-data",
@@ -61,7 +61,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   let(:section_d_edition_draft_version_1_major_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "draft",
       slug: "#{manual_slug}/draft-info",
@@ -71,7 +71,7 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
   end
 
   let(:section_e_edition_published_version_1_major_update) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :section_edition,
       state: "published",
       slug: "#{manual_slug}/third-further-info",
@@ -82,12 +82,12 @@ describe ManualPublicationLogFilter, "# delete_logs_and_rebuild_for_major_update
 
   let!(:previous_publication_logs) {
     [
-      FactoryGirl.create(:publication_log, slug: manual_slug, created_at: 10.seconds.ago, version_number: 1),
-      FactoryGirl.create(:publication_log, slug: manual_slug, created_at: 8.seconds.ago, version_number: 2)
+      FactoryBot.create(:publication_log, slug: manual_slug, created_at: 10.seconds.ago, version_number: 1),
+      FactoryBot.create(:publication_log, slug: manual_slug, created_at: 8.seconds.ago, version_number: 2)
     ]
   }
   let!(:previous_other_publication_log) {
-    FactoryGirl.create :publication_log, slug: other_slug, created_at: 6.seconds.ago, version_number: 1
+    FactoryBot.create :publication_log, slug: other_slug, created_at: 6.seconds.ago, version_number: 1
   }
 
   let(:first_manual_edition_creation_time) { Time.current - 1.week }
@@ -190,12 +190,12 @@ end
 
 describe ManualPublicationLogFilter::EditionOrdering do
   describe ".sort_by_section_uuids_and_created_at" do
-    let!(:edition_in_third_position) { FactoryGirl.create :section_edition }
-    let!(:edition_in_first_position) { FactoryGirl.create :section_edition }
-    let!(:edition_in_second_position) { FactoryGirl.create :section_edition }
+    let!(:edition_in_third_position) { FactoryBot.create :section_edition }
+    let!(:edition_in_first_position) { FactoryBot.create :section_edition }
+    let!(:edition_in_second_position) { FactoryBot.create :section_edition }
 
-    let!(:other_edition_newer) { FactoryGirl.create :section_edition, created_at: Time.now - 1.day }
-    let!(:other_edition_older) { FactoryGirl.create :section_edition, created_at: Time.now - 1.week }
+    let!(:other_edition_newer) { FactoryBot.create :section_edition, created_at: Time.now - 1.day }
+    let!(:other_edition_older) { FactoryBot.create :section_edition, created_at: Time.now - 1.week }
 
     let!(:section_uuids) {
       [

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -14,16 +14,16 @@ describe ManualRelocator do
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }
-    let!(:existing_section_1) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:existing_section_2) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:temporary_section_1) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:temporary_section_2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:existing_section_1) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:existing_section_2) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:temporary_section_1) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:temporary_section_2) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published", exported_at: DateTime.now) }
 
-    let!(:existing_section_3) { FactoryGirl.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:temporary_section_3) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:existing_section_3) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:temporary_section_3) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published", exported_at: DateTime.now) }
 
-    let!(:existing_publication_log) { FactoryGirl.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
-    let!(:temporary_publication_log) { FactoryGirl.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }
+    let!(:existing_publication_log) { FactoryBot.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
+    let!(:temporary_publication_log) { FactoryBot.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }
 
     before do
       allow(STDOUT).to receive(:puts)
@@ -322,8 +322,8 @@ describe ManualRelocator do
       end
 
       context "when the temp manual has a draft" do
-        let!(:temporary_section_1_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
-        let!(:temporary_section_2_v2) { FactoryGirl.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
+        let!(:temporary_section_1_v2) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 2, state: "draft", body: temporary_section_1.body.reverse) }
+        let!(:temporary_section_2_v2) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 2, state: "draft", body: temporary_section_2.body.reverse) }
 
         before do
           temp_manual.editions << ManualRecord::Edition.new(section_uuids: %w(abcdef bcdefg), state: "published", version_number: 1, body: "This has been published")

--- a/spec/lib/manual_relocator_spec.rb
+++ b/spec/lib/manual_relocator_spec.rb
@@ -14,13 +14,13 @@ describe ManualRelocator do
   describe "#move!" do
     let!(:existing_manual) { ManualRecord.create(manual_id: existing_manual_id, slug: existing_slug, organisation_slug: "cabinet-office") }
     let!(:temp_manual) { ManualRecord.create(manual_id: temp_manual_id, slug: temp_slug, organisation_slug: "cabinet-office") }
-    let!(:existing_section_1) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:existing_section_2) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:temporary_section_1) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:temporary_section_2) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:existing_section_1) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/existing_section_1", section_uuid: "12345", version_number: 1, state: "published", exported_at: Time.zone.now) }
+    let!(:existing_section_2) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/existing_section_2", section_uuid: "23456", version_number: 1, state: "published", exported_at: Time.zone.now) }
+    let!(:temporary_section_1) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_1", section_uuid: "abcdef", version_number: 1, state: "published", exported_at: Time.zone.now) }
+    let!(:temporary_section_2) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/temp_section_2", section_uuid: "bcdefg", version_number: 1, state: "published", exported_at: Time.zone.now) }
 
-    let!(:existing_section_3) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published", exported_at: DateTime.now) }
-    let!(:temporary_section_3) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published", exported_at: DateTime.now) }
+    let!(:existing_section_3) { FactoryBot.create(:section_edition, slug: "#{existing_slug}/section_3", section_uuid: "34567", version_number: 1, state: "published", exported_at: Time.zone.now) }
+    let!(:temporary_section_3) { FactoryBot.create(:section_edition, slug: "#{temp_slug}/section_3", section_uuid: "cdefgh", version_number: 1, state: "published", exported_at: Time.zone.now) }
 
     let!(:existing_publication_log) { FactoryBot.create(:publication_log, slug: "#{existing_slug}/slug-for-existing-section", change_note: "Hello from #{existing_manual_id}") }
     let!(:temporary_publication_log) { FactoryBot.create(:publication_log, slug: "#{temp_slug}/slug-for-temp-section", change_note: "Hello from #{temp_manual_id}") }

--- a/spec/lib/marked_section_deleter_spec.rb
+++ b/spec/lib/marked_section_deleter_spec.rb
@@ -15,7 +15,7 @@ describe MarkedSectionDeleter do
 
   context "when edition is marked for deletion but isn't in publishing api" do
     let!(:edition) {
-      FactoryGirl.create(:section_edition, title: 'xx-to-be-deleted')
+      FactoryBot.create(:section_edition, title: 'xx-to-be-deleted')
     }
 
     before {
@@ -34,7 +34,7 @@ describe MarkedSectionDeleter do
 
   context "when edition is marked for deletion and is in publishing api" do
     let!(:edition) {
-      FactoryGirl.create(:section_edition, title: 'xx-to-be-deleted')
+      FactoryBot.create(:section_edition, title: 'xx-to-be-deleted')
     }
 
     before {
@@ -64,7 +64,7 @@ describe MarkedSectionDeleter do
 
   context "when edition isn't marked for deletion" do
     let!(:edition) {
-      FactoryGirl.create(:section_edition, title: 'not-to-be-deleted')
+      FactoryBot.create(:section_edition, title: 'not-to-be-deleted')
     }
 
     it "doesn't delete any editions" do
@@ -76,7 +76,7 @@ describe MarkedSectionDeleter do
 
   context "when executed in dry run mode" do
     let!(:edition) {
-      FactoryGirl.create(:section_edition, title: 'xx-to-be-deleted')
+      FactoryBot.create(:section_edition, title: 'xx-to-be-deleted')
     }
 
     before {

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe PermissionChecker do
-  let(:generic_writer) { FactoryGirl.build(:generic_writer) }
-  let(:generic_editor) { FactoryGirl.build(:generic_editor) }
-  let(:gds_editor)     { FactoryGirl.build(:gds_editor) }
+  let(:generic_writer) { FactoryBot.build(:generic_writer) }
+  let(:generic_editor) { FactoryBot.build(:generic_editor) }
+  let(:gds_editor)     { FactoryBot.build(:gds_editor) }
 
   describe "#can_publish?" do
     context "a user who is not an editor" do

--- a/spec/lib/publication_logger_spec.rb
+++ b/spec/lib/publication_logger_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PublicationLogger do
   let(:manual) { double(:manual, slug: 'manual-slug', removed_sections: []) }
   let(:sections) { [section] }
   let(:section) { Section.new(manual: manual, uuid: "section-id-1", latest_edition: section_edition) }
-  let(:section_edition) { FactoryGirl.create(:section_edition) }
+  let(:section_edition) { FactoryBot.create(:section_edition) }
 
   before do
     allow(manual).to receive(:sections).and_return(sections)
@@ -21,7 +21,7 @@ RSpec.describe PublicationLogger do
     # update is not to be logged by the PublicationLogger
     context "when a section edition has no change note" do
       let(:cloned_section) { Section.new(manual: manual, uuid: "section-id-2", latest_edition: cloned_section_edition) }
-      let(:cloned_section_edition) { FactoryGirl.create(:section_edition, change_note: nil) }
+      let(:cloned_section_edition) { FactoryBot.create(:section_edition, change_note: nil) }
       let(:sections) { [section, cloned_section] }
       it "does not create a PublicationLog for a cloned Section" do
         expect {

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -26,7 +26,7 @@ describe Attachment do
 
   context "#save" do
     let(:edition) do
-      FactoryGirl.create(:section_edition)
+      FactoryBot.create(:section_edition)
     end
 
     let(:upload_file) do

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -21,8 +21,8 @@ describe Manual do
   }
 
   let(:id) { "0123-4567-89ab-cdef" }
-  let(:updated_at) { Time.parse("2001-01-01") }
-  let(:originally_published_at) { DateTime.parse("2002-02-02") }
+  let(:updated_at) { Time.zone.parse("2001-01-01") }
+  let(:originally_published_at) { Time.zone.parse("2002-02-02") }
   let(:use_originally_published_at_for_public_timestamp) { false }
   let(:title) { "manual-title" }
   let(:summary) { "manual-summary" }

--- a/spec/models/manual_spec.rb
+++ b/spec/models/manual_spec.rb
@@ -4,7 +4,7 @@ require "manual"
 
 describe Manual do
   subject(:manual) {
-    FactoryGirl.build(
+    FactoryBot.build(
       :manual,
       id: id,
       slug: slug,
@@ -56,26 +56,26 @@ describe Manual do
   describe "#eql?" do
     it "is considered the same as another manual instance if they have the same id" do
       expect(manual).to eql(manual)
-      expect(manual).to eql(FactoryGirl.build(:manual, id: manual.id))
-      expect(manual).not_to eql(FactoryGirl.build(:manual, id: manual.id.reverse))
+      expect(manual).to eql(FactoryBot.build(:manual, id: manual.id))
+      expect(manual).not_to eql(FactoryBot.build(:manual, id: manual.id.reverse))
     end
 
     it "is considered the same as another manual instance with the same id even if the version number is different" do
-      expect(manual).to eql(FactoryGirl.build(:manual, id: manual.id, version_number: manual.version_number + 1))
+      expect(manual).to eql(FactoryBot.build(:manual, id: manual.id, version_number: manual.version_number + 1))
     end
   end
 
   describe "#has_ever_been_published?" do
     it "is false if not told at initialize time" do
-      expect(FactoryGirl.build(:manual, id: "1234-5678-9012-3456")).not_to have_ever_been_published
+      expect(FactoryBot.build(:manual, id: "1234-5678-9012-3456")).not_to have_ever_been_published
     end
 
     it "is false if told so at initialize time" do
-      expect(FactoryGirl.build(:manual, id: "1234-5678-9012-3456", ever_been_published: false)).not_to have_ever_been_published
+      expect(FactoryBot.build(:manual, id: "1234-5678-9012-3456", ever_been_published: false)).not_to have_ever_been_published
     end
 
     it "is true if told so at initialize time" do
-      expect(FactoryGirl.build(:manual, id: "1234-5678-9012-3456", ever_been_published: true)).to have_ever_been_published
+      expect(FactoryBot.build(:manual, id: "1234-5678-9012-3456", ever_been_published: true)).to have_ever_been_published
     end
   end
 
@@ -117,7 +117,7 @@ describe Manual do
     end
 
     it "defaults to 0 if not supplied in the initalizer attributes" do
-      expect(FactoryGirl.build(:manual, id: "1234-5678").version_number).to eq 0
+      expect(FactoryBot.build(:manual, id: "1234-5678").version_number).to eq 0
     end
   end
 
@@ -314,9 +314,9 @@ describe Manual do
   end
 
   describe '.all' do
-    let(:user) { FactoryGirl.create(:gds_editor) }
+    let(:user) { FactoryBot.create(:gds_editor) }
     let!(:manual_records) {
-      FactoryGirl.create_list(:manual_record, 2, :with_sections, :with_removed_sections)
+      FactoryBot.create_list(:manual_record, 2, :with_sections, :with_removed_sections)
     }
     let(:all_manuals) { Manual.all(user) }
 
@@ -361,10 +361,10 @@ describe Manual do
   end
 
   describe '.find' do
-    let(:user) { FactoryGirl.create(:gds_editor) }
+    let(:user) { FactoryBot.create(:gds_editor) }
 
     context 'when a manual record with the given id exists in the users collection' do
-      let(:manual_record) { FactoryGirl.create(:manual_record) }
+      let(:manual_record) { FactoryBot.create(:manual_record) }
       let(:edition) { manual_record.editions.first }
 
       it 'builds and returns a manual from the manual record and its edition' do
@@ -392,10 +392,10 @@ describe Manual do
   end
 
   describe "#save" do
-    let(:user) { FactoryGirl.create(:gds_editor) }
+    let(:user) { FactoryBot.create(:gds_editor) }
 
     subject(:manual) {
-      FactoryGirl.build(
+      FactoryBot.build(
         :manual,
         id: 'id',
         slug: 'manual-slug',
@@ -502,8 +502,8 @@ describe Manual do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
       let(:manual_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "draft") }
-      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "draft") }
-      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "draft") }
+      let!(:section_1) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "draft") }
+      let!(:section_2) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "draft") }
 
       before do
         manual_record.editions << manual_edition
@@ -553,8 +553,8 @@ describe Manual do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
       let(:manual_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "published") }
-      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
-      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
+      let!(:section_1) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+      let!(:section_2) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
 
       before do
         manual_record.editions << manual_edition
@@ -604,8 +604,8 @@ describe Manual do
       let(:manual_id) { SecureRandom.uuid }
       let(:manual_record) { ManualRecord.create(manual_id: manual_id, slug: "guidance/my-amazing-manual", organisation_slug: "cabinet-office") }
       let(:manual_edition) { ManualRecord::Edition.new(section_uuids: %w(12345 67890), version_number: 1, state: "withdrawn") }
-      let!(:section_1) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "archived") }
-      let!(:section_2) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "archived") }
+      let!(:section_1) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "archived") }
+      let!(:section_2) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "archived") }
 
       before do
         manual_record.editions << manual_edition
@@ -636,10 +636,10 @@ describe Manual do
       end
 
       context "including new drafts of all sections" do
-        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
-        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
-        let!(:section_1_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 2, state: "draft") }
-        let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 2, state: "draft") }
+        let!(:section_1_published) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+        let!(:section_2_published) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
+        let!(:section_1_draft) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 2, state: "draft") }
+        let!(:section_2_draft) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 2, state: "draft") }
 
         context "the published version returned" do
           it "is the published version as a Manual instance" do
@@ -709,8 +709,8 @@ describe Manual do
       end
 
       context "without new drafts of any sections" do
-        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
-        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
+        let!(:section_1_published) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+        let!(:section_2_published) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
 
         context "the published version returned" do
           it "is the published version as a Manual instance" do
@@ -780,9 +780,9 @@ describe Manual do
       end
 
       context "including new drafts of some sections" do
-        let!(:section_1_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
-        let!(:section_2_published) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
-        let!(:section_2_draft) { FactoryGirl.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 2, state: "draft") }
+        let!(:section_1_published) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-1", section_uuid: "12345", version_number: 1, state: "published") }
+        let!(:section_2_published) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 1, state: "published") }
+        let!(:section_2_draft) { FactoryBot.create(:section_edition, slug: "#{manual_record.slug}/section-2", section_uuid: "67890", version_number: 2, state: "draft") }
 
         context "the published version returned" do
           it "is the published version as a Manual instance" do
@@ -970,7 +970,7 @@ describe Manual do
   end
 
   describe "#destroy" do
-    let!(:manual_record) { FactoryGirl.create(:manual_record, manual_id: manual.id) }
+    let!(:manual_record) { FactoryBot.create(:manual_record, manual_id: manual.id) }
 
     it "destroys underlying manual record" do
       manual.destroy
@@ -979,10 +979,10 @@ describe Manual do
     end
 
     context "when manual has some sections with editions" do
-      let(:section_1_edition_1) { FactoryGirl.create(:section_edition, section_uuid: "section-1") }
-      let(:section_1_edition_2) { FactoryGirl.create(:section_edition, section_uuid: "section-1") }
-      let(:section_2_edition_1) { FactoryGirl.create(:section_edition, section_uuid: "section-2") }
-      let(:section_2_edition_2) { FactoryGirl.create(:section_edition, section_uuid: "section-2") }
+      let(:section_1_edition_1) { FactoryBot.create(:section_edition, section_uuid: "section-1") }
+      let(:section_1_edition_2) { FactoryBot.create(:section_edition, section_uuid: "section-1") }
+      let(:section_2_edition_1) { FactoryBot.create(:section_edition, section_uuid: "section-2") }
+      let(:section_2_edition_2) { FactoryBot.create(:section_edition, section_uuid: "section-2") }
 
       let(:section_1) do
         Section.new(manual: manual, uuid: "section-1",
@@ -1014,11 +1014,11 @@ describe Manual do
   end
 
   describe ".find_by_slug!" do
-    let(:user) { FactoryGirl.create(:gds_editor) }
+    let(:user) { FactoryBot.create(:gds_editor) }
 
     context "when a manual record with the given slug exists" do
       let!(:manual_record) do
-        FactoryGirl.create(:manual_record, slug: "manual-slug")
+        FactoryBot.create(:manual_record, slug: "manual-slug")
       end
 
       it "builds and returns a manual from the manual record and its edition" do
@@ -1028,7 +1028,7 @@ describe Manual do
       end
 
       context "but user does not have access to manual record" do
-        let(:user) { FactoryGirl.create(:generic_editor_of_another_organisation) }
+        let(:user) { FactoryBot.create(:generic_editor_of_another_organisation) }
 
         it "raises Manual::NotFoundError" do
           expect {
@@ -1048,11 +1048,11 @@ describe Manual do
 
     context "when multiple manual records with the given slug exist" do
       let!(:manual_record) do
-        FactoryGirl.create(:manual_record, slug: "manual-slug")
+        FactoryBot.create(:manual_record, slug: "manual-slug")
       end
 
       let!(:another_manual_record) do
-        FactoryGirl.create(:manual_record, slug: manual_record.slug)
+        FactoryBot.create(:manual_record, slug: manual_record.slug)
       end
 
       it "raises Manual::AmbiguousSlugError" do
@@ -1064,7 +1064,7 @@ describe Manual do
   end
 
   describe "#editions" do
-    let!(:manual_record) { FactoryGirl.create(:manual_record, manual_id: manual.id) }
+    let!(:manual_record) { FactoryBot.create(:manual_record, manual_id: manual.id) }
 
     it "returns editions from underlying manual record" do
       expect(manual.editions).to eq(manual_record.editions)
@@ -1072,7 +1072,7 @@ describe Manual do
   end
 
   describe "#set" do
-    let!(:manual_record) { FactoryGirl.create(:manual_record, manual_id: manual.id) }
+    let!(:manual_record) { FactoryBot.create(:manual_record, manual_id: manual.id) }
 
     it "sets attributes on underlying manual record" do
       manual.set(slug: "new-slug")

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -29,9 +29,9 @@ describe SectionEdition do
 
   describe '.all_for_section' do
     it 'returns all editions for a section' do
-      section_1_edition_1 = FactoryGirl.create(:section_edition, section_uuid: 'section-1')
-      section_1_edition_2 = FactoryGirl.create(:section_edition, section_uuid: 'section-1')
-      section_2_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-2')
+      section_1_edition_1 = FactoryBot.create(:section_edition, section_uuid: 'section-1')
+      section_1_edition_2 = FactoryBot.create(:section_edition, section_uuid: 'section-1')
+      section_2_edition = FactoryBot.create(:section_edition, section_uuid: 'section-2')
 
       editions = SectionEdition.all_for_section('section-1')
 
@@ -43,9 +43,9 @@ describe SectionEdition do
 
   describe '.all_for_sections' do
     it 'returns all editions for sections' do
-      section_1_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-1')
-      section_2_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-2')
-      section_3_edition = FactoryGirl.create(:section_edition, section_uuid: 'section-3')
+      section_1_edition = FactoryBot.create(:section_edition, section_uuid: 'section-1')
+      section_2_edition = FactoryBot.create(:section_edition, section_uuid: 'section-2')
+      section_3_edition = FactoryBot.create(:section_edition, section_uuid: 'section-3')
 
       editions = SectionEdition.all_for_sections('section-1', 'section-2')
 

--- a/spec/models/section_edition_spec.rb
+++ b/spec/models/section_edition_spec.rb
@@ -29,29 +29,29 @@ describe SectionEdition do
 
   describe '.all_for_section' do
     it 'returns all editions for a section' do
-      section_1_edition_1 = FactoryBot.create(:section_edition, section_uuid: 'section-1')
-      section_1_edition_2 = FactoryBot.create(:section_edition, section_uuid: 'section-1')
-      section_2_edition = FactoryBot.create(:section_edition, section_uuid: 'section-2')
+      section_a_edition_one = FactoryBot.create(:section_edition, section_uuid: 'section-a')
+      section_a_edition_two = FactoryBot.create(:section_edition, section_uuid: 'section-a')
+      section_b_edition = FactoryBot.create(:section_edition, section_uuid: 'section-b')
 
-      editions = SectionEdition.all_for_section('section-1')
+      editions = SectionEdition.all_for_section('section-a')
 
-      expect(editions).to include(section_1_edition_1)
-      expect(editions).to include(section_1_edition_2)
-      expect(editions).not_to include(section_2_edition)
+      expect(editions).to include(section_a_edition_one)
+      expect(editions).to include(section_a_edition_two)
+      expect(editions).not_to include(section_b_edition)
     end
   end
 
   describe '.all_for_sections' do
     it 'returns all editions for sections' do
-      section_1_edition = FactoryBot.create(:section_edition, section_uuid: 'section-1')
-      section_2_edition = FactoryBot.create(:section_edition, section_uuid: 'section-2')
-      section_3_edition = FactoryBot.create(:section_edition, section_uuid: 'section-3')
+      section_a_edition = FactoryBot.create(:section_edition, section_uuid: 'section-a')
+      section_b_edition = FactoryBot.create(:section_edition, section_uuid: 'section-b')
+      section_c_edition = FactoryBot.create(:section_edition, section_uuid: 'section-c')
 
-      editions = SectionEdition.all_for_sections('section-1', 'section-2')
+      editions = SectionEdition.all_for_sections('section-a', 'section-b')
 
-      expect(editions).to include(section_1_edition)
-      expect(editions).to include(section_2_edition)
-      expect(editions).not_to include(section_3_edition)
+      expect(editions).to include(section_a_edition)
+      expect(editions).to include(section_b_edition)
+      expect(editions).not_to include(section_c_edition)
     end
   end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -145,8 +145,8 @@ describe Section do
 
   describe '.find' do
     context 'when there are associated section editions' do
-      let(:previous_edition) { FactoryGirl.build(:section_edition) }
-      let(:latest_edition) { FactoryGirl.build(:section_edition) }
+      let(:previous_edition) { FactoryBot.build(:section_edition) }
+      let(:latest_edition) { FactoryBot.build(:section_edition) }
       let(:editions_proxy) { double(:editions_proxy, to_a: [latest_edition, previous_edition]).as_null_object }
 
       before do
@@ -769,7 +769,7 @@ describe Section do
   end
 
   describe "#valid?" do
-    let(:latest_edition) { FactoryGirl.build(:section_edition) }
+    let(:latest_edition) { FactoryBot.build(:section_edition) }
 
     before do
       allow(section).to receive(:change_note_required?).and_return(change_note_required)
@@ -880,7 +880,7 @@ describe Section do
   end
 
   describe "#all_editions" do
-    let(:latest_edition) { FactoryGirl.build(:section_edition) }
+    let(:latest_edition) { FactoryBot.build(:section_edition) }
 
     before do
       allow(SectionEdition).to receive(:all_for_section).with(section_uuid).and_return([latest_edition])

--- a/spec/services/link_check_report/create_service_spec.rb
+++ b/spec/services/link_check_report/create_service_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 RSpec.describe LinkCheckReport::CreateService do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
 
-  let(:link_check_report) { FactoryGirl.create(:link_check_report, manual_id: manual.id) }
+  let(:link_check_report) { FactoryBot.create(:link_check_report, manual_id: manual.id) }
 
   let(:link_checker_api_response) do
     {

--- a/spec/services/link_check_report/find_reportable_service_spec.rb
+++ b/spec/services/link_check_report/find_reportable_service_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe LinkCheckReport::FindReportableService do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
   let(:manual) { double(:manual, id: 1, body: "[link](http://www.example.com)") }
 
   before do

--- a/spec/services/link_check_report/show_service_spec.rb
+++ b/spec/services/link_check_report/show_service_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 RSpec.describe LinkCheckReport::ShowService do
   let(:link_check_report) do
-    FactoryGirl.create(:link_check_report, :with_broken_links,
-                                            manual_id: 1,
-                                            batch_id: 1)
+    FactoryBot.create(:link_check_report, :with_broken_links,
+                                          manual_id: 1,
+                                          batch_id: 1)
   end
 
   let(:link_check_report_id) { link_check_report.id }

--- a/spec/services/link_check_report/update_service_spec.rb
+++ b/spec/services/link_check_report/update_service_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe LinkCheckReport::UpdateService do
   let(:link_check_report) do
-    FactoryGirl.create(:link_check_report, :with_pending_links,
+    FactoryBot.create(:link_check_report, :with_pending_links,
                                            batch_id: 1,
                                            manual_id: 1,
                                            link_uris: ['http://www.example.com', 'http://www.gov.com'])

--- a/spec/services/section/list_service_spec.rb
+++ b/spec/services/section/list_service_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 RSpec.describe Section::ListService do
   it 'returns the manual and its sections' do
-    user = FactoryGirl.build(:user, organisation_slug: 'org-slug')
-    manual = FactoryGirl.build(:manual,
+    user = FactoryBot.build(:user, organisation_slug: 'org-slug')
+    manual = FactoryBot.build(:manual,
       organisation_slug: user.organisation_slug)
     section = manual.build_section(title: 'section-title')
     manual.save(user)

--- a/spec/services/section/new_service_spec.rb
+++ b/spec/services/section/new_service_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 RSpec.describe Section::NewService do
   it 'returns the manual and a new section' do
-    user = FactoryGirl.build(:user, organisation_slug: 'org-slug')
-    manual = FactoryGirl.build(:manual, organisation_slug: user.organisation_slug)
+    user = FactoryBot.build(:user, organisation_slug: 'org-slug')
+    manual = FactoryBot.build(:manual, organisation_slug: user.organisation_slug)
     manual.save(user)
 
     service = Section::NewService.new(user: user, manual_id: manual.id)

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -8,7 +8,7 @@ module AuthenticationControllerHelpers
   end
 
   def stub_user
-    FactoryGirl.build(:generic_writer)
+    FactoryBot.build(:generic_writer)
   end
 
   def login_as_stub_user

--- a/spec/views/sections/_form.html.erb_spec.rb
+++ b/spec/views/sections/_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'sections/_form.html.erb', type: :view do
   it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
-    manual = FactoryGirl.build(:manual, id: 'manual-id')
+    manual = FactoryBot.build(:manual, id: 'manual-id')
     section = Section.new(manual: manual, uuid: 'section-uuid')
 
     allow(manual).to receive(:has_ever_been_published?).and_return(true)

--- a/spec/views/sections/withdraw.html.erb_spec.rb
+++ b/spec/views/sections/withdraw.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'sections/withdraw.html.erb', type: :view do
   it 'contains the elements required by the JavaScript that toggles the visibility of the change note field' do
-    manual = FactoryGirl.build(:manual, id: 'manual-id')
+    manual = FactoryBot.build(:manual, id: 'manual-id')
     section = Section.new(manual: manual, uuid: 'section-uuid')
 
     allow(view).to receive(:manual).and_return(ManualViewAdapter.new(manual))


### PR DESCRIPTION
We try to fix the majority of the deprecation warnings present in the tests.  There are a few we can't fix though.

1. There's a warning from cucumber about preferring `not @tag` to `~@tag`, but the lines that cause this warning come from cucumber-rails which hasn't been updated yet (and probably won't be because it works with older versions of cucumber that don't support the new syntax).
2. There's a warning from govuk_frontend_toolkit about `Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0)`, but we can't remove this because there is no way to do so (see https://github.com/alphagov/govuk_frontend_toolkit/issues/416).

Note, the `Replace DateTime with Time` commit may be contentious as we change the type of some fields from `DateTime` to `Time`.  We've done this in response to a rubocop cop suggesting we avoid `DateTime` to make sure we preserve time zone information properly.  It should be a no-op change to the objects because any value stored in the DB that can be parsed by `DateTime` can also be parsed by `Time`, but we'll test this out on integration fully before merging properly though just in case.  Note that the `created_at` and `updated_at` fields added by `::Mongoid::Timestamp` are already `Time` so this gives us even more confidence that all will be ok.