### PR TITLE
Revert "Bump sidekiq from 3.2.1 to 5.1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "mongoid", "~> 6.0"
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 gem "plek"
 gem "raindrops", ">= 0.13.0" # we need a version > 0.13.0 for ruby 2.2
-gem "sidekiq", "5.1.0"
+gem "sidekiq", "3.2.1"
 gem "sidekiq-statsd", "0.1.5"
 gem "state_machine", "1.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,23 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    celluloid (0.17.3)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.6)
+      timers (>= 4.1.1)
     cliver (0.3.2)
     coderay (1.1.2)
     commander (4.4.3)
@@ -178,6 +195,7 @@ GEM
     hashdiff (0.3.7)
     hashie (3.5.7)
     highline (1.7.10)
+    hitimes (1.2.6)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -312,6 +330,8 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.0.1)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     request_store (1.4.0)
       rack (>= 1.4)
     rest-client (2.0.2)
@@ -368,11 +388,12 @@ GEM
       sass (~> 3.5.3)
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
-    sidekiq (5.1.0)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.4, < 5)
+    sidekiq (3.2.1)
+      celluloid (>= 0.15.2)
+      connection_pool (>= 2.0.0)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
     sidekiq-statsd (0.1.5)
       activesupport
       sidekiq (>= 2.6)
@@ -400,6 +421,8 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    timers (4.1.2)
+      hitimes
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (4.1.5)
@@ -460,7 +483,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   sass-rails
-  sidekiq (= 5.1.0)
+  sidekiq (= 3.2.1)
   sidekiq-statsd (= 0.1.5)
   simplecov
   sinatra (~> 2.0)


### PR DESCRIPTION
Reverts alphagov/manuals-publisher#1279

This upgrade broke the Sidekiq worker with this message:

```
ERROR: Your Redis configuration uses the namespace 'manuals-publisher' but the redis-namespace gem is not included in the Gemfile.Add the gem to your Gemfile to continue using a namespace. Otherwise, remove the namespace parameter.
```