### PR TITLE
Adding ability to add ASSETS_PREFIX ENV value.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
 FROM $builder_image AS builder
 
+ENV ASSETS_PREFIX=/assets/manuals-publisher
+
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
@@ -16,7 +18,8 @@ RUN bundle exec rails assets:precompile && rm -fr /app/log
 
 FROM $base_image
 
-ENV GOVUK_APP_NAME=manuals-publisher
+ENV GOVUK_APP_NAME=manuals-publisher \
+    ASSETS_PREFIX=/assets/manuals-publisher
 
 WORKDIR /app
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,7 @@ module ManualsPublisher
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    config.assets.prefix = ENV.fetch("ASSETS_PREFIX", "/assets")
   end
 end


### PR DESCRIPTION
Same change that was applied to collections-publisher: https://github.com/alphagov/collections-publisher/commit/44cd9ccabeb51e4ef45947104de747352c193c8d

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
