### PR TITLE
Add UI to sections for broken link reporting

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -185,6 +185,10 @@ class Section
     SectionEdition.all_for_section(uuid)
   end
 
+  def link_check_report
+    @link_check_report ||= LinkCheckReport.where(section_id: uuid).last
+  end
+
 private
 
   attr_reader :slug_generator, :latest_edition, :previous_edition

--- a/app/views/admin/link_check_reports/_form.html.erb
+++ b/app/views/admin/link_check_reports/_form.html.erb
@@ -1,3 +1,3 @@
-<%= form_tag link_check_reports_path(link_reportable: { type: "manual", manual_id: reportable.id }), remote: true do %>
+<%= form_tag link_check_reports_path(link_reportable: reportable), remote: true do %>
   <%= submit_tag button_text, class: "btn btn-default add-top-margin remove-bottom-margin" %>
 <% end %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -14,10 +14,10 @@
     </section>
   <% elsif report.broken_links.any? || report.caution_links.any? %>
     <section class="alert alert-warning">
-      <h3 class="remove-top-margin">Links</h3>
+      <h3 class="remove-top-margin"><%= t "broken_links.title" %></h3>
       <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
         <% next unless %w(broken caution).include? status %>
-        <p class="issue-status-description"><%= status.capitalize %></p>
+        <p class="issue-status-description"><%= t "broken_links.#{status}.subheading" %></p>
         <ul class="issue-list">
           <% links.each do |link| %>
             <li>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -111,6 +111,6 @@
   </div>
 
   <div class="col-md-4">
-    <%= render 'admin/link_check_reports/link_check_report', reportable: manual, report: manual.link_check_report %>
+    <%= render "admin/link_check_reports/link_check_report", reportable: { manual_id: manual.to_param }, report: manual.link_check_report %>
   </div>
 </div>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>
-  <li class='active'><%= section.title %></li>
+  <li class="active"><%= section.title %></li>
 <% end %>
 
 <h1 class="page-header">
@@ -10,12 +10,21 @@
 
 <div class="row">
   <div class="sidebar col-md-8">
-    <h2>Summary</h2>
-    <p><%= section.summary %></p>
+    <div class="row">
+      <div class="col-md-12">
+        <h2>Summary</h2>
+        <p><%= section.summary %></p>
+      </div>
+      <div class="col-md-12">
+        <div class="actions well">
+          <%= link_to("Edit section", edit_manual_section_path(manual, section), class: "action-link btn btn-success") %>
+          <%= link_to("Withdraw section", withdraw_manual_section_path(manual, section), class: "action-link btn btn-danger") %>
+        </div>
+      </div>
+    </div>
   </div>
-</div>
 
-<div class="actions well">
-  <%= link_to("Edit section", edit_manual_section_path(manual, section), class: 'action-link btn btn-success') %>
-  <%= link_to("Withdraw section", withdraw_manual_section_path(manual, section), class: 'action-link btn btn-danger') %>
+  <div class="col-md-4">
+    <%= render "admin/link_check_reports/link_check_report", reportable: { manual_id: manual.to_param, section_id: section.to_param }, report: section.link_check_report %>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,9 @@
 
 en:
   hello: "Hello world"
+  broken_links:
+    title: Broken links
+    broken:
+      subheading: We’ve found links in this document that may be broken
+    caution:
+      subheading: We’ve found some issues with links that may indicate problems, you should apply caution in linking to them

--- a/spec/features/check_broken_links_spec.rb
+++ b/spec/features/check_broken_links_spec.rb
@@ -1,38 +1,74 @@
 require "spec_helper"
 
-RSpec.describe "Checking broken links on manuals", type: :feature do
+RSpec.describe "Checking broken links", type: :feature do
   before do
     login_as(:gds_editor)
   end
 
