### PR TITLE
Fix the republish manuals rake task

### DIFF
--- a/lib/tasks/republish_manuals.rake
+++ b/lib/tasks/republish_manuals.rake
@@ -2,9 +2,11 @@ require "manuals_republisher"
 require "logger"
 
 desc "Republish manuals"
-task :republish_manuals, [:slug] => :environment do |_, args|
+task :republish_manuals, %i[user_email slug] => :environment do |_, args|
   logger = Logger.new(STDOUT)
   logger.formatter = Logger::Formatter.new
+
+  user = User.find_by(email: args[:user_email])
 
   manuals = if args.has_key?(:slug)
               [Manual.find_by_slug!(args[:slug], user)]


### PR DESCRIPTION
Previously, it would fail as user isn't defined. Now you can provide
an email address, and it will republish using that user.

I believe this has been broken for a while, ever since
e838d066257fd3372e5bd3a6215848753597ed47.

I'm looking at this as part of investigating data anomalies in the
Content Performance Manager, as the guidance/the-highway-code manual
was republished back in 2017, and was sent through without a
public_updated_at value.