### PR TITLE
Fix for change note not showing

### DIFF
--- a/app/views/sections/_form.html.erb
+++ b/app/views/sections/_form.html.erb
@@ -19,7 +19,7 @@
         <div class="checkbox add-vertical-margins">
           <%= f.radio_button :minor_update, 0, class: 'js-update-type-major', tag_type: :p, label: 'Major update', checked: !section.minor_update %>
         </div>
-        <div class="<%= section.minor_update ? 'js-hidden' : nil %>">
+        <div class="change_note_container <%= section.minor_update ? 'js-hidden' : nil %>">
           <%= f.text_area :change_note, rows: 20, cols: 40, class: 'form-control short-textarea' %>
           <p class="help-block">This will be publically viewable on GOV.UK.</p>
         </div>
@@ -86,12 +86,12 @@
 
   window.toggleDisplayWithCheckedInput({
     $input: $("#section_minor_update_1"),
-    $element: $("#section_change_note").parent(),
+    $element: $("#change_note_container"),
     mode: 'hide'
   });
   window.toggleDisplayWithCheckedInput({
     $input: $("#section_minor_update_0"),
-    $element: $("#section_change_note").parent(),
+    $element: $("#change_note_container"),
     mode: 'show'
   });
   $('.js-hidden').hide();

--- a/app/views/sections/withdraw.html.erb
+++ b/app/views/sections/withdraw.html.erb
@@ -24,7 +24,7 @@
         <div class="checkbox add-vertical-margins">
           <%= f.radio_button :minor_update, 0, tag_type: :p, label: 'Major update', checked: !section.minor_update %>
         </div>
-        <div class="<%= section.minor_update ? 'js-hidden' : nil %>">
+        <div class="change_note_container <%= section.minor_update ? 'js-hidden' : nil %>">
           <%= f.text_area :change_note, rows: 20, cols: 40, class: 'form-control short-textarea' %>
           <p class="help-block">This will be publically viewable on GOV.UK.</p>
         </div>
@@ -40,12 +40,12 @@
 <%= content_for :document_ready do %>
   window.toggleDisplayWithCheckedInput({
     $input: $("#section_minor_update_1"),
-    $element: $("#section_change_note").parent(),
+    $element: $("#change_note_container"),
     mode: 'hide'
   });
   window.toggleDisplayWithCheckedInput({
     $input: $("#section_minor_update_0"),
-    $element: $("#section_change_note").parent(),
+    $element: $("#change_note_container"),
     mode: 'show'
   });
   $('.js-hidden').hide();


### PR DESCRIPTION
Ex: https://manuals-publisher.publishing.service.gov.uk/manuals/64edf75e-7c37-45e9-927f-c116d7ded396/sections/4de36988-aa62-496c-9a2a-a7fdb5c1fa52/edit

When editing sections where "Minor update" is checked by default, the change note does not appear when you choose "Major update" instead. This is because the JS for unhiding the change note is too ambiguous and looks for the _parent_ of the change note to make visible, which is unexpectedly an extra p tag instead of the expected parent div.

HTML in `app/views/sections/_form.html.erb`:

```
<div class="change_note_container <%= section.minor_update ? 'js-hidden' : nil %>">
  <%= f.text_area :change_note, rows: 20, cols: 40, class: 'form-control short-textarea' %>
  <p class="help-block">This will be publically viewable on GOV.UK.</p>
</div>
```

which gets turned into

```
<div class="js-hidden" style="display: none;">
  <p style="display: block;"><label for="section_change_note">Change note </label><textarea rows="20" cols="40" class="form-control short-textarea" name="section[change_note]" id="section_change_note"></texta
  <p class="help-block">This will be publically viewable on GOV.UK.</p>
</div>
```

Notice that the extra p has the style property set to "display:block" instead of neutralizing
the "display:none" from the div above.

This commit adds a class to the div (`change_note_container `) and points to that instead of using `$("#section_change_note").parent()` which was less reliable.

For: https://govuk.zendesk.com/agent/tickets/2617087

## Expected 
<img width="899" alt="screen shot 2018-03-21 at 17 16 58" src="https://user-images.githubusercontent.com/1354439/37725862-d7d5bd02-2d2b-11e8-9ab8-702359b0e391.png">

## What actually happens 
<img width="768" alt="screen shot 2018-03-21 at 17 16 38" src="https://user-images.githubusercontent.com/1354439/37725826-bfd2fc60-2d2b-11e8-963f-4e0a1570ef5d.png">
