### PR TITLE
Resolve drag and drop capybara test failing

### DIFF
--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -705,8 +705,12 @@ end
 
 When(/^I reorder the sections$/) do
   click_on("Reorder sections")
-  elems = page.all(".reorderable-document-list li.ui-sortable-handle")
-  elems[0].drag_to(elems[1])
+  # Using capybara drag_to doesn't work reliably with our jQuery sortable
+  # therefore we have to take a manual approach to replicating the drag/drop
+  inputs = page.all(".reorderable-document-list li.ui-sortable-handle input", visible: false)
+  values = inputs.map(&:value).reverse
+  inputs.each_with_index { |input, index| input.execute_script("this.value = '#{values[index]}'") }
+
   click_on("Save section order")
   @reordered_section_attributes = [
     @attributes_for_sections[1],


### PR DESCRIPTION
I've noticed that it has been a long time since we had a successful main
branch build for this application. This seems to be because of this one
particular test that relies on utilising a jQuery sortable drag and
drop.

The previous implementation of the test fails consistently on my local
machine - and fails intermittently on CI. Further investigation revealed
that CI has different versions of Chrome on different machines so my
expectation is that this has started failing on a newer version of
Chrome (for reference I've seen it pass on Chrome 87.0.4280.141 and fail
on 96.0.4664.45).

The fix for this test is to not use the drag_to function as it's not
particularly reliable [1] and has to synthetically produce browser
events to make the JS think it's been dragged and dropped (as this is
quite old, jQuery based, JS it doesn't use the native HTML5 drap and
drop). We've applied a similar fix to this to travel_advice_publisher in
the past [2].

[1]: https://github.com/teamcapybara/capybara/issues/222
[2]: https://github.com/alphagov/travel-advice-publisher/commit/3b880c94ac4189f98d4bbfba1b60d0d2b26e1be2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️