### PR TITLE
Don't try and discard draft if it doesn't exist

### DIFF
--- a/app/services/section/remove_service.rb
+++ b/app/services/section/remove_service.rb
@@ -31,7 +31,10 @@ class Section::RemoveService
       manual.remove_section(section_uuid)
       manual.save!(user)
       Adapters.publishing.save_draft(manual, include_sections: false)
-      Adapters.publishing.discard_section(section)
+
+      if section.draft?
+        Adapters.publishing.discard_section(section)
+      end
     end
 
     [manual, section]


### PR DESCRIPTION
Fixes bug which returned the user an error when the section was not in a
draft state. This is possible either, if the user withdraws the section
via the UI, without editing the section first, due to it remaining in a
'published' state or when a section is withdrawn and redirected, the
state of the section is 'withdrawn'.

Both these scenarios are valid and so we shouldn't try and remove a
draft, unless there is one.

Trello:
https://trello.com/c/Xr6RU7UX/1363-fix-longstanding-bug-in-manuals-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️