### PR TITLE
Limit the number of manuals on index page to 25

### DIFF
--- a/app/services/manual/list_service.rb
+++ b/app/services/manual/list_service.rb
@@ -4,7 +4,7 @@ class Manual::ListService
   end
 
   def call
-    Manual.all(user, load_associations: false)
+    Manual.all(user, load_associations: false).first(25)
   end
 
 private

--- a/spec/services/manual/list_service_spec.rb
+++ b/spec/services/manual/list_service_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Manual::ListService do
-  let(:user) { double(:user) }
+  let(:user) { FactoryBot.create(:gds_editor) }
 
   subject do
     Manual::ListService.new(
@@ -10,14 +10,27 @@ RSpec.describe Manual::ListService do
   end
 
   it "loads all manuals for the user" do
-    expect(Manual).to receive(:all).with(user, anything)
+    expect(Manual).to receive(:all).with(user, anything).and_return([])
 
     subject.call
   end
 
   it "avoids loading manual associations" do
-    expect(Manual).to receive(:all).with(anything, load_associations: false)
+    expect(Manual).to receive(:all).with(anything, load_associations: false).and_return([])
 
     subject.call
+  end
+
+  it "returns all manuals" do
+    expect(subject.call).to eq([])
+  end
+
+  it "only returns 15 results" do
+    manuals = (1..100).to_a
+    expected_manuals = (1..25).to_a
+
+    expect(Manual).to receive(:all).with(user, anything).and_return(manuals)
+
+    expect(subject.call).to eq(expected_manuals)
   end
 end


### PR DESCRIPTION
Users with GDS editor permissions are able to see all manuals when
Manual.all is called. This causes the  index page to time out when
trying to load the page as a user with gds_editor permissions.

We have limited the number of manuals returned on the index page to
prevent this happening again.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️