### PR TITLE
Change rendering app to government-frontend

### DIFF
--- a/app/lib/gds_api_constants.rb
+++ b/app/lib/gds_api_constants.rb
@@ -1,7 +1,7 @@
 module GdsApiConstants
   module PublishingApi
     PUBLISHING_APP = "manuals-publisher".freeze
-    RENDERING_APP = "manuals-frontend".freeze
+    RENDERING_APP = "government-frontend".freeze
 
     MANUAL_SCHEMA_NAME = "manual".freeze
     MANUAL_DOCUMENT_TYPE = "manual".freeze

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -259,7 +259,7 @@ module ManualHelpers
       attributes = {
         "schema_name" => GdsApiConstants::PublishingApi::MANUAL_SCHEMA_NAME,
         "document_type" => GdsApiConstants::PublishingApi::MANUAL_DOCUMENT_TYPE,
-        "rendering_app" => "manuals-frontend",
+        "rendering_app" => "government-frontend",
         "publishing_app" => "manuals-publisher",
       }.merge(extra_attributes)
       with_matcher = request_json_including(attributes)
@@ -286,7 +286,7 @@ module ManualHelpers
       attributes = {
         "schema_name" => GdsApiConstants::PublishingApi::SECTION_SCHEMA_NAME,
         "document_type" => GdsApiConstants::PublishingApi::SECTION_DOCUMENT_TYPE,
-        "rendering_app" => "manuals-frontend",
+        "rendering_app" => "government-frontend",
         "publishing_app" => "manuals-publisher",
       }.merge(extra_attributes)
       with_matcher = request_json_including(attributes)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## WHAT
Update rendering app to government-frontend

## WHY
We'd like to migrate the rendering so we can retire manuals-frontend as on trello ticket.

### Trello
https://trello.com/c/e8XNP4Sk/1128-manuals-change-manuals-publisher-and-hmrc-manuals-api-rendering-app

## RELATED
https://github.com/alphagov/hmrc-manuals-api/pull/664
https://github.com/alphagov/govuk-developer-docs/pull/3460
