### PR TITLE
Use manual's content id

### DIFF
--- a/lib/tasks/tmp_fix_manuals_in_incorrect_state.rake
+++ b/lib/tasks/tmp_fix_manuals_in_incorrect_state.rake
@@ -73,7 +73,7 @@ namespace :tmp_fix_manuals_in_incorrect_state do
     ]
 
     Services.publishing_api.unpublish(
-      manual.id,
+      "7e144535-482a-4866-aac2-bdf3af3563c0",
       type: "redirect",
       redirects: [
         {


### PR DESCRIPTION
`manual.id` was mistakenly used instead of hardcoding the manual's content id.

Trello:
https://trello.com/c/ZhJ2oj7N/1339-resolve-redirect-issues-for-manuals

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️