### PR TITLE
Bump govuk_app_config to 4.6 and install sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "mongoid"
 gem "plek"
 gem "raindrops"
 gem "sass-rails"
+gem "sentry-sidekiq"
 gem "state_machine"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,12 +194,12 @@ GEM
       jquery-rails (~> 4.3)
       plek (>= 2.1)
       rails (>= 6)
-    govuk_app_config (4.5.0)
+    govuk_app_config (4.6.0)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
       puma (~> 5.6)
-      sentry-rails (~> 5.2)
-      sentry-ruby (~> 5.2)
+      sentry-rails (~> 5.3)
+      sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
     govuk_frontend_toolkit (9.0.1)
@@ -251,7 +251,7 @@ GEM
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
-    loofah (2.17.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -354,7 +354,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rainbow (3.1.1)
-    raindrops (0.19.1)
+    raindrops (0.20.0)
     rake (13.0.6)
     redis (4.5.1)
     redis-namespace (1.8.0)
@@ -437,14 +437,17 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sentry-rails (5.2.1)
+    sentry-rails (5.3.0)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.2.1)
-    sentry-ruby (5.2.1)
+      sentry-ruby-core (~> 5.3.0)
+    sentry-ruby (5.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.2.1)
-    sentry-ruby-core (5.2.1)
+      sentry-ruby-core (= 5.3.0)
+    sentry-ruby-core (5.3.0)
       concurrent-ruby
+    sentry-sidekiq (5.3.0)
+      sentry-ruby-core (~> 5.3.0)
+      sidekiq (>= 3.0)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -533,6 +536,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sass-rails
+  sentry-sidekiq
   simplecov
   state_machine
   timecop


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

In order to track sidekiq errors apps that use Sidekiq need to install
sentry-sidekiq, this installs it.

Without it a warning will occur on application initialisation and
Sidekiq errors won't be tracked by Sentry.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️