### PR TITLE
Disable Publishing E2E Tests for this repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,10 @@ node {
   // Run against the MongoDB 3.6 Docker instance on GOV.UK CI
   govuk.setEnvar("TEST_MONGODB_URI", "mongodb://127.0.0.1:27036/manuals-publisher-test")
 
-  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-manuals-publisher")
   govuk.buildProject(
     beforeTest: {
       govuk.setEnvar("TEST_COVERAGE", "true")
     },
-    publishingE2ETests: true,
     brakeman: true,
   )
 }


### PR DESCRIPTION
Analysis of the coverage provided by these tests shows they are
redundant and can be safely removed [^1]. Before we can remove
them, we need to stop trying to run them here.

NOTE: to merge this PR you will need to disable E2E tests as a 
required check, since they aren't going to run.

WARNING: this is a one-off argument / decision that only applies
to this repo and two others, and should not be repeated. This
change does not set a precedent for removing any other apps or
tests from publishing-e2e-tests until the full condition of the
Continuous Deployment (CD) RFC is met i.e. we have enabled CD
for all of the supported, non-frontend apps [^2].

[^1]: https://docs.google.com/spreadsheets/d/1Rp9afBgwm-QvLgMYKairC5U51HbHbihjS6F6XHtaf_E/edit#gid=0
[^2]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#delete-publishing-e2e-tests


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️