### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "govuk_admin_template"
 gem "govuk_app_config"
 gem "govuk_frontend_toolkit"
 gem "govuk_sidekiq"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongoid"
 gem "plek"
 gem "sass-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,6 +530,7 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   listen
+  mail (~> 2.7.1)
   mongoid
   plek
   pry-byebug


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
