### PR TITLE
Require full manual section slug when reslugging

### DIFF
--- a/lib/section_reslugger.rb
+++ b/lib/section_reslugger.rb
@@ -23,6 +23,8 @@ class SectionReslugger
 
 private
 
+  attr_reader :old_section_slug, :new_section_slug
+
   def validate
     validate_old_section
     validate_new_section
@@ -48,22 +50,22 @@ private
   end
 
   def validate_new_section_in_database
-    section_edition = section_edition_in_database(full_new_section_slug)
+    section_edition = section_edition_in_database(new_section_slug)
     raise Error.new("Manual Section already exists in database") if section_edition
   end
 
   def validate_new_section_in_content_store
-    section = section_in_content_store(full_new_section_slug)
+    section = section_in_content_store(new_section_slug)
     raise Error.new("Manual Section already exists in content store") if section
   rescue GdsApi::ContentStore::ItemNotFound # rubocop:disable Lint/HandleExceptions
   end
 
   def redirect_section(section)
-    Adapters.publishing.redirect_section(section, to: "/#{full_new_section_slug}")
+    Adapters.publishing.redirect_section(section, to: "/#{new_section_slug}")
   end
 
   def update_slug
-    new_edition_for_slug_change.update_slug!(full_new_section_slug)
+    new_edition_for_slug_change.update_slug!(new_section_slug)
   end
 
   def new_edition_for_slug_change
@@ -113,11 +115,11 @@ private
   end
 
   def old_section_edition
-    @old_section_edition ||= section_edition_in_database(full_old_section_slug)
+    @old_section_edition ||= section_edition_in_database(old_section_slug)
   end
 
   def old_section_in_content_store
-    @old_section_in_content_store ||= section_in_content_store(full_old_section_slug)
+    @old_section_in_content_store ||= section_in_content_store(old_section_slug)
   end
 
   def section_edition_in_database(slug)
@@ -130,17 +132,5 @@ private
 
   def content_store
     Services.content_store
-  end
-
-  def full_old_section_slug
-    full_section_slug(@old_section_slug)
-  end
-
-  def full_new_section_slug
-    full_section_slug(@new_section_slug)
-  end
-
-  def full_section_slug(slug)
-    "#{manual.slug}/#{slug}"
   end
 end

--- a/lib/section_slug_synchroniser.rb
+++ b/lib/section_slug_synchroniser.rb
@@ -15,13 +15,13 @@ class SectionSlugSynchroniser
     else
       if amendments.any?
         log "The following sections can be reslugged:"
-        amendments.each { |k, v| log "'#{section_slug(k)}' to '#{section_slug(v)}'" }
+        amendments.each { |k, v| log "'#{k}' to '#{v}'" }
       end
 
       if conflicts.any?
         log "The following sections cannot be reslugged:"
         conflicts.each do |k, v|
-          log "'#{section_slug(k)}' would change to '#{section_slug(v)}' but this is already in use."
+          log "'#{k}' would change to '#{v}' but this is already in use."
         end
       end
     end
@@ -29,10 +29,8 @@ class SectionSlugSynchroniser
 
   def synchronise
     amendments = analyse_sections.first
-    amendments.each do |full_old_section_slug, full_new_section_slug|
-      old_section_slug = section_slug(full_old_section_slug)
-      new_section_slug = section_slug(full_new_section_slug)
-      log "Reslugging #{full_old_section_slug} to #{full_new_section_slug}"
+    amendments.each do |old_section_slug, new_section_slug|
+      log "Reslugging #{old_section_slug} to #{new_section_slug}"
       SectionReslugger.new(manual.slug, old_section_slug, new_section_slug).call
     end
   end
@@ -58,10 +56,6 @@ private
     end
 
     [amendments, conflicts]
-  end
-
-  def section_slug(slug)
-    slug.split("/").last
   end
 
   def log(str)

--- a/lib/tasks/reslug_section.rake
+++ b/lib/tasks/reslug_section.rake
@@ -9,10 +9,10 @@ def usage
       slug of manual (eg 'guidance/countryside-stewardship-manual')
 
     old_section_slug:
-      current slug of section to be renamed (eg '8-terms-and-conditions')
+      current slug of section to be renamed (eg 'guidance/countryside-stewardship-manual/8-terms-and-conditions')
 
     new_section_slug:
-      new slug for section (eg '8-scheme-requirements-and-procedures')
+      new slug for section (eg 'guidance/countryside-stewardship-manual/8-scheme-requirements-and-procedures')
   USAGE
 
   exit(1)

--- a/spec/lib/section_reslugger_spec.rb
+++ b/spec/lib/section_reslugger_spec.rb
@@ -12,8 +12,8 @@ describe SectionReslugger do
   subject {
     described_class.new(
       'manual-slug',
-      'old-section-slug',
-      'new-section-slug'
+      'manual-slug/old-section-slug',
+      'manual-slug/new-section-slug'
     )
   }
 

--- a/spec/lib/section_slug_synchroniser_spec.rb
+++ b/spec/lib/section_slug_synchroniser_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe SectionSlugSynchroniser do
         expect(logger).to receive(:puts)
           .with("The following sections can be reslugged:")
         expect(logger).to receive(:puts)
-          .with("'6-section' to '1-section'")
+          .with("'manual-slug/6-section' to 'manual-slug/1-section'")
         expect(logger).to receive(:puts)
-          .with("'5-section' to '2-section'")
+          .with("'manual-slug/5-section' to 'manual-slug/2-section'")
         expect(logger).to receive(:puts)
           .with("The following sections cannot be reslugged:")
         expect(logger).to receive(:puts)
-          .with("'4-section' would change to '3-section' but this is already in use.")
+          .with("'manual-slug/4-section' would change to 'manual-slug/3-section' but this is already in use.")
         expect(logger).to receive(:puts)
-          .with("'3-section' would change to '4-section' but this is already in use.")
+          .with("'manual-slug/3-section' would change to 'manual-slug/4-section' but this is already in use.")
       end
     end
 
@@ -67,10 +67,10 @@ RSpec.describe SectionSlugSynchroniser do
         allow(logger).to receive(:puts).with(anything)
 
         expect(SectionReslugger).to receive(:new)
-          .with("manual-slug", "6-section", "1-section")
+          .with("manual-slug", "manual-slug/6-section", "manual-slug/1-section")
           .and_return(reslugger)
         expect(SectionReslugger).to receive(:new)
-          .with("manual-slug", "5-section", "2-section")
+          .with("manual-slug", "manual-slug/5-section", "manual-slug/2-section")
           .and_return(reslugger)
 
         subject.synchronise


### PR DESCRIPTION
Currently when we want to relug a section, we assume
that the manual slug will be a part of the section
slug.

But if the manual slug changes, and the section slugs
do not, then the reslugging implementation wont work,
because we assume that manual-slug + last-part-of-section-slug
will equal the full section slug.

This change the reslugging classes and tasks to require
a full section slug when reslugging.

Relates to ticket no. 3669351