### PR TITLE
Add bearer tokens for link-checker-api authentication

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -30,6 +30,7 @@ module Services
   def self.link_checker_api
     @link_checker_api ||= GdsApi::LinkCheckerApi.new(
       Plek.find("link-checker-api"),
+      bearer_token: ENV['LINK_CHECKER_API_BEARER_TOKEN'],
     )
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/2IdzHdtp

Related to: 
* https://github.com/alphagov/govuk-puppet/pull/8488
* https://github.com/alphagov/link-checker-api/pull/227

Passes the bearer token needed to authenticate with link-checker-api using signon.