### PR TITLE
Add browser titles for each page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <%= javascript_include_tag 'application' %>
 <% end %>
 
-<% content_for :page_title, "Manuals Publisher" %>
+<% content_for :page_title, " | Manuals Publisher" %>
 <% content_for :app_title, "GOV.UK Manuals Publisher" %>
 
 <% content_for :navbar_items do %>

--- a/app/views/manuals/edit.html.erb
+++ b/app/views/manuals/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Edit manual" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/manuals/edit_original_publication_date.html.erb
+++ b/app/views/manuals/edit_original_publication_date.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Edit first publication date" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Your manuals" %>
+
 <% content_for :breadcrumbs do %>
   <li class='active'>Your manuals</li>
 <% end %>

--- a/app/views/manuals/new.html.erb
+++ b/app/views/manuals/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "New manual" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li class='active'>Create new manual</li>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, manual.title %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li class='active'><%= manual.title %></li>

--- a/app/views/section_attachments/edit.html.erb
+++ b/app/views/section_attachments/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Edit attachment" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/section_attachments/new.html.erb
+++ b/app/views/section_attachments/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Add attachment" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/sections/edit.html.erb
+++ b/app/views/sections/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Edit section" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/sections/new.html.erb
+++ b/app/views/sections/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Add section" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/sections/reorder.html.erb
+++ b/app/views/sections/reorder.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Reorder sections" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Summary" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>

--- a/app/views/sections/withdraw.html.erb
+++ b/app/views/sections/withdraw.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Withdraw section" %>
+
 <% content_for :breadcrumbs do %>
   <li><%= link_to "Your manuals", manuals_path %></li>
   <li><%= link_to manual.title, manual_path(manual) %></li>


### PR DESCRIPTION
### Description

When you navigate through a service the browser title should be descriptive of the primary function of the page you’re on.

This adds a browser title for each page and ensures that the format follows the `page title | service name` pattern.

### Trello card

https://trello.com/c/5EBSgwl4/361-browser-title-is-not-descriptive-of-pages-function

### Guidance to review

It's probably easiest to just run the branch locally and click around checking that the browser titles for each page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️