### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
 RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV MONGODB_URI mongodb://mongo/manuals-publisher
 ENV PORT 3205
@@ -18,4 +19,4 @@ ADD . $APP_HOME
 
 RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
-CMD bash -c "bundle exec foreman run web"
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ end
 
 group :development, :test do
   gem "awesome_print"
-  gem "foreman"
   gem "jasmine-rails"
   gem "pry-byebug"
   gem "sinatra", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,8 +142,6 @@ GEM
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.21)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -459,7 +457,6 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   factory_bot_rails
-  foreman
   gds-api-adapters (~> 51.2.0)
   gds-sso
   generic_form_builder
@@ -493,4 +490,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec unicorn -p ${PORT:-3205}
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3205}
 worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-PORT=3205 bundle exec foreman start
+bundle exec rails s -p 3205


### PR DESCRIPTION
Wider context: alphagov/publishing-e2e-tests#202

This removes foreman from the Gemfile and from the startup.sh usage and
instead installs foreman separately via gem install in the Dockerfile
so that it can be used in the docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.