### PR TITLE
Add standard header to protect .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,16 @@ inherit_mode:
   merge:
     - Exclude
 
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************
+
 # This is not supported for Mongoid
 Rails/FindBy:
   Enabled: false


### PR DESCRIPTION
https://trello.com/c/Cr2TnMtI/193-make-it-easier-to-agree-with-rubocop-govuk

This follows the convention established in [1].

[1]: https://github.com/alphagov/content-publisher/pull/2411


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️