### PR TITLE
Application specific asset path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,9 @@ module ManualsPublisher
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/manuals-publisher"
   end
 end

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/manuals-publisher",
   "srcFiles": [
     "govuk-admin-template-*.js",
     "application-*.js"


### PR DESCRIPTION
This sets the asset path to include the application name. It is an alternative to https://github.com/alphagov/manuals-publisher/pull/2003 which made this something configurable by an env var.

As this will work in all environments set to a consistent pattern we can avoid the need for this be something that is configured.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
