### PR TITLE
Add option to expand accordions to Manuals Publisher

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -265,6 +265,7 @@ private
             web_url: organisation.web_url,
           },
         ],
+        visually_expanded: section.visually_expanded,
       },
       locale: GdsApiConstants::PublishingApi::EDITION_LOCALE,
     }

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -201,7 +201,7 @@ private
   def section_params
     params
       .require(:section)
-      .permit(:title, :summary, :body, :change_note, :minor_update)
+      .permit(:title, :summary, :body, :change_note, :minor_update, :visually_expanded)
       .to_h
       .symbolize_keys
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -35,6 +35,7 @@ class Section
            :change_note,
            :minor_update,
            :exported_at,
+           :visually_expanded,
            to: :latest_edition
 
   attr_reader :uuid
@@ -88,7 +89,7 @@ class Section
     else
       previous_edition_attributes = latest_edition.attributes
         .symbolize_keys
-        .slice(:section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update)
+        .slice(:section_uuid, :version_number, :title, :slug, :summary, :body, :state, :change_note, :minor_update, :visually_expanded)
 
       attributes = previous_edition_attributes
         .merge(attributes)

--- a/app/models/section_edition.rb
+++ b/app/models/section_edition.rb
@@ -15,6 +15,7 @@ class SectionEdition
   field :state, type: String
   field :change_note, type: String
   field :minor_update, type: Boolean
+  field :visually_expanded, type: Boolean, default: false
   field :exported_at, type: Time
 
   validates :section_uuid, presence: true

--- a/app/views/sections/_form.html.erb
+++ b/app/views/sections/_form.html.erb
@@ -11,6 +11,11 @@
       <div class="preview_button add-vertical-margins"></div>
       <div class="preview_container add-vertical-margins" style="display: none;"></div>
 
+      <div class="checkbox add-vertical-margins">
+        <%= f.check_box :visually_expanded, tag_type: :p, label: "Remove collapsible content functionality (accordions)", checked_value: section.visually_expanded %>
+        <p class="help-block">This manuals page will not have any collapsible sections. The formatting markdown ## will create a top level heading (H2) only, not a collapsible section.</p>
+      </div>
+
       <% if manual.has_ever_been_published? && section.accepts_minor_updates? %>
         <div class="checkbox add-vertical-margins">
           <%= f.radio_button :minor_update, 1, class: 'js-update-type-minor', tag_type: :p, label: 'Minor update', checked: section.minor_update %>

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -64,6 +64,14 @@ Feature: Creating and editing a manual
     Given a draft manual exists without any sections
     When I create a section for the manual
     Then I see the manual has the new section
+    And I see the section isn't visually expanded
+    And the section and table of contents will have been sent to the draft publishing api
+
+  Scenario: Add an expanded section to a manual
+    Given a draft manual exists without any sections
+    When I create an expanded section for the manual
+    Then I see the manual has the new section
+    And I see the section is visually expanded
     And the section and table of contents will have been sent to the draft publishing api
 
   Scenario: Edit a draft section on a manual

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -122,6 +122,21 @@ When(/^I create a section for the manual$/) do
   @section = most_recently_created_manual.sections.to_a.last
 end
 
+When(/^I create an expanded section for the manual$/) do
+  @section_title = "Created Section 1"
+  @section_slug = [@manual_slug, "created-section-1"].join("/")
+
+  @section_fields = {
+    section_title: @section_title,
+    section_summary: "Section 1 summary",
+    section_body: "Section 1 body",
+  }
+
+  create_expanded_section(@manual_fields.fetch(:title), @section_fields)
+
+  @section = most_recently_created_manual.sections.to_a.last
+end
+
 When(/^I create a section for the manual with a change note$/) do
   @section_title = "Created Section 1"
   @section_slug = [@manual_slug, "created-section-1"].join("/")
@@ -143,6 +158,16 @@ Then(/^I see the manual has the new section$/) do
   visit manuals_path
   click_on @manual_fields.fetch(:title)
   expect(page).to have_content(@section_fields.fetch(:section_title))
+end
+
+Then(/^I see the section isn't visually expanded$/) do
+  click_on @section_fields.fetch(:section_title)
+  expect(@section.visually_expanded).to eq(false)
+end
+
+Then(/^I see the section is visually expanded$/) do
+  click_on @section_fields.fetch(:section_title)
+  expect(@section.visually_expanded).to eq(true)
 end
 
 Then(/^the section and table of contents will have been sent to the draft publishing api$/) do

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -41,6 +41,19 @@ module ManualHelpers
     save_as_draft
   end
 
+  def create_expanded_section(manual_title, fields)
+    go_to_manual_page(manual_title)
+    click_on "Add section"
+
+    fill_in_fields(fields)
+
+    check "Remove collapsible content functionality (accordions)"
+
+    yield if block_given?
+
+    save_as_draft
+  end
+
   def create_section_without_ui(manual, fields, organisation_slug: "ministry-of-tea")
     user = FactoryBot.build(:generic_editor, organisation_slug: organisation_slug)
 

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -241,6 +241,7 @@ describe PublishingAdapter do
               web_url: "organisation-web-url",
             },
           ],
+          visually_expanded: false,
         },
         locale: GdsApiConstants::PublishingApi::EDITION_LOCALE,
       )

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -11,11 +11,20 @@ describe SectionsController, type: :controller do
     end
 
     it "symbolizes the attribute keys" do
+      expected_keys = %i[title summary body change_note minor_update visually_expanded]
+      submitted_attributes = {
+        "title" => "title",
+        "summary" => "summary",
+        "body" => "body",
+        "change_note" => "change_note",
+        "minor_update" => true,
+        "visually_expanded" => false,
+      }
       expect(Section::CreateService).to receive(:new) { |args|
-        expect(args[:attributes].to_hash).to have_key(:title)
+        expect(args[:attributes].to_hash.keys).to eq(expected_keys)
       }.and_return(service)
 
-      post :create, params: { manual_id: "manual-id", id: "section-uuid", section: { "title" => "title" } }
+      post :create, params: { manual_id: "manual-id", id: "section-uuid", section: submitted_attributes }
     end
 
     it "removes attributes that are not permitted" do

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -303,6 +303,19 @@ describe Section do
       context "with an existing draft edition" do
         let(:latest_edition) { draft_edition_v1 }
 
+        context "when visually expanding" do
+          it "recieves visually_expanded" do
+            section.assign_attributes(visually_expanded: false)
+
+            expect(draft_edition_v1).to have_received(:assign_attributes)
+              .with(
+                hash_including(
+                  visually_expanded: false,
+                ),
+              )
+          end
+        end
+
         context "when providing a title" do
           let(:new_title) { double(:new_title) }
           let(:slug)      { double(:slug) }


### PR DESCRIPTION
Departmental request to add functionality to the Manuals format so that publishers
can choose to expand accordions, when expanded accordions are removed entirely.

The changes to the appearance of accordions is shown in this PR (https://github.com/alphagov/manuals-frontend/pull/1082)

![image](https://user-images.githubusercontent.com/24547183/112170201-c776ec80-8bea-11eb-99bb-08fab7e72ae1.png)


Trello: https://trello.com/c/wgEKW9Ze/2398-5-allow-manuals-publisher-to-set-accordions-to-open

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️