### PR TITLE
Remove secret token environment variable

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -21,5 +21,5 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] || ENV["SECRET_TOKEN"] %>
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   link_checker_api_secret_token: <%= ENV["LINK_CHECKER_API_SECRET_TOKEN"] %>


### PR DESCRIPTION
The work to migrate this away has been completed and the environment
variable is no longer set in production.