### PR TITLE
Consolidation paste to govspeak squashed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,9 +11,7 @@ docs
 features
 log
 node_modules
-package.json
 script
 spec
 test
 tmp
-yarn.lock

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
+/* global pasteHtmlToGovspeak */
 //= require vendor/jquery-1.11.0.min
 //= require vendor/jquery-ui.min.js
 
@@ -13,7 +14,7 @@ jQuery(function ($) {
   })
 
   $('.js-paste-html-to-govspeak').each(function () {
-    this.addEventListener('paste', pasteHtmlToGovspeak.pasteListener) // eslint-disable-line no-undef
+    this.addEventListener('paste', pasteHtmlToGovspeak.pasteListener)
   })
 
   $('.reorderable-document-list').sortable()

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,10 +6,14 @@
 //= require length_counter
 //= require markdown_preview
 //= require toggle_display_with_checked_input
-
+//= require paste-html-to-govspeak
 jQuery(function ($) {
   $('.js-length-counter').each(function () {
     new GOVUK.LengthCounter({ $el: $(this) }) // eslint-disable-line no-new
+  })
+
+  $('.js-paste-html-to-govspeak').each(function () {
+    this.addEventListener('paste', pasteHtmlToGovspeak.pasteListener) // eslint-disable-line no-undef
   })
 
   $('.reorderable-document-list').sortable()

--- a/app/views/manuals/_form.html.erb
+++ b/app/views/manuals/_form.html.erb
@@ -8,7 +8,7 @@
       <div class="summary-length-info" aria-live="polite">
         Summary text should be 280 characters or fewer. <span class="count"></span>
       </div>
-      <%= f.text_area :body, rows: 20, cols: 40, class: 'form-control' %>
+      <%= f.text_area :body, rows: 20, cols: 40, class: 'form-control js-paste-html-to-govspeak' %>
 
       <div class="preview_button add-vertical-margins"></div>
       <div class="preview_container add-vertical-margins" style="display: none;"></div>

--- a/app/views/sections/_form.html.erb
+++ b/app/views/sections/_form.html.erb
@@ -6,7 +6,7 @@
       <%= f.text_field :title, label: 'Section title', class: 'form-control' %>
       <%= f.text_area :summary, rows: 20, cols: 40, label: 'Section summary', class: 'form-control short-textarea js-length-counter', data: { :"count-message-threshold" => 280, :"count-message-selector" => ".summary-length-info" } %>
       <div class="summary-length-info warning" aria-live="polite">Summary text should be 280 characters or fewer. <span class="count"></span></div>
-      <%= f.text_area :body, rows: 20, cols: 40, label: 'Section body', class: 'form-control' %>
+      <%= f.text_area :body, rows: 20, cols: 40, label: 'Section body', class: 'form-control js-paste-html-to-govspeak' %>
 
       <div class="preview_button add-vertical-margins"></div>
       <div class="preview_container add-vertical-margins" style="display: none;"></div>

--- a/features/creating-and-editing-a-manual.feature
+++ b/features/creating-and-editing-a-manual.feature
@@ -51,6 +51,12 @@ Feature: Creating and editing a manual
     When I edit a manual
     Then the manual's sections won't have changed
 
+  @javascript
+  Scenario: Pasting HTML into a manual
+    When I start creating a new manual
+    And I paste HTML into the manual body
+    Then the manual body field contains govspeak
+
   Scenario: Try to create an invalid manual
     When I create a manual with an empty title
     Then I see errors for the title field
@@ -66,6 +72,13 @@ Feature: Creating and editing a manual
     Then I see the manual has the new section
     And I see the section isn't visually expanded
     And the section and table of contents will have been sent to the draft publishing api
+
+  @javascript
+  Scenario: Pasting HTML into a section
+    Given a draft manual exists without any sections
+    When I start creating a section for the manual
+    And I paste HTML into the section body
+    Then the section body field contains govspeak
 
   Scenario: Add an expanded section to a manual
     Given a draft manual exists without any sections

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -278,9 +278,9 @@ end
 When(/^I add another section and publish the manual later$/) do
   create_section(
     @manual.title,
-    section_title: "Another section so we can publish",
-    section_summary: "Another section so we can publish summary",
-    section_body: "Another section so we can publish body",
+    { section_title: "Another section so we can publish",
+      section_summary: "Another section so we can publish summary",
+      section_body: "Another section so we can publish body" },
   )
   go_to_manual_page(@manual.title)
   publish_manual
@@ -665,6 +665,24 @@ When(/^I start creating a new manual$/) do
   }
 
   create_manual(@manual_fields, save: false)
+end
+
+When(/^I start creating a section for the manual$/) do
+  create_section(@manual_fields.fetch(:title), {}, save: false)
+end
+
+When(/^I paste HTML into the manual body$/) do
+  fill_in_field("body", "")
+  page.execute_script(javascript_to_simulate_paste("manual_body", "<h2>Benefits of following this advice</h2>"))
+end
+
+When(/^I paste HTML into the section body$/) do
+  fill_in_field("section body", "")
+  page.execute_script(javascript_to_simulate_paste("section_body", "<h2>Benefits of following this advice</h2>"))
+end
+
+Then(/^the (manual|section) body field contains govspeak$/) do |content_type_name|
+  expect(page).to have_field("#{content_type_name}_body", with: "## Benefits of following this advice")
 end
 
 When(/^I preview the manual$/) do

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -15,6 +15,18 @@ module FormHelpers
     end
   end
 
+  def javascript_to_simulate_paste(element_id, paste_content)
+    <<~JS
+      var event = new Event('paste')
+      event.clipboardData = {
+        getData: function() {
+          return '#{paste_content}'
+        }
+      }
+      document.getElementById('#{element_id}').dispatchEvent(event)
+    JS
+  end
+
   def clear_datetime(label)
     base_dom_id = find(:xpath, ".//label[contains(., '#{label}')]")["for"].gsub(/(_[1-5]i)$/, "")
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -30,7 +30,7 @@ module ManualHelpers
     Manual.find(manual.id, FactoryBot.build(:gds_editor))
   end
 
-  def create_section(manual_title, fields)
+  def create_section(manual_title, fields, save: true)
     go_to_manual_page(manual_title)
     click_on "Add section"
 
@@ -38,7 +38,7 @@ module ManualHelpers
 
     yield if block_given?
 
-    save_as_draft
+    save_as_draft if save
   end
 
   def create_expanded_section(manual_title, fields)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,2 @@
+# Maintain Rails < 7 behaviour of running yarn:install before assets:precompile
+Rake::Task["assets:precompile"].enhance(["yarn:install"])

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   "resolutions": {
     "stylelint/strip-ansi": "6.0.1",
     "stylelint/string-width": "4.2.3"
+  },
+  "dependencies": {
+    "paste-html-to-govspeak": "^0.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,6 +1894,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+paste-html-to-govspeak@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.3.0.tgz#9c4717690f3d6cd290c972c9bf106ead14adb177"
+  integrity sha512-K4jcJkZLQpvpukkiSzXZcXPbV80CDSKTI3zEs0/gVG+jx5H7v2XsdIOEuCZ56cRCCuuIH3rsrJcyoleGqPj6xw==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
## What

Improve the Manuals Publisher UX by automatically converting HTML pasted into the body fields of manuals and sections into govspeak.

This PR is a slightly modified version of [PR-2083](https://github.com/alphagov/manuals-publisher/pull/2083) that was merged into [consolidation-main](https://github.com/alphagov/manuals-publisher/tree/consolidation-main). The changes from that PR:
- removing the autogovspeak from the summary fields (since they are just plain text fields)
- added a feature test for pasting into the section body
- rebased on latest main.

## Why

Provides a quality of life update to users.

## Trello

https://trello.com/c/VSFs9h05/306-auto-govspeak

## Pics

H1 HTML

![Screenshot 2023-06-22 at 15 12 40](https://github.com/alphagov/manuals-publisher/assets/125891738/09bb9e08-7f3a-42e9-8f90-24f235bfc9f6)

Before paste

![Screenshot 2023-06-22 at 15 12 57](https://github.com/alphagov/manuals-publisher/assets/125891738/e0eddfc3-6441-4e44-ac46-78d83b7c9880)

After paste converted to Govspeak

![Screenshot 2023-06-22 at 15 13 53](https://github.com/alphagov/manuals-publisher/assets/125891738/3b925242-474d-4a65-b878-7b96a3b85aa2)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
