### PR TITLE
Remove content schema test helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
   gem "cucumber-rails", require: false
   gem "database_cleaner-mongoid"
   gem "factory_bot_rails"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "launchy"
   gem "rails-controller-testing"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,8 +187,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_admin_template (6.9.2)
       bootstrap-sass (~> 3.4)
       jquery-rails (~> 4.3)
@@ -215,6 +213,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -525,10 +525,10 @@ DEPENDENCIES
   gds-sso
   generic_form_builder
   govspeak
-  govuk-content-schema-test-helpers
   govuk_admin_template
   govuk_app_config
   govuk_frontend_toolkit
+  govuk_schemas
   govuk_sidekiq
   govuk_test
   launchy

--- a/spec/adapters/publishing_adapter_spec.rb
+++ b/spec/adapters/publishing_adapter_spec.rb
@@ -805,7 +805,7 @@ describe PublishingAdapter do
 private
 
   def attributes_valid_according_to_schema(schema_name)
-    be_valid_against_schema(schema_name)
+    be_valid_against_publisher_schema(schema_name)
   end
 
   def attributes_valid_according_to_links_schema(schema_name)

--- a/spec/support/govuk_content_schema_helpers.rb
+++ b/spec/support/govuk_content_schema_helpers.rb
@@ -1,9 +1,0 @@
-require "govuk-content-schema-test-helpers"
-require "govuk-content-schema-test-helpers/rspec_matchers"
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
-
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers

--- a/spec/support/govuk_schemas_helpers.rb
+++ b/spec/support/govuk_schemas_helpers.rb
@@ -1,0 +1,3 @@
+require "govuk_schemas/rspec_matchers"
+
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem)

This PR replaces the deprecated govuk-content-schemas-test-helpers gem with the govuk_schemas gem.
It updates the RSpec support files to include the govuk_schemas RSpec matchers, and updates the RSpec syntax to make sure tests are passing.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️