### PR TITLE
Remove initialisation of the PrimaryLinks JS Module

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,12 +7,6 @@
 //= require markdown_preview
 //= require toggle_display_with_checked_input
 
-function initPrimaryLinks () {
-  GOVUK.primaryLinks.init('.primary-item')
-}
-$(initPrimaryLinks)
-$(window).on('displayPreviewDone', initPrimaryLinks)
-
 jQuery(function ($) {
   $('.js-length-counter').each(function () {
     new GOVUK.LengthCounter({ $el: $(this) }) // eslint-disable-line no-new


### PR DESCRIPTION
## What
Remove the initialisation of the PrimaryLinks JS Module

## Why
Previewing a Priority List is not required as the PrimaryLinks module is to be removed from govuk-publishing-components and govspeak.

## Visual Changes

| Before | After |
| - | - |
| <img width="768" alt="before" src="https://user-images.githubusercontent.com/28779939/180734304-b20cb078-8bf7-4cd9-9015-8e0261ae8c8d.png"> | <img width="767" alt="after" src="https://user-images.githubusercontent.com/28779939/180734348-4e3de17c-3695-4b33-8e6a-406f689bf487.png"> |

Trello: https://trello.com/c/nezjGrzF/1388-investigate-and-potentially-fix-primary-links-module

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️