### PR TITLE
Set org abbreviation to "" if nil

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -163,7 +163,7 @@ private
         organisations: [
           {
             title: organisation.title,
-            abbreviation: organisation.abbreviation,
+            abbreviation: organisation.abbreviation || "",
             web_url: organisation.web_url,
           },
         ],
@@ -257,7 +257,7 @@ private
         organisations: [
           {
             title: organisation.title,
-            abbreviation: organisation.abbreviation,
+            abbreviation: organisation.abbreviation || "",
             web_url: organisation.web_url,
           },
         ],


### PR DESCRIPTION
Attempting to republish all the manuals fails part-way through with an
error from publishing-api about a nil abbreviation.  So if it's
missing, send an empty string instead.

The org in question is the Cabinet Office, which helpfully has the
acronym "" in its content item:

https://www.gov.uk/api/content/government/organisations/cabinet-office