### PR TITLE
Rescue from GdsApi::HTTPNotFound errors when unpublishing a section

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -287,8 +287,12 @@ private
 
   def unpublish_section(section, manual, republish:)
     if !section.withdrawn? || republish
-      Services.publishing_api.unpublish(section.uuid, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
-      section.withdraw_and_mark_as_exported! if !republish
+      begin
+        Services.publishing_api.unpublish(section.uuid, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+        section.withdraw_and_mark_as_exported! if !republish
+      rescue GdsApi::HTTPNotFound
+        puts "Content item with section_uuid #{section_uuid} not present in the publishing API"
+      end
     end
   end
 


### PR DESCRIPTION
A manual section may have already been unpublished in the relevant publishing app.  If we try to unpublish it again here when updating a manual, a 404 error is returned from publishing-api.

This allows the update of the manual to continue when the section has already been removed elsewhere.

Related to Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3669351