### PR TITLE
Add migration to fix broken manual

### DIFF
--- a/db/migrate/20181030143621_another_force_update_broken_manual_published.rb
+++ b/db/migrate/20181030143621_another_force_update_broken_manual_published.rb
@@ -1,0 +1,22 @@
+class AnotherForceUpdateBrokenManualPublished < Mongoid::Migration
+  def self.up
+    user = User.find_by(email: "oscar.wyatt@digital.cabinet-office.gov.uk")
+    if user
+      manual = Manual.find("99005789-d82b-4045-932b-8ad9752a80bc", user)
+      if manual
+        service = Manual::UpdateService.new(
+          user: user,
+          manual_id: manual.id,
+          attributes: { state: "published" }
+        )
+        service.call
+        # It is incorrectly using the old publish tasks which are all aborted so delete them before republishing
+        manual.publish_tasks.each(&:delete)
+        manual.publish
+      end
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Fixes manual marked as unpublished on the local database of manuals-publisher but publishing-api has successfully published the manual so it can't be updated as a minor change

PR #1394 was a previous, unsuccessful attempt at fixing the same problem

Ticket: https://govuk.zendesk.com/agent/tickets/3401170