### PR TITLE
Send attachment_type and id for attachments to pub-api

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -246,6 +246,8 @@ private
         ],
         attachments: section.attachments.map do |attachment|
           {
+            attachment_type: "file",
+            id: SecureRandom.uuid,
             title: attachment.title,
             url: attachment.file_url,
             content_type: attachment.content_type,


### PR DESCRIPTION
These fields are going to become mandatory.

---

[Trello card](https://trello.com/c/jq7Srpk4/1353-introduce-new-mandatory-attachment-metadata)