### PR TITLE
Set primary publishing organisation

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -87,6 +87,7 @@ private
       manual.id,
       links: {
         organisations: [organisation.content_id],
+        primary_publishing_organisation: [organisation.content_id],
         sections: manual.sections.map(&:uuid),
       }
     )
@@ -196,6 +197,7 @@ private
       section.uuid,
       links: {
         organisations: [organisation.content_id],
+        primary_publishing_organisation: [organisation.content_id],
         manual: [manual.id],
       }
     )

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -96,6 +96,7 @@ describe PublishingAdapter do
         manual_id,
         links: {
           organisations: [organisation_content_id],
+          primary_publishing_organisation: [organisation_content_id],
           sections: [section_uuid]
         }
       )
@@ -178,6 +179,7 @@ describe PublishingAdapter do
         section_uuid,
         links: {
           organisations: [organisation_content_id],
+          primary_publishing_organisation: [organisation_content_id],
           manual: [manual_id]
         }
       )


### PR DESCRIPTION
This is set to be the same as the organisation.

As part of work to set `primary_publishing_organisation` on all content items so that we can slice data in the Content Performance Manager data-warehouse according to the organisation. 

Depends on https://github.com/alphagov/govuk-content-schemas/pull/764