### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,16 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+node_modules
+package.json
+script
+spec
+test
 tmp
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 
 
@@ -18,6 +19,7 @@ ENV GOVUK_APP_NAME=manuals-publisher
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,24 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-
-RUN bundle exec rails assets:precompile && rm -fr /app/log
+COPY . .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=manuals-publisher
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD bundle exec puma
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4"
 
+gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "generic_form_builder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -261,6 +263,7 @@ GEM
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.18.0, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
+    msgpack (1.6.0)
     multi_test (1.1.0)
     multi_xml (0.6.0)
     net-imap (0.3.4)
@@ -516,6 +519,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bootsnap
   cucumber
   cucumber-rails (~> 2.6)
   database_cleaner-mongoid

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Update .dockerignore.

Tested: app boots successfully with `docker run`.
