### PR TITLE
Withdraw and redirect manuals

### DIFF
--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -32,6 +32,19 @@ class PublishingAdapter
     end
   end
 
+  def unpublish_section(section, redirect:, republish: false, discard_drafts: true)
+    if !section.withdrawn? || republish
+      begin
+        Services.publishing_api.unpublish(
+          section.uuid, type: "redirect", alternative_path: redirect, discard_drafts: discard_drafts
+        )
+        section.withdraw_and_mark_as_exported! unless republish
+      rescue GdsApi::HTTPNotFound
+        Rails.logger.warn "Content item with section uuid #{section.uuid} not present in the publishing API"
+      end
+    end
+  end
+
   def unpublish(manual)
     Services.publishing_api.unpublish(manual.id, type: "gone")
 
@@ -302,19 +315,6 @@ private
     if section.needs_exporting? || republish
       Services.publishing_api.publish(section.uuid, update_type(republish))
       section.mark_as_exported! unless republish
-    end
-  end
-
-  def unpublish_section(section, redirect:, republish: false, discard_drafts: true)
-    if !section.withdrawn? || republish
-      begin
-        Services.publishing_api.unpublish(
-          section.uuid, type: "redirect", alternative_path: redirect, discard_drafts: discard_drafts
-        )
-        section.withdraw_and_mark_as_exported! unless republish
-      rescue GdsApi::HTTPNotFound
-        Rails.logger.warn "Content item with section uuid #{section.uuid} not present in the publishing API"
-      end
     end
   end
 

--- a/app/adapters/publishing_adapter.rb
+++ b/app/adapters/publishing_adapter.rb
@@ -14,6 +14,24 @@ class PublishingAdapter
     end
   end
 
+  def unpublish_and_redirect_manual_and_sections(manual, redirect:, include_sections:, discard_drafts:)
+    Services.publishing_api.unpublish(
+      manual.id,
+      type: "redirect",
+      redirects: [
+        { path: "/#{manual.slug}", type: "exact", destination: redirect },
+        { path: "/#{manual.slug}/updates", type: "exact", destination: redirect },
+      ],
+      discard_drafts: discard_drafts,
+    )
+
+    if include_sections
+      manual.sections.each do |section|
+        unpublish_section(section, redirect: redirect, discard_drafts: discard_drafts)
+      end
+    end
+  end
+
   def unpublish(manual)
     Services.publishing_api.unpublish(manual.id, type: "gone")
 
@@ -30,7 +48,7 @@ class PublishingAdapter
     end
 
     manual.removed_sections.each do |section|
-      unpublish_section(section, manual, republish: republish)
+      unpublish_section(section, redirect: "/#{manual.slug}", republish: republish)
     end
   end
 
@@ -287,10 +305,12 @@ private
     end
   end
 
-  def unpublish_section(section, manual, republish:)
+  def unpublish_section(section, redirect:, republish: false, discard_drafts: true)
     if !section.withdrawn? || republish
       begin
-        Services.publishing_api.unpublish(section.uuid, type: "redirect", alternative_path: "/#{manual.slug}", discard_drafts: true)
+        Services.publishing_api.unpublish(
+          section.uuid, type: "redirect", alternative_path: redirect, discard_drafts: discard_drafts
+        )
         section.withdraw_and_mark_as_exported! unless republish
       rescue GdsApi::HTTPNotFound
         Rails.logger.warn "Content item with section uuid #{section.uuid} not present in the publishing API"

--- a/app/lib/withdraw_and_redirect_manual.rb
+++ b/app/lib/withdraw_and_redirect_manual.rb
@@ -1,16 +1,19 @@
 require "adapters"
 
 class WithdrawAndRedirectManual
-  def initialize(user:, manual_path:, redirect:, include_sections:, discard_drafts:)
+  def initialize(user:, manual_path:, redirect:, include_sections:, discard_drafts:, dry_run: false)
     @user = user
     @manual_path = manual_path
     @redirect = redirect
     @include_sections = include_sections
     @discard_drafts = discard_drafts
