### PR TITLE
Updates enabling Docker to run Manuals Publisher

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,6 @@ if User.where(name: "Test user").blank?
     name: "Test user",
     permissions: %w[signin gds_editor],
     organisation_content_id: gds_organisation_id,
-    organisation_slug: "test-organisation",
+    organisation_slug: "government-digital-service",
   )
 end


### PR DESCRIPTION
Updates needed to allow the app to be run via Docker. 

More info in the commits -> 

Related PRs:
* https://github.com/alphagov/govuk-docker/pull/472
* https://github.com/alphagov/whitehall/pull/6046

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️