### PR TITLE
Fix missing section_id bug

### DIFF
--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -8,6 +8,8 @@ class LinkCheckReportsController < ApplicationController
 
     @report = service.call
 
+    return handle_nil_report unless @report
+
     @reportable = reportable_hash
 
     respond_to do |format|
@@ -30,6 +32,13 @@ class LinkCheckReportsController < ApplicationController
   end
 
 private
+
+  def handle_nil_report
+    respond_to do |format|
+      format.js { head :unprocessable_entity }
+      format.html { redirect_back(fallback_location: root_path) }
+    end
+  end
 
   def reportable_object
     @reportable_object ||= find_reportable(section_id: @report.section_id, manual_id: @report.manual_id)

--- a/spec/controllers/link_check_reports_controller_spec.rb
+++ b/spec/controllers/link_check_reports_controller_spec.rb
@@ -22,6 +22,21 @@ describe LinkCheckReportsController, type: :controller do
       stub_link_checker_api
     end
 
+    context "when there are no links" do
+      let(:manual) { FactoryBot.build(:manual, id: 538, body: "hello") }
+
+      it "returns 422 for AJAX requests" do
+        post :create, xhr: true, params: { link_reportable: { manual_id: manual.id } }
+        expect(response.status).to eq(422)
+      end
+
+      it "redirects POST page" do
+        post :create, params: { link_reportable: { manual_id: manual.id } }
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
     context "manual" do
       it "POST returns a redirects to the manual show page" do
         post :create, params: { link_reportable: { manual_id: manual.id } }


### PR DESCRIPTION
This PR fixes the error that occurs if no links existed in a manual or a section. It does this by returning a 422 status for AJAX requests or redirects back for normal HTTP requests