### PR TITLE
Add temporary csv for bulk manuals redirect

### DIFF
--- a/lib/tasks/tmp_redirects.csv
+++ b/lib/tasks/tmp_redirects.csv
@@ -1,6 +1,6 @@
 base_path,redirect
-guidance/how-to-complete-your-2022-environmental-stewardship-revenue-claim-form,/guidance/how-to-complete-your-2022-environmental-stewardship-revenue-claim-form
-guidance/how-to-complete-your-2021-environmental-stewardship-claim-form,/guidance/how-to-complete-your-2021-environmental-stewardship-claim-form
+guidance/how-to-complete-your-2022-environmental-stewardship-revenue-claim-form,/guidance/environmental-stewardship-how-to-get-paid-under-your-agreement
+guidance/how-to-complete-your-2021-environmental-stewardship-claim-form,/guidance/environmental-stewardship-how-to-get-paid-under-your-agreement
 guidance/how-to-apply-online-for-bps-in-2022,/guidance/basic-payment-scheme
 guidance/basic-payment-scheme-2022-how-to-apply-using-a-paper-form,/guidance/basic-payment-scheme
 guidance/how-to-apply-online-for-bps-in-2021,/guidance/basic-payment-scheme


### PR DESCRIPTION
This PR slightly amends `tmp_redirects.csv` with updated redirects as per this [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5309756)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