+    @dry_run = dry_run
   end
 
   def execute
     manual = Manual.find_by_slug!(manual_path, user)
+
+    return if dry_run
 
     published_manual = manual.current_versions[:published]
 
@@ -29,7 +32,7 @@ class WithdrawAndRedirectManual
 
 private
 
-  attr_reader :user, :manual_path, :redirect, :include_sections, :discard_drafts
+  attr_reader :user, :manual_path, :redirect, :include_sections, :discard_drafts, :dry_run
 
   class ManualNotPublishedError < StandardError; end
 end

--- a/app/lib/withdraw_and_redirect_manual.rb
+++ b/app/lib/withdraw_and_redirect_manual.rb
@@ -1,0 +1,35 @@
+require "adapters"
+
+class WithdrawAndRedirectManual
+  def initialize(user:, manual_path:, redirect:, include_sections:, discard_drafts:)
+    @user = user
+    @manual_path = manual_path
+    @redirect = redirect
+    @include_sections = include_sections
+    @discard_drafts = discard_drafts
+  end
+
+  def execute
+    manual = Manual.find_by_slug!(manual_path, user)
+
+    published_manual = manual.current_versions[:published]
+
+    raise ManualNotPublishedError, manual.slug if published_manual.blank?
+
+    published_manual.withdraw
+    published_manual.save!(user)
+
+    Adapters.publishing.unpublish_and_redirect_manual_and_sections(
+      published_manual,
+      redirect: redirect,
+      include_sections: include_sections,
+      discard_drafts: discard_drafts,
+    )
+  end
+
+private
+
+  attr_reader :user, :manual_path, :redirect, :include_sections, :discard_drafts
+
+  class ManualNotPublishedError < StandardError; end
+end

--- a/app/lib/withdraw_and_redirect_section.rb
+++ b/app/lib/withdraw_and_redirect_section.rb
@@ -1,17 +1,21 @@
 require "adapters"
 
 class WithdrawAndRedirectSection
-  def initialize(user:, manual_path:, section_path:, redirect:, discard_draft:)
+  def initialize(user:, manual_path:, section_path:, redirect:, discard_draft:, dry_run: false)
     @user = user
     @manual_path = manual_path
     @section_path = section_path
     @redirect = redirect
     @discard_draft = discard_draft
+    @dry_run = dry_run
   end
 
   def execute
-    manual = Manual.find_by_slug!(manual_path, user)
     section_uuid = SectionEdition.find_by(slug: section_path).section_uuid
+    manual = Manual.find_by_slug!(manual_path, user)
+
+    return if dry_run
+
     section = Section.find(manual, section_uuid)
 
     raise SectionNotPublishedError, section.slug unless section.published?
@@ -25,7 +29,7 @@ class WithdrawAndRedirectSection
 
 private
 
-  attr_reader :user, :manual_path, :section_path, :redirect, :discard_draft
+  attr_reader :user, :manual_path, :section_path, :redirect, :discard_draft, :dry_run
 
   class SectionNotPublishedError < StandardError; end
 end

--- a/app/lib/withdraw_and_redirect_section.rb
+++ b/app/lib/withdraw_and_redirect_section.rb
@@ -1,0 +1,31 @@
+require "adapters"
+
+class WithdrawAndRedirectSection
+  def initialize(user:, manual_path:, section_path:, redirect:, discard_draft:)
+    @user = user
+    @manual_path = manual_path
+    @section_path = section_path
+    @redirect = redirect
+    @discard_draft = discard_draft
+  end
+
+  def execute
+    manual = Manual.find_by_slug!(manual_path, user)
+    section_uuid = SectionEdition.find_by(slug: section_path).section_uuid
+    section = Section.find(manual, section_uuid)
+
+    raise SectionNotPublishedError, section.slug unless section.published?
+
+    if discard_draft && section.draft?
+      Adapters.publishing.unpublish_section(section, redirect: redirect, discard_drafts: true)
+    else
+      Adapters.publishing.unpublish_section(section, redirect: redirect, discard_drafts: false)
+    end
+  end
+
+private
+
+  attr_reader :user, :manual_path, :section_path, :redirect, :discard_draft
+
+  class SectionNotPublishedError < StandardError; end
+end

