### PR TITLE
Add GDS system & layout for transition

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,9 @@
 // govuk_admin_template
 @import "govuk_admin_template";
 
+// govuk_components
+@import "govuk_publishing_components/all_components";
+
 // govuk_frontend_toolkit
 @import "colours";
 @import "typography";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,22 @@ class ApplicationController < ActionController::Base
     redirect_to(manuals_path, flash: { error: "Manual not found" })
   end
 
+  def preview_design_system?(next_release: false)
+    # Temporarily force this flag to 'on' for users in production, regardless of their permissions
+    return true if next_release && !Rails.env.test?
+
+    current_user.can_preview_design_system? || (next_release && current_user.can_preview_next_release?)
+  end
+  helper_method :preview_design_system?
+
+  def render_design_system(design_system_view, legacy_view, locals)
+    if get_layout == "design_system"
+      render(design_system_view, locals:)
+    else
+      render legacy_view, locals:
+    end
+  end
+
   def current_user_can_publish?
     permission_checker.can_publish?
   end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -1,7 +1,8 @@
 class PermissionChecker
   GDS_EDITOR_PERMISSION = "gds_editor".freeze
   EDITOR_PERMISSION = "editor".freeze
-
+  PREVIEW_DESIGN_SYSTEM = "Preview design system".freeze
+  PREVIEW_NEXT_RELEASE = "Preview next release".freeze
   def initialize(user)
     @user = user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,12 @@ class User
       ManualRecord.where(organisation_slug:)
     end
   end
+
+  def can_preview_design_system?
+    has_permission?(PermissionChecker::PREVIEW_DESIGN_SYSTEM)
+  end
+
+  def can_preview_next_release?
+    has_permission?(PermissionChecker::PREVIEW_NEXT_RELEASE)
+  end
 end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,0 +1,54 @@
+<% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
+
+<% content_for :head do %>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= stylesheet_link_tag "application", :media => "all" %>
+  <%= javascript_include_tag 'application' %>
+<% end %>
+
+<% content_for :page_title, " | Manuals Publisher" %>
+<% content_for :app_title, "GOV.UK Manuals Publisher" %>
+
+<% content_for :navbar_items do %>
+  <li><%= nav_link_to 'Manuals', '/manuals' %></li>
+<% end %>
+
+<% content_for :navbar_right do %>
+  Hello, <%= link_to current_user.name, Plek.external_url_for('signon') %>
+  &bull; <%= link_to 'Sign out', gds_sign_out_path %>
+<% end %>
+
+<% content_for :content do %>
+  <% flash.each do |type, msg| %>
+    <%= content_tag :div, msg, class: "alert #{bootstrap_class_for(type)}" %>
+  <% end -%>
+  <%= render(:partial => 'shared/breadcrumbs') %>
+  <%= yield %>
+  <script>
+      $(document).ready(function() {
+          <%= yield :document_ready %>
+      });
+  </script>
+<% end %>
+
+<%# use the govuk_admin_foundation layout %>
+<%= render :template => 'layouts/govuk_admin_template' %>
+
+<%= render "govuk_publishing_components/components/layout_footer", {
+  navigation: [
+    {
+      title: "Support and feedback",
+      items: [
+        {
+          href: Plek.external_url_for("support"),
+          text: "Raise a support request"
+        },
+        {
+          href: "https://www.gov.uk/government/content-publishing",
+          text: "How to write, publish, and improve content"
+        }
+      ]
+    }
+  ]
+} %>

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -1,0 +1,84 @@
+##
+# Helper methods for use with the "select-with-search" component.
+# This wraps and extends the Select component's helper methods to add support for option groups.
+##
+module GovukPublishingComponents
+  module Presenters
+    class SelectWithSearchHelper
+      include ActionView::Helpers::FormOptionsHelper
+
+      attr_reader :options, :selected_option
+
+      delegate :describedby,
+               :error_id,
+               :error_message,
+               :hint_id,
+               :hint,
+               :label_classes,
+               :select_classes,
+               to: :@select_helper
+
+      def initialize(local_assigns)
+        @select_helper = SelectHelper.new(local_assigns.except(:options, :grouped_options))
+        @options = local_assigns[:options]
+        @grouped_options = local_assigns[:grouped_options]
+        @include_blank = local_assigns[:include_blank]
+        @local_assigns = local_assigns
+      end
+
+      def css_classes
+        classes = %w[app-c-select-with-search govuk-form-group]
+        classes << "govuk-form-group--error" if error_message
+        classes
+      end
+
+      def options_html
+        if @grouped_options.present?
+          blank_option_if_include_blank +
+            grouped_options_for_select(
+              transform_grouped_options(@grouped_options),
+              selected_option,
+            )
+        elsif @options.present?
+          blank_option_if_include_blank +
+            options_for_select(
+              transform_options(@options),
+              selected_option,
+            )
+        end
+      end
+
+      def data_attributes
+        {
+          "module": "select-with-search",
+          "track-category": @local_assigns[:track_category],
+          "track-label": @local_assigns[:track_label],
+        }.compact
+      end
+
+    private
+
+      def transform_options(options)
+        options.map do |option|
+          @selected_option = option[:value] if option[:selected]
+          [
+            option[:text],
+            option[:value],
+          ]
+        end
+      end
+
+      def transform_grouped_options(grouped_options)
+        grouped_options.map do |(group, options)|
+          [group, transform_options(options)]
+        end
+      end
+
+      def blank_option_if_include_blank
+        return "".html_safe if @include_blank.blank?
+
+        options_for_select([["", ""]])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
Add design_system.html.erb for layout
Add select_with_search_helper.html.erb required by layout Extend application.scss to include GDS components
Extend application_controller.rb to include preview_design_system & render_design_system functions Extend user.rb to include PermissionChecker for the release flags Why
Enable porting of Manuals pages to GDS to improve Manuals Publisher functionality & mirror similar styles to Whitehall for User & Developer consistency. Adding design system flags to allow incremental functionality improvement's without visual page changes. This could also be done without the get_layout and flags by adjusting to render "design_system" but this would require all page views to be done at once Trello
https://trello.com/c/M0crhdKs/314-move-pages-to-gov-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
