### PR TITLE
Update README in favour of GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,27 @@
 # Manuals publisher
 
-Manuals Publisher is a Ruby on Rails content management application for the 'manuals' format. The manuals format is currently in a rendered phase of migration, so content is stored in a local datastore but also drafted and published through the publishing-pipeline via the [Publishing API](https://github.com/alphagov/publishing-api).
-
-This is the renamed repository of the original Specialist
-Publisher. Specialist Publisher has been divided into two publishing
-applications to accommodate Specialist Documents and Manuals
-separately.  _Specialist Document_ or _Finders_ publishing now lives
-at https://github.com/alphagov/specialist-publisher. See [history](docs/history.md) for more details.
-
-## Purpose
-
-Publishing app for manuals.
+Publishing app for manuals. E.g. [The Highway Code].
 
 ## Nomenclature
 
-* Manual: Grouped Documents published as a number of sections inside a parent document
+* Manual: Parent document which is made up of a number of sections
+* Section: Individual segment / page of a Manual
+* Attachment: File attachment which can be added to a section
 
-### Live examples of manuals
+## Technical documentation
 
-* [The Highway Code](https://www.gov.uk/guidance/the-highway-code)
-* [Style guide](https://www.gov.uk/guidance/style-guide)
-* [Buying for schools](https://www.gov.uk/guidance/buying-for-schools)
+This is a Ruby on Rails app, and should follow [our Rails app
+conventions][conventions].
 
-## Dependencies
+You can use the [GOV.UK Docker environment][govuk-docker] to run the
+application and its tests with all the necessary dependencies. Follow the
+[usage instructions][docker-usage] to get started.
 
-* [alphagov/asset-manager](http://github.com/alphagov/asset-manager): provides uploading for static files
-* [alphagov/publishing-api](http://github.com/alphagov/publishing-api): allows documents to be published to the Publishing queue
-* [link-checker-api](https://github.com/alphagov/link-checker-api): checks all the links in an edition on request from the edition show page.
-
-## Running the application
-
-To run the application in development you will need at least one user in the application database. In a rails console do:
-
-```
-User.create!(name: "My Name", email: "my.email@somedomain.com", permissions: ["gds_editor"], organisation_slug: "government-digital-service", organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9")
-```
-
-Note: This insert (and the app in general) doesn't work with recent versions of MongoDB. v3.0.12 works OK; v3.4.1 does NOT work due to a problem with the `:w => 1` option no longer being supported at the top level, i.e. outside the Write Concern options. [It looks as if](https://github.com/alphagov/manuals-publisher/pull/796#issuecomment-276379600) [v2.4.9 is currently being used in production](https://github.com/alphagov/govuk-puppet/blob/f3614e33bcf037b218e0b9e816f0994786b41efb/hieradata/common.yaml#L1256).
-
-Then start the application:
-
-```
-$ ./startup.sh
-```
-
-If you are using the GDS development virtual machine then the application will be available on the host at http://manuals-publisher.dev.gov.uk/
-
-## Running the test suite
+### Running the test suite
 
 ```
 $ bundle exec rake
 ```
-
-## Application directory structure
-
-Non standard Rails directories and what they're used for:
-
-* `app/models`
-  Combination of Mongoid documents and Ruby objects for handling Documents and various behaviours
-  * `app/models/validators`
-    Not validators. Decorators for providing validation logic.
-* app/presenters
-  Decorators mainly used for previewing documents
-* `app/services`
-  Reusable classes for completing actions on documents
-* `app/view_adapters`
-  Provide classes which allow us to have Rails like form objects in views
-* `app/workers`
-  Classes for sidekiq workers. Currently the only worker in the App is for publishing Manuals as Manual publishing was timing out due to the large number of document objects inside a Manual
 
 ## Documentation
 
@@ -76,3 +30,8 @@ Non standard Rails directories and what they're used for:
 * [Information about Rake tasks](docs/rake-tasks.md)
 * [Possible next steps for development](docs/next-steps.md)
 * [Notes on investigation into fully migrating app with respect to Publishing API](docs/fully-migrated-spike.md)
+
+[The Highway Code]: https://www.gov.uk/guidance/the-highway-code
+[conventions]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html
+[govuk-docker]: https://github.com/alphagov/govuk-docker
+[docker-usage]: https://github.com/alphagov/govuk-docker#usage

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails s -p 3205


### PR DESCRIPTION
Updates and standardises README to favour GOV.UK Docker over startup scripts.

Related PR:
https://github.com/alphagov/govuk-docker/pull/471

Trello:
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️