-  let(:manual) { create_manual_without_ui(title: "A manual", summary: "A manual summary", body: "[link](http://www.example.com)") }
+  context "on manuals" do
+    let(:manual) { create_manual_without_ui(title: "A manual", summary: "A manual summary", body: "[link](http://www.example.com)") }
 
-  context "when no link check report exists" do
-    it "should display a link check button if there are links in the manual" do
-      visit "/manuals/#{manual.id}"
-      expect(page).to have_content("Check this document for broken links")
+    context "when no link check report exists" do
+      it "should display a link check button if there are links in the manual" do
+        visit "/manuals/#{manual.id}"
+        expect(page).to have_content("Check this document for broken links")
+      end
+
+      it "should display a link check in progress if the button has been clicked" do
+        create(:link_check_report, manual_id: manual.id)
+        visit "/manuals/#{manual.id}"
+        expect(page).to have_content("Broken link report in progress.")
+      end
     end
 
-    it "should display a link check in progress if the button has been clicked" do
-      create(:link_check_report, manual_id: manual.id)
-      visit "/manuals/#{manual.id}"
-      expect(page).to have_content("Broken link report in progress.")
+    context "when a link check with no broken links exists" do
+      it "should display that there are no broken links" do
+        create(:link_check_report, :completed, manual_id: manual.id)
+        visit "/manuals/#{manual.id}"
+        expect(page).to have_content("This document contains no broken links.")
+      end
+    end
+
+    context "when a link check with broken links exists" do
+      it "should display that there are broken links" do
+        create(:link_check_report, :completed, :with_broken_links, manual_id: manual.id)
+        visit "/manuals/#{manual.id}"
+        expect(page).to have_content("See more details about this link")
+      end
     end
   end
 
-  context "when a link check with no broken links exists" do
-    it "should display that there are no broken links" do
-      create(:link_check_report, :completed, manual_id: manual.id)
-      visit "/manuals/#{manual.id}"
-      expect(page).to have_content("This document contains no broken links.")
-    end
-  end
+  context "on sections" do
+    let(:manual) { create_manual_without_ui(title: "A manual", summary: "A manual summary", body: "[link](http://www.example.com)") }
+    let(:section) { create_section_without_ui(manual, title: "A section", summary: "Section 1 summary", body: "[link](http://www.example.com)") }
 
-  context "when a link check with broken links exists" do
-    it "should display that there are broken links" do
-      create(:link_check_report, :completed, :with_broken_links, manual_id: manual.id)
-      visit "/manuals/#{manual.id}"
-      expect(page).to have_content("See more details about this link")
+    context "when no link check report exists" do
+      it "should display a link check button if there are links in the manual" do
+        visit "/manuals/#{manual.id}/sections/#{section.uuid}"
+        expect(page).to have_content("Check this document for broken links")
+      end
+
+      it "should display a link check in progress if the button has been clicked" do
+        create(:link_check_report, manual_id: manual.id, section_id: section.uuid)
+        visit "/manuals/#{manual.id}/sections/#{section.uuid}"
+        expect(page).to have_content("Broken link report in progress.")
+      end
+    end
+
+    context "when a link check with no broken links exists" do
+      it "should display that there are no broken links" do
+        create(:link_check_report, :completed, manual_id: manual.id, section_id: section.uuid)
+        visit "/manuals/#{manual.id}/sections/#{section.uuid}"
+        expect(page).to have_content("This document contains no broken links.")
+      end
+    end
+
+    context "when a link check with broken links exists" do
+      it "should display that there are broken links" do
+        create(:link_check_report, :completed, :with_broken_links, manual_id: manual.id, section_id: section.uuid)
+        visit "/manuals/#{manual.id}/sections/#{section.uuid}"
+        expect(page).to have_content("See more details about this link")
+      end
     end
   end
 end


### PR DESCRIPTION
- Include the Link Checker button on the Sections show page
- Include suggested fix and summary problem for links with issues

Continuation of work in https://github.com/alphagov/manuals-publisher/pull/1233