### PR TITLE
Update update_manual_organisation rake task to update sections.

### DIFF
--- a/lib/tasks/update_manual_organisation.rake
+++ b/lib/tasks/update_manual_organisation.rake
@@ -21,12 +21,17 @@ task :update_manual_organisation, %i[manual_base_path organisation_slug] => :env
   # Update the record in the local database to allow the members of the
   # given organisation to access the manual in Manuals Publisher
   logger.info "Updating record in local database"
-  ManualRecord.find_by(manual_id:).update!(organisation_slug:)
+  manual_record = ManualRecord.find_by(manual_id:)
+  manual_record.update!(organisation_slug:)
+  section_content_ids = manual_record.latest_edition.section_uuids
 
   # Use the Publishing API to update the document
   # across GOV.UK and front end applications
   logger.info "Updating organisations links in Publishing API"
-  Services.publishing_api.patch_links(manual_id, links: { organisations: [organisation_id] })
+  [manual_id, *section_content_ids].each do |content_id|
+    logger.info " - Updateing content item #{content_id}"
+    Services.publishing_api.patch_links(content_id, links: { organisations: [organisation_id], primary_publishing_organisation: [organisation_id] })
+  end
 
   logger.info "Complete. Updated organisation for '#{manual_base_path}' to '#{organisation_slug}'"
 end


### PR DESCRIPTION
Update this task so that it update the section owner organisation when it updates the manual.

https://govuk.zendesk.com/agent/tickets/5145766

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