--- a/app/lib/withdraw_and_redirect_to_multiple_paths.rb
+++ b/app/lib/withdraw_and_redirect_to_multiple_paths.rb
@@ -1,0 +1,73 @@
+require "csv"
+
+class WithdrawAndRedirectToMultiplePaths
+  def initialize(csv_path:, discard_drafts:)
+    @csv_path = csv_path
+    @discard_drafts = discard_drafts
+    @user = User.gds_editor
+  end
+
+  def execute
+    grouped_sections_by_manual.each do |manual_path, children|
+      children.each do |child|
+        next if updates_page?(child["base_path"])
+
+        if manual_path == child["base_path"]
+          withdraw_and_redirect_manual(child)
+        else
+          withdraw_and_redirect_section(child, manual_path)
+        end
+
+      rescue WithdrawAndRedirectManual::ManualNotPublishedError
+        log("[ERROR] Manual not redirected due to not being in a published state: #{child['base_path']}")
+      rescue WithdrawAndRedirectSection::SectionNotPublishedError
+        log("[ERROR] Section not redirected due to not being in a published state: #{child['base_path']}")
+      end
+    end
+  end
+
+private
+
+  attr_reader :discard_drafts, :user, :csv_path
+
+  def grouped_sections_by_manual
+    CSV.read(Rails.root.join(csv_path), headers: true).group_by do |route|
+      route["base_path"].split("/")[0..1].join("/")
+    end
+  end
+
+  def updates_page?(base_path)
+    if base_path =~ /^guidance\/.*\/updates$/
+      log("Updates page '#{base_path}' will be redirected to Manual's redirect, if provided") unless dry_run
+      true
+    end
+  end
+
+  def withdraw_and_redirect_manual(child)
+    WithdrawAndRedirectManual.new(
+      user: user,
+      manual_path: child["base_path"],
+      redirect: child["redirect"],
+      include_sections: false,
+      discard_drafts: discard_drafts,
+    ).execute
+
+    log("Withdrawn manual '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run
+  end
+
+  def withdraw_and_redirect_section(child, manual_path)
+    WithdrawAndRedirectSection.new(
+      user: user,
+      manual_path: manual_path,
+      section_path: child["base_path"],
+      redirect: child["redirect"],
+      discard_draft: discard_drafts,
+    ).execute
+
+    log("Withdrawn section '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run
+  end
+
+  def log(str)
+    $stdout.puts(str)
+  end
+end

--- a/app/lib/withdraw_and_redirect_to_multiple_paths.rb
+++ b/app/lib/withdraw_and_redirect_to_multiple_paths.rb
@@ -1,13 +1,18 @@
 require "csv"
 
 class WithdrawAndRedirectToMultiplePaths
-  def initialize(csv_path:, discard_drafts:)
+  def initialize(csv_path:, discard_drafts: false, dry_run: false)
     @csv_path = csv_path
     @discard_drafts = discard_drafts
     @user = User.gds_editor
+    @dry_run = dry_run
   end
 
   def execute
+    if dry_run
+      missing_paths = { sections: [], manuals: [] }
+    end
+
     grouped_sections_by_manual.each do |manual_path, children|
       children.each do |child|
         next if updates_page?(child["base_path"])
@@ -22,13 +27,19 @@ class WithdrawAndRedirectToMultiplePaths
         log("[ERROR] Manual not redirected due to not being in a published state: #{child['base_path']}")
       rescue WithdrawAndRedirectSection::SectionNotPublishedError
         log("[ERROR] Section not redirected due to not being in a published state: #{child['base_path']}")
+      rescue Manual::NotFoundError
+        dry_run ? missing_paths[:manuals] << child["base_path"] : raise
+      rescue Mongoid::Errors::DocumentNotFound
+        dry_run ? missing_paths[:sections] << child["base_path"] : raise
       end
     end
+
+    missing_paths if dry_run
   end
 
 private
 
-  attr_reader :discard_drafts, :user, :csv_path
+  attr_reader :discard_drafts, :user, :csv_path, :dry_run
 
   def grouped_sections_by_manual
     CSV.read(Rails.root.join(csv_path), headers: true).group_by do |route|
@@ -50,6 +61,7 @@ private
       redirect: child["redirect"],
       include_sections: false,
       discard_drafts: discard_drafts,
+      dry_run: dry_run,
     ).execute
 
     log("Withdrawn manual '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run
@@ -62,6 +74,7 @@ private
       section_path: child["base_path"],
       redirect: child["redirect"],
       discard_draft: discard_drafts,
+      dry_run: dry_run,
     ).execute
 
     log("Withdrawn section '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run

--- a/lib/tasks/withdraw_and_redirect_manual.rake
+++ b/lib/tasks/withdraw_and_redirect_manual.rake
@@ -1,0 +1,22 @@
+desc "Withdraw and redirect manual, e.g withdraw_and_redirect_manual['guidance/manual,/redirect/blah,true,true']"
+task :withdraw_and_redirect_manual, %i[manual_path redirect include_sections discard_drafts] => :environment do |_, args|
+  discard_drafts = args.fetch(:discard_drafts) == "true"
+  include_sections = args.fetch(:include_sections) == "true"
+  redirect = args.fetch(:redirect)
+
+  redirect_manual = WithdrawAndRedirectManual.new(
+    user: User.gds_editor,
+    manual_path: args.fetch(:manual_path),
+    redirect: redirect,
+    include_sections: include_sections,
+    discard_drafts: discard_drafts,
+  )
+
+  redirect_manual.execute
+
+  if include_sections
+    puts "Manual and sections withdrawn and redirected to #{redirect}"
+  else
+    puts "Manual withdrawn and redirected to #{redirect}"
+  end
+end

--- a/lib/tasks/withdraw_and_redirect_manuals_to_multiple_paths.rake
+++ b/lib/tasks/withdraw_and_redirect_manuals_to_multiple_paths.rake
@@ -1,8 +1,27 @@
-desc "Withdraw and redirect manual to multiple paths, e.g withdraw_and_redirect_sections_to_multiple_paths['lib/tasks/tmp_redirect.csv,true']"
-task :withdraw_and_redirect_manuals_to_multiple_paths, %i[csv_path discard_drafts] => :environment do |_, args|
-  discard_drafts = args.fetch(:discard_drafts) == "true"
+namespace :withdraw_and_redirect_manuals_to_multiple_paths  do
+  desc "Withdraw and redirect manual to multiple paths, e.g withdraw_and_redirect_sections_to_multiple_paths['lib/tasks/tmp_redirect.csv,true']"
+  task :real, %i[csv_path discard_drafts] => :environment do |_, args|
+    discard_drafts = args.fetch(:discard_drafts) == "true"
 
-  WithdrawAndRedirectToMultiplePaths.new(
-    csv_path: args.fetch(:csv_path), discard_drafts: discard_drafts,
-  ).execute
+    WithdrawAndRedirectToMultiplePaths.new(
+      csv_path: args.fetch(:csv_path), discard_drafts: discard_drafts,
+    ).execute
+  end
+
+  desc "Dry run to check all base_paths in CSV exist"
+  task :dry_run, %i[csv_path] => :environment do |_, args|
+    missing_paths = WithdrawAndRedirectToMultiplePaths.new(
+      csv_path: args.fetch(:csv_path), dry_run: true,
+    ).execute
+
+    if missing_paths[:sections].blank? && missing_paths[:manuals].blank?
+      puts "PASS - all paths from the CSV exist"
+    else
+      puts "FAIL - some paths don't exist"
+
+      puts "Missing Manuals: #{missing_paths[:manuals]}"
+
+      puts "Missing Sections: #{missing_paths[:sections]}"
+    end
+  end
 end

--- a/lib/tasks/withdraw_and_redirect_manuals_to_multiple_paths.rake
+++ b/lib/tasks/withdraw_and_redirect_manuals_to_multiple_paths.rake
@@ -1,0 +1,8 @@
+desc "Withdraw and redirect manual to multiple paths, e.g withdraw_and_redirect_sections_to_multiple_paths['lib/tasks/tmp_redirect.csv,true']"
+task :withdraw_and_redirect_manuals_to_multiple_paths, %i[csv_path discard_drafts] => :environment do |_, args|
+  discard_drafts = args.fetch(:discard_drafts) == "true"
+
+  WithdrawAndRedirectToMultiplePaths.new(
+    csv_path: args.fetch(:csv_path), discard_drafts: discard_drafts,
+  ).execute
+end

--- a/lib/tasks/withdraw_and_redirect_section.rake
+++ b/lib/tasks/withdraw_and_redirect_section.rake
@@ -1,0 +1,16 @@
+desc "Withdraw and redirect section, e.g withdraw_and_redirect_section['guidance/manual,guidance/manual/section,/redirect/blah,true']"
+task :withdraw_and_redirect_section, %i[manual_path section_path redirect discard_draft] => :environment do |_, args|
+  discard_draft = args.fetch(:discard_draft) == "true"
+
+  redirect_section = WithdrawAndRedirectSection.new(
+    user: User.gds_editor,
+    manual_path: args.fetch(:manual_path),
+    section_path: args.fetch(:section_path),
+    redirect: args.fetch(:redirect),
+    discard_draft: discard_draft,
+  )
+
+  redirect_section.execute
+
+  puts "Section withdrawn and redirected to #{args.fetch(:redirect)}"
+end

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -546,6 +546,46 @@ describe PublishingAdapter do
     end
   end
 
+  describe "#unpublish_and_redirect_manual_and_sections" do
+    let(:redirect) { "/blah/redirect" }
+    let(:redirects) do
+      [
+        { path: "/#{manual.slug}", type: "exact", destination: redirect },
+        { path: "/#{manual.slug}/updates", type: "exact", destination: redirect },
+      ]
+    end
+
+    before do
+      allow(publishing_api).to receive(:unpublish)
+    end
+
+    it "unpublishes and redirects only manual via Publishing API" do
+      expect(publishing_api).to receive(:unpublish).with(
+        manual_id, type: "redirect", redirects: redirects, discard_drafts: true
+      )
+
+      subject.unpublish_and_redirect_manual_and_sections(
+        manual, redirect: redirect, include_sections: false, discard_drafts: true
+      )
+    end
+
+    it "unpublishes and redirects manual plus sections via Publishing API" do
+      manual.sections = [section]
+
+      expect(publishing_api).to receive(:unpublish).with(
+        manual_id, type: "redirect", redirects: redirects, discard_drafts: false
+      )
+
+      expect(publishing_api).to receive(:unpublish).with(
+        section.uuid, type: "redirect", discard_drafts: false, alternative_path: redirect
+      )
+
+      subject.unpublish_and_redirect_manual_and_sections(
+        manual, redirect: redirect, include_sections: true, discard_drafts: false
+      )
+    end
+  end
+
   describe "#unpublish" do
     before do
       manual.sections = [section]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
     summary { "My summary" }
     body { "My body" }
     change_note { "New section added" }
+    state { "draft" }
   end
 
   factory :publication_log do
@@ -59,18 +60,22 @@ FactoryBot.define do
   end
 
   factory :manual_record do
-    slug { "slug" }
+    slug { "guidance/manual" }
     manual_id { "abc-123" }
     organisation_slug { "organisation_slug" }
 
-    after(:build) do |manual_record|
-      manual_record.editions << FactoryBot.build(:manual_record_edition)
+    transient do
+      state { "draft" }
+    end
+
+    after(:build) do |manual_record, evaluator|
+      manual_record.editions << FactoryBot.build(:manual_record_edition, state: evaluator.state)
     end
 
     trait :with_sections do
-      after(:build) do |manual_record|
+      after(:build) do |manual_record, evaluator|
         manual_record.editions.each do |edition|
-          section = FactoryBot.create(:section_edition)
+          section = FactoryBot.create(:section_edition, state: evaluator.state)
           edition.section_uuids = [section.section_uuid]
         end
       end
@@ -90,7 +95,7 @@ FactoryBot.define do
     title { "title" }
     summary { "summary" }
     body { "body" }
-    state { "state" }
+    state { "draft" }
     version_number { 1 }
     originally_published_at { Time.zone.now }
     use_originally_published_at_for_public_timestamp { true }

--- a/spec/lib/withdraw_and_redirect_manual_spec.rb
+++ b/spec/lib/withdraw_and_redirect_manual_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe WithdrawAndRedirectManual do
   let(:state) { "published" }
   let(:user) { User.gds_editor }
   let(:include_sections) { true }
+  let(:dry_run) { false }
 
   let(:discard_service) { double(:discard_service) }
   let(:publishing_adapter) { double(:publishing_adapter) }
@@ -20,6 +21,7 @@ RSpec.describe WithdrawAndRedirectManual do
       redirect: redirect,
       include_sections: include_sections,
       discard_drafts: discard_drafts,
+      dry_run: dry_run,
     )
   end
 
@@ -52,6 +54,15 @@ RSpec.describe WithdrawAndRedirectManual do
 
     it "raises an error" do
       expect { subject.execute }.to raise_error(WithdrawAndRedirectManual::ManualNotPublishedError)
+    end
+  end
+
+  context "when a dry run is flagged" do
+    let(:dry_run) { true }
+
+    it "doesn't action the withdrawal" do
+      subject.execute
+      expect(publishing_adapter).to_not have_received(:unpublish_and_redirect_manual_and_sections)
     end
   end
 end

--- a/spec/lib/withdraw_and_redirect_manual_spec.rb
+++ b/spec/lib/withdraw_and_redirect_manual_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe WithdrawAndRedirectManual do
+  let(:manual_record) { FactoryBot.create(:manual_record, :with_sections, state: state) }
+  let(:manual) { Manual.build_manual_for(manual_record) }
+  let(:section) { manual.sections.last }
+  let(:redirect) { "/redirect/blah" }
+  let(:discard_drafts) { false }
+  let(:state) { "published" }
+  let(:user) { User.gds_editor }
+  let(:include_sections) { true }
+
+  let(:discard_service) { double(:discard_service) }
+  let(:publishing_adapter) { double(:publishing_adapter) }
+
+  subject do
+    described_class.new(
+      user: user,
+      manual_path: manual.slug,
+      redirect: redirect,
+      include_sections: include_sections,
+      discard_drafts: discard_drafts,
+    )
+  end
+
+  before do
+    allow(Manual::DiscardDraftService).to receive(:new) { discard_service }
+    allow(discard_service).to receive(:call)
+
+    allow(Adapters).to receive(:publishing) { publishing_adapter }
+    allow(publishing_adapter).to receive(:unpublish_and_redirect_manual_and_sections)
+  end
+
+  it "withdraws the manual" do
+    subject.execute
+
+    reloaded_manual = Manual.find(manual.id, user)
+    expect(reloaded_manual.withdrawn?).to eq(true)
+  end
+
+  it "calls the publishing adapter to unpublish the manual" do
+    subject.execute
+    expect(publishing_adapter).to have_received(:unpublish_and_redirect_manual_and_sections)
+      .with(instance_of(Manual),
+            redirect: redirect,
+            include_sections: include_sections,
+            discard_drafts: discard_drafts)
+  end
+
+  context "when there is no published manual" do
+    let(:state) { "draft" }
+
+    it "raises an error" do
+      expect { subject.execute }.to raise_error(WithdrawAndRedirectManual::ManualNotPublishedError)
+    end
+  end
+end

--- a/spec/lib/withdraw_and_redirect_section_spec.rb
+++ b/spec/lib/withdraw_and_redirect_section_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.describe WithdrawAndRedirectSection do
+  let(:manual_record) { FactoryBot.create(:manual_record, :with_sections, state: state) }
+  let(:manual) { Manual.build_manual_for(manual_record) }
+  let(:section) { manual.sections.last }
+  let(:publishing_adapter) { double(:publishing_adapter) }
+  let(:redirect) { "/redirect/blah" }
+  let(:discard_draft) { false }
+  let(:state) { "published" }
+
+  subject do
+    described_class.new(
+      user: User.gds_editor,
+      manual_path: manual.slug,
+      section_path: manual.sections.last.slug,
+      redirect: redirect,
+      discard_draft: discard_draft,
+    )
+  end
+
+  before do
+    allow(Adapters).to receive(:publishing) { publishing_adapter }
+    allow(publishing_adapter).to receive(:unpublish_section)
+  end
+
+  it "calls the publishing adapter to unpublish the section" do
+    subject.execute
+    expect(publishing_adapter).to have_received(:unpublish_section)
+      .with(instance_of(Section),
+            redirect: redirect,
+            discard_drafts: discard_draft)
+  end
+
+  context "when only a draft section exists" do
+    let(:state) { "draft" }
+
+    it "raises an error if section is not published" do
+      expect { subject.execute }.to raise_error(WithdrawAndRedirectSection::SectionNotPublishedError)
+    end
+  end
+
+  context "when an accompanying drafts exists and discard_draft is flagged" do
+    let(:discard_draft) { true }
+
+    it "discards draft" do
+      manual.draft
+      section.assign_attributes({})
+      manual.save!(User.gds_editor)
+
+      subject.execute
+      expect(publishing_adapter).to have_received(:unpublish_section)
+        .with(instance_of(Section),
+              redirect: redirect,
+              discard_drafts: discard_draft)
+    end
+  end
+end

--- a/spec/lib/withdraw_and_redirect_section_spec.rb
+++ b/spec/lib/withdraw_and_redirect_section_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe WithdrawAndRedirectSection do
   let(:redirect) { "/redirect/blah" }
   let(:discard_draft) { false }
   let(:state) { "published" }
+  let(:dry_run) { false }
 
   subject do
     described_class.new(
@@ -16,6 +17,7 @@ RSpec.describe WithdrawAndRedirectSection do
       section_path: manual.sections.last.slug,
       redirect: redirect,
       discard_draft: discard_draft,
+      dry_run: dry_run,
     )
   end
 
@@ -53,6 +55,15 @@ RSpec.describe WithdrawAndRedirectSection do
         .with(instance_of(Section),
               redirect: redirect,
               discard_drafts: discard_draft)
+    end
+  end
+
+  context "when a dry run is flagged" do
+    let(:dry_run) { true }
+
+    it "doesn't action the withdrawal" do
+      subject.execute
+      expect(publishing_adapter).to_not have_received(:unpublish_section)
     end
   end
 end

--- a/spec/lib/withdraw_and_redirect_to_multiple_paths_spec.rb
+++ b/spec/lib/withdraw_and_redirect_to_multiple_paths_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+RSpec.describe WithdrawAndRedirectToMultiplePaths do
+  let(:discard_drafts) { false }
+  let(:withdraw_and_redirect_manual) { double(:withdraw_and_redirect_manual) }
+  let(:withdraw_and_redirect_section) { double(:withdraw_and_redirect_section) }
+
+  subject do
+    described_class.new(
+      csv_path: "spec/support/withdraw_and_redirect_to_multiple_paths.csv",
+      discard_drafts: discard_drafts,
+    )
+  end
+
+  before do
+    allow(WithdrawAndRedirectManual).to receive(:new) { withdraw_and_redirect_manual }
+    allow(withdraw_and_redirect_manual).to receive(:execute)
+
+    allow(WithdrawAndRedirectSection).to receive(:new) { withdraw_and_redirect_section }
+    allow(withdraw_and_redirect_section).to receive(:execute)
+  end
+
+  it "withdraws and redirects a manual" do
+    subject.execute
+
+    expect(WithdrawAndRedirectManual).to have_received(:new).with(
+      user: instance_of(User),
+      manual_path: "guidance/published",
+      redirect: "/guidance/redirect",
+      include_sections: false,
+      discard_drafts: false,
+    )
+
+    expect(withdraw_and_redirect_manual).to have_received(:execute)
+  end
+
+  it "withdraws and redirects section" do
+    subject.execute
+
+    expect(WithdrawAndRedirectSection).to have_received(:new).with(
+      user: instance_of(User),
+      manual_path: "guidance/manual",
+      section_path: "guidance/manual/just-a-section",
+      redirect: "/guidance/section-blah",
+      discard_draft: false,
+    )
+
+    expect(withdraw_and_redirect_section).to have_received(:execute)
+  end
+
+  it "skips updates page" do
+    expect { subject.execute }.to output(
+      /Updates page 'guidance\/published\/updates' will be redirected to Manual's redirect, if provided\n/,
+    ).to_stdout
+  end
+
+  it "rescues and logs error if a manual isn't published" do
+    allow(withdraw_and_redirect_manual).to receive(:execute).and_raise(WithdrawAndRedirectManual::ManualNotPublishedError)
+
+    expect { subject.execute }.to output(
+      /\[ERROR\] Manual not redirected due to not being in a published state: guidance\/published/,
+    ).to_stdout
+  end
+
+  it "rescues and logs error if a section isn't published" do
+    allow(withdraw_and_redirect_section).to receive(:execute).and_raise(WithdrawAndRedirectSection::SectionNotPublishedError)
+
+    expect { subject.execute }.to output(
+      /\[ERROR\] Section not redirected due to not being in a published state: guidance\/manual\/just-a-section/,
+    ).to_stdout
+  end
+end

--- a/spec/support/withdraw_and_redirect_to_multiple_paths.csv
+++ b/spec/support/withdraw_and_redirect_to_multiple_paths.csv
@@ -1,0 +1,4 @@
+base_path,redirect
+guidance/published,/guidance/redirect
+guidance/published/updates,/guidance/redirect/blah
+guidance/manual/just-a-section,/guidance/section-blah


### PR DESCRIPTION
Adds ability to withdraw and redirect manuals and sections, either one by one or as a bulk job.

### Jenkins builds

- [x] [withdraw_and_redirect_manuals_to_multiple_paths:dry_run](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218286/)
- [x] `withdraw_and_redirect_manuals_to_multiple_paths:real`, first run (https://deploy.blue.staging.govuk.digital/job/run-rake-task/218287/) and second (https://deploy.blue.staging.govuk.digital/job/run-rake-task/218289/). A space in a path in the CSV caused a validation error so had to run twice after pushing the fix.

Trello:
https://trello.com/c/HospHGQo/1362-enable-unpublishing-and-redirecting-of-manuals-via-rake-tasks

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️