### PR TITLE
Fixed broken manual by forcing state to be published

### DIFF
--- a/db/migrate/20181029170924_force_update_broken_manual_published.rb
+++ b/db/migrate/20181029170924_force_update_broken_manual_published.rb
@@ -1,0 +1,14 @@
+class ForceUpdateBrokenManualPublished < Mongoid::Migration
+  def self.up
+    user = User.find_by(email: "oscar.wyatt@digital.cabinet-office.gov.uk")
+    if user
+      manual = Manual.find("b59056ac-f7e9-4415-96b5-79cc5cfb0a76", user)
+      if manual
+        manual.editions.sort_by{|ed| ed.created_at}.last.update(state: "published")
+      end
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Fixes manual marked as unpublished on the local database of manuals-publisher but publishing-api has successfully published the manual so it can't be updated as a minor change

ticket: https://govuk.zendesk.com/agent/tickets/3401170