### PR TITLE
Send change notes to the publishing-api

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -219,6 +219,7 @@ private
       update_type: update_type,
       publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
       rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
+      change_note: section.change_note,
       routes: [
         {
           path: "/#{section.slug}",

--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -170,6 +170,11 @@ private
       locale: GdsApiConstants::PublishingApiV2::EDITION_LOCALE,
     }
 
+    latest_publication = manual.publication_logs.first
+    if latest_publication
+      attributes[:change_note] = "#{latest_publication.title} - #{latest_publication.change_note}"
+    end
+
     if manual.originally_published_at.present?
       attributes[:first_published_at] = manual.originally_published_at
       if manual.use_originally_published_at_for_public_timestamp?

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -463,14 +463,17 @@ describe PublishingAdapter do
       it "saves content for manual to Publishing API including change notes" do
         expect(publishing_api).to receive(:put_content).with(
           manual_id,
-          including(details: including(
-            change_notes: [{
-              title: "section-title",
-              base_path: "/manual-slug/section-slug",
-              change_note: "section-change-note",
-              published_at: timestamp
-            }]
-          ))
+          including(
+            change_note: "section-title - section-change-note",
+            details: including(
+              change_notes: [{
+                title: "section-title",
+                base_path: "/manual-slug/section-slug",
+                change_note: "section-change-note",
+                published_at: timestamp
+              }]
+            )
+          )
         )
 
         subject.save(manual)

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -53,7 +53,8 @@ describe PublishingAdapter do
       slug: "manual-slug/section-slug",
       title: "section-title",
       summary: "section-summary",
-      body: "section-body"
+      body: "section-body",
+      change_note: "change-note",
     )
   }
 
@@ -206,6 +207,7 @@ describe PublishingAdapter do
         update_type: GdsApiConstants::PublishingApiV2::MAJOR_UPDATE_TYPE,
         publishing_app: GdsApiConstants::PublishingApiV2::PUBLISHING_APP,
         rendering_app: GdsApiConstants::PublishingApiV2::RENDERING_APP,
+        change_note: "change-note",
         routes: [
           {
             path: "/manual-slug/section-slug",


### PR DESCRIPTION
This PR means that change notes from sections will be sent to the Publishing API, and therefore picked up by the Email Alert Service.

[Trello Card](https://trello.com/c/5M9OTPir/517-get-change-notes-to-show-up-for-more-formats-email-updates)