### PR TITLE
Fixes previous edition ordering bug

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -323,7 +323,7 @@ class Manual
       # This means the previous edition is withdrawn so we shouldn't
       # expose it as it's not actually published (we've got a new
       # draft waiting in the wings for a withdrawn manual)
-      return unless previous_edition.state == "published"
+      return unless previous_edition&.state == "published"
 
       self.class.build_manual_for(manual_record, edition: previous_edition, published: true)
     end

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -36,7 +36,7 @@ class ManualRecord
   end
 
   def previous_edition
-    editions.order_by(%i[version_number desc]).limit(2).last
+    editions.order_by(%i[version_number desc]).second
   end
 
   def has_ever_been_published?

--- a/spec/models/manual_record_spec.rb
+++ b/spec/models/manual_record_spec.rb
@@ -28,6 +28,16 @@ describe ManualRecord, hits_db: true do
     end
   end
 
+  describe "#previous_edition" do
+    it "returns the edition with the second highest version number" do
+      record.editions.create!(state: "published", version_number: 2)
+      record.editions.create!(state: "draft", version_number: 3)
+      record.editions.create!(state: "published", version_number: 1)
+
+      expect(record.previous_edition.version_number).to eq(2)
+    end
+  end
+
   context "saving" do
     it "saves the latest edition if it needs saving" do
       new_draft = record.new_or_existing_draft_edition


### PR DESCRIPTION
`previous_edition` was retuning the wrong edition as `.last` was ignoring
`limit(2)` and returning the last item in the non-limited ordered list,
which is the first version (desc ordering). Not sure if this was always
broken, or a result of a ruby / rails / mongoid upgrade.

Updates the code to return the actual previous edition by selecting the
second from the top.

Other uses of `limit` are working as expected within the app.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️