### PR TITLE
Ensure all links sent to Link Checker API urls

### DIFF
--- a/app/services/link_check_report/create_service.rb
+++ b/app/services/link_check_report/create_service.rb
@@ -1,5 +1,4 @@
 require "services"
-require "govspeak/link_extractor"
 
 class LinkCheckReport::CreateService
   include Rails.application.routes.url_helpers
@@ -19,6 +18,8 @@ class LinkCheckReport::CreateService
   end
 
   def call
+    return if uris.empty?
+
     link_report = call_link_checker_api.deep_symbolize_keys
 
     report = LinkCheckReport.new(
@@ -49,12 +50,8 @@ private
     ).call
   end
 
-  def govspeak_document
-    Govspeak::Document.new(reportable.body)
-  end
-
   def uris
-    govspeak_document.extracted_links
+    @uris ||= LinkCheckReport::LinkExtractorService.new(body: reportable.body).call
   end
 
   def call_link_checker_api

--- a/app/services/link_check_report/link_extractor_service.rb
+++ b/app/services/link_check_report/link_extractor_service.rb
@@ -1,0 +1,23 @@
+require "govspeak/link_extractor"
+
+class LinkCheckReport::LinkExtractorService
+  def initialize(body:)
+    @body = body
+  end
+
+  def call
+    govspeak_document.extracted_links(website_root: website_root)
+  end
+
+private
+
+  attr_reader :body
+
+  def website_root
+    @website_root ||= Plek.new.website_root
+  end
+
+  def govspeak_document
+    Govspeak::Document.new(body)
+  end
+end

--- a/spec/services/link_check_report/link_extractor_service_spec.rb
+++ b/spec/services/link_check_report/link_extractor_service_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReport::LinkExtractorService do
+  let(:body) do
+    %{
+## Heading
+
+[link](http://www.example.com)
+
+[link_two](http://www.gov.com)
+
+[not_a_link](#somepage)
+
+[mailto:](mailto:someone@www.example.com)
+
+[absolute_path](/cais-trwydded-yrru-dros-dro)
+    }
+  end
+
+  let(:website_root) { Plek.new.website_root }
+
+  subject { described_class.new(body: body).call }
+
+  it "should contain three full urls" do
+    expected_result = %W{http://www.example.com http://www.gov.com #{website_root}/cais-trwydded-yrru-dros-dro}
+
+    expect(subject).to match(expected_result)
+  end
+
+  it "should not contain a mailto" do
+    expect(subject).not_to include("mailto:someone@www.example.com")
+  end
+
+  it "should not an anchor" do
+    expect(subject).not_to include("#somepage")
+  end
+end


### PR DESCRIPTION
This PR ensures all the links we send to the link checker API are full URLs not just absolute paths.