### PR TITLE
Don't set content_id, created_at, or updated_at for attachments

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -246,11 +246,8 @@ private
         ],
         attachments: section.attachments.map do |attachment|
           {
-            content_id: SecureRandom.uuid,
             title: attachment.title,
             url: attachment.file_url,
-            updated_at: attachment.updated_at,
-            created_at: attachment.created_at,
             content_type: attachment.content_type,
           }
         end,

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -515,7 +515,6 @@ describe PublishingAdapter do
 
       before do
         allow(section).to receive(:attachments).and_return(attachments)
-        allow(SecureRandom).to receive(:uuid).and_return("attachment-content-id")
       end
 
       it "saves content for section to Publishing API including attachments" do
@@ -524,11 +523,8 @@ describe PublishingAdapter do
           including(details: including(
             attachments: [
               including(
-                content_id: "attachment-content-id",
                 title: "attachment-title",
                 url: "attachment-file-url.jpg",
-                created_at: timestamp,
-                updated_at: another_timestamp,
                 content_type: "application/jpg",
               ),
             ],


### PR DESCRIPTION
We're removing these fields from the attachment type as part of RFC
116.

---

[Trello card](https://trello.com/c/euVRDSPs/691-stop-manuals-publisher-sending-contentid-updatedat-and-createdat-for-attachments)