### PR TITLE
Allow changing the organisation of draft manuals

### DIFF
--- a/lib/tasks/update_manual_organisation.rake
+++ b/lib/tasks/update_manual_organisation.rake
@@ -9,7 +9,7 @@ task :update_manual_organisation, %i[manual_base_path organisation_slug] => :env
   organisation_slug = args[:organisation_slug] # e.g. "homes-england"
 
   logger.info "Looking up Manual content_id from base path (#{manual_base_path})"
-  manual_id = Services.publishing_api.lookup_content_id(base_path: manual_base_path)
+  manual_id = Services.publishing_api.lookup_content_id(base_path: manual_base_path, with_drafts: true)
   logger.info "- found: #{manual_base_path} => #{manual_id}"
 
   logger.info "Looking up organisation content_id from organisation slug (#{organisation_slug})"


### PR DESCRIPTION
This adds support for changing the organisation of manuals which haven't yet been published (i.e. draft manuals).

The Rake task `update_manual_organisation` previously couldn't find draft manuals because `with_drafts` defaults to `false` if not specified.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
