### PR TITLE
Replace poltergeist with chrome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,10 @@ group :test do
   gem "cucumber-rails", require: false
   gem "database_cleaner"
   gem "factory_bot_rails"
+  gem "govuk_test"
   gem "govuk-lint"
   gem "govuk-content-schema-test-helpers", "1.6.1"
   gem "launchy"
-  gem "poltergeist", "~> 1.17.0"
-  gem "phantomjs", ">= 1.9.7.1"
   gem "rspec"
   gem "rails-controller-testing"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (8.3.0)
@@ -82,7 +84,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    cliver (0.3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     commander (4.4.4)
       highline (~> 1.7.2)
@@ -185,6 +191,11 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
+    govuk_test (0.1.0)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     hashdiff (0.3.7)
     hashie (3.5.7)
     highline (1.7.10)
@@ -193,6 +204,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jasmine-core (2.99.2)
     jasmine-rails (0.14.8)
       jasmine-core (>= 1.3, < 3.0)
@@ -272,10 +284,6 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -284,6 +292,7 @@ GEM
       byebug (~> 9.1)
       pry (~> 0.10)
     public_suffix (3.0.2)
+    puma (3.12.0)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -365,6 +374,7 @@ GEM
     rubocop-rspec (1.19.0)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sanitize (4.6.4)
       crass (~> 1.0.2)
@@ -384,6 +394,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (5.1.3)
@@ -461,13 +474,12 @@ DEPENDENCIES
   govuk_app_config (~> 1.8)
   govuk_frontend_toolkit (= 7.6.0)
   govuk_sidekiq (~> 3)
+  govuk_test
   jasmine-rails
   launchy
   mongoid (~> 6.0)
   mongoid_rails_migrations!
-  phantomjs (>= 1.9.7.1)
   plek
-  poltergeist (~> 1.17.0)
   pry-byebug
   rails (~> 5.2)
   rails-controller-testing
@@ -482,4 +494,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/features/support/gds_sso_helpers.rb
+++ b/features/support/gds_sso_helpers.rb
@@ -11,6 +11,7 @@ module GdsSsoHelpers
   end
 
   def log_out
+    Capybara.reset_session!
     GDS::SSO.test_user = nil
     logout # warden
   end

--- a/features/support/govuk_test.rb
+++ b/features/support/govuk_test.rb
@@ -1,0 +1,1 @@
+GovukTest.configure

--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -1,3 +1,0 @@
-require "capybara/poltergeist"
-require "phantomjs/poltergeist"
-Capybara.javascript_driver = :poltergeist

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,10 +1,2 @@
 require "webmock/cucumber"
-WebMock.disable_net_connect!
-
-Before("@javascript") do
-  WebMock.disable_net_connect!(allow_localhost: true)
-end
-
-After("@javascript") do
-  WebMock.disable_net_connect!
-end
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
https://trello.com/c/aaOagXQX/419-switch-manuals-publisher-from-poltergeist-to-headless-chrome

Poltergeist is no longer maintained so use headless chrome driver for Capybara.