### PR TITLE
Update govuk_frontend_toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "generic_form_builder"
 gem "govspeak"
 gem "govuk_admin_template"
 gem "govuk_app_config"
-gem "govuk_frontend_toolkit", "9.0.0" # we rely on this for correctly previewing govspeak (including interactive elements) - to help with that keep it in sync with the version used in manuals-frontend
+gem "govuk_frontend_toolkit"
 gem "govuk_sidekiq"
 gem "mongoid"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,9 +202,8 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_frontend_toolkit (9.0.0)
+    govuk_frontend_toolkit (9.0.1)
       railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_publishing_components (24.10.3)
       govuk_app_config
       kramdown
@@ -362,9 +361,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.3)
-    rb-fsevent (0.10.4)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     redis (4.1.4)
     redis-namespace (1.8.0)
       redis (>= 3.0.4)
@@ -433,11 +429,6 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -530,7 +521,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk_admin_template
   govuk_app_config
-  govuk_frontend_toolkit (= 9.0.0)
+  govuk_frontend_toolkit
   govuk_sidekiq
   govuk_test
   jasmine


### PR DESCRIPTION
This updates govuk_frontend_toolkit to 9.0.1 which removes Ruby Sass
from this project.

I've also removed the pin and comment for this as manuals-frontend
doesn't use govuk_frontend_toolkit so there is nothing to keep in sync
anymore.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️