### PR TITLE
Upgrade govspeak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV["GOVSPEAK_DEV"]
   gem "govspeak", path: "../govspeak"
 else
-  gem "govspeak", "~> 5.3"
+  gem "govspeak", "~> 5.4.0"
 end
 
 gem "govuk_frontend_toolkit", "7.2.0" # we rely on this for correctly previewing govspeak (including interactive elements) - to help with that keep it in sync with the version used in manuals-frontend

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     gherkin (5.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    govspeak (5.3.0)
+    govspeak (5.4.0)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -463,7 +463,7 @@ DEPENDENCIES
   gds-api-adapters (~> 50.9.1)
   gds-sso
   generic_form_builder
-  govspeak (~> 5.3)
+  govspeak (~> 5.4.0)
   govuk-content-schema-test-helpers (= 1.6.0)
   govuk-lint
   govuk_admin_template


### PR DESCRIPTION
This PR bumps the version of govspeak so we can use the new `website_root` argument in `extracted_links` ensure all links extracted are fully qualified.