### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,7 @@ library("govuk")
 node("mongodb-2.4") {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-manuals-publisher")
   govuk.buildProject(
-    sassLint: false,
     beforeTest: {
-      sh("yarn install")
       govuk.setEnvar("TEST_COVERAGE", "true")
     },
     publishingE2ETests: true,


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️