### PR TITLE
Enforce Sidekiq strict args

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,2 @@
+# Use Sidekiq strict args to force Sidekiq 6 deprecations to error ahead of upgrade to Sidekiq 7
+Sidekiq.strict_args!


### PR DESCRIPTION
## Description

We're going through out apps that use Sidekiq and enforcing Sidekiq strict args to ensure we're compatible with Sidekiq 7.

## Trello card

https://trello.com/c/JXAvbpOX/1103-upgrade-apps-to-sidekiq-v6

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
