### PR TITLE
Test Mongo and Redis connectivity on healthcheck endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,5 +42,8 @@ Rails.application.routes.draw do
 
   root to: redirect("/manuals")
 
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::Mongoid,
+    GovukHealthcheck::SidekiqRedis,
+  )
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,10 +1,20 @@
 require "spec_helper"
 
 RSpec.describe "healthcheck path", type: :request do
-  it "should respond with 'OK'" do
+  it "should return a 200 response" do
     get "/healthcheck"
 
     expect(response.status).to eq(200)
-    expect(response.body).to eq("OK")
+  end
+
+  it "should return a JSON response with 'status' and 'checks' fields" do
+    get "/healthcheck"
+
+    json = JSON.parse(response.body)
+    expect(json["status"]).to eq("ok")
+    expect(json["checks"]).to include(
+      "database_connectivity",
+      "redis_connectivity",
+    )
   end
 end


### PR DESCRIPTION
This is a pre-requisite for enabling CD on Manuals Publisher.

Depended on by https://github.com/alphagov/smokey/pull/756.