### PR TITLE
Improve query performance for Manual.all

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -49,11 +49,19 @@ class Manual
   end
 
   def self.all(user, load_associations: true)
-    collection = user.manual_records
+    user.manual_records
+      .includes(:editions)
+      .all_by_updated_at
+      .lazy
+      .map do |manual_record|
+        edition = manual_record.editions.max_by(&:version_number)
 
-    collection.all_by_updated_at.lazy.map do |manual_record|
-      build_manual_for(manual_record, load_associations: load_associations)
-    end
+        build_manual_for(
+          manual_record,
+          edition: edition,
+          load_associations: load_associations,
+        )
+      end
   end
 
   def slug_unique?(user)

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -80,6 +80,8 @@ private
     field :originally_published_at, type: Time
     field :use_originally_published_at_for_public_timestamp, type: Boolean
 
+    index manual_record_id: 1
+
     # We don't make use of the relationship but Mongoid can't save the
     # timestamps properly without it.
     belongs_to :manual_record

--- a/app/services/manual/list_service.rb
+++ b/app/services/manual/list_service.rb
@@ -4,7 +4,7 @@ class Manual::ListService
   end
 
   def call
-    Manual.all(user, load_associations: false).first(25)
+    Manual.all(user, load_associations: false)
   end
 
 private

--- a/spec/services/manual/list_service_spec.rb
+++ b/spec/services/manual/list_service_spec.rb
@@ -24,13 +24,4 @@ RSpec.describe Manual::ListService do
   it "returns all manuals" do
     expect(subject.call.force).to eq([])
   end
-
-  it "only returns 15 results" do
-    manuals = (1..100).to_a
-    expected_manuals = (1..25).to_a
-
-    expect(Manual).to receive(:all).with(user, anything).and_return(manuals)
-
-    expect(subject.call).to eq(expected_manuals)
-  end
 end

--- a/spec/services/manual/list_service_spec.rb
+++ b/spec/services/manual/list_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Manual::ListService do
   end
 
   it "returns all manuals" do
-    expect(subject.call).to eq([])
+    expect(subject.call.force).to eq([])
   end
 
   it "only returns 15 results" do


### PR DESCRIPTION
## What

The intent of this change is to reduce the number of cursors used by the app for a single query.

We experienced [an issue impacting multiple apps](https://docs.google.com/document/d/1FWhRp4EV5PYss_hlEChiqFpP0Dv4PQlGq03K1lUh7FA/edit#) due to Manual Publisher making an N+1 query, consuming the maximum 450 cursors (per DocumentDB instance) causing other requests to fail.

## How

Rather than do an N+1 query for all manuals and their latest edition (hitting the DB 200+ times), we can use [eager loading](https://docs.mongodb.com/mongoid/current/tutorials/mongoid-queries/#eager-loading) to make 2 requests to the DB.

This will make the Manuals Publisher homepage (/manuals) load faster, and at prevent most requests from timing out.

Unfortunately eager loading pulls more editions out of the DB than required (we only need the latest edition, not all). However, it does save on extra round trips to the DB. This prevents Manuals Publisher maxing out the number of DocumentDB cursors, which is the problem we're trying to solve.

## Other solutions

* We should [add pagination to the manuals homepage](https://trello.com/c/amQiLOxa/1093-manuals-publisher-manuals-page-should-have-pagination), which solve this problem entirely.
* Ideally we'd do something like this, but it's not permitted:

    ```
     has_one :last_edition,
              class_name: 'ManualRecord::Edition',
              order: 'updated_at DESC'
    ```
    
    Perhaps swapping out MongoDB for Postgres might be a good idea.