### PR TITLE
Turn off 'autosave' to fix performance issue

### DIFF
--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -8,8 +8,7 @@ class ManualRecord
 
   has_many :editions,
            class_name: "ManualRecord::Edition",
-           dependent: :destroy,
-           autosave: true
+           dependent: :destroy
 
   def self.find_by(attributes)
     where(attributes).first

--- a/app/models/manual_record.rb
+++ b/app/models/manual_record.rb
@@ -84,14 +84,5 @@ private
     # We don't make use of the relationship but Mongoid can't save the
     # timestamps properly without it.
     belongs_to :manual_record
-
-    after_save :touch_manual_record
-    before_destroy :touch_manual_record
-
-    def touch_manual_record
-      # Apparently touch is a Mongoid 3 thing, so we use the callback code
-      # from Mongoid::Timestamps::Updated
-      manual_record.set_updated_at if manual_record.able_to_set_updated_at?
-    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,6 +72,10 @@ FactoryBot.define do
       manual_record.editions << FactoryBot.build(:manual_record_edition, state: evaluator.state)
     end
 
+    after(:create) do |manual_record|
+      manual_record.editions.each(&:save!)
+    end
+
     trait :with_sections do
       after(:build) do |manual_record, evaluator|
         manual_record.editions.each do |edition|


### PR DESCRIPTION
This PR has been opened in response to reports from users that are unable to save Manuals that have a large number of Editions.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️