### PR TITLE
Update styling of what's new page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,5 @@
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/skip-link";
 @import "govuk_publishing_components/components/title";
+
+@import "views/whats_new";

--- a/app/assets/stylesheets/views/whats_new.scss
+++ b/app/assets/stylesheets/views/whats_new.scss
@@ -1,3 +1,14 @@
 .app-view-whats-new__last-updated {
   color: $govuk-secondary-text-colour;
 }
+
+.app-view-whats-new__section {
+  @include govuk-responsive-padding(5, "top");
+  @include govuk-responsive-padding(5, "bottom");
+
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-view-whats-new__section:last-child {
+  border-bottom: none;
+}

--- a/app/assets/stylesheets/views/whats_new.scss
+++ b/app/assets/stylesheets/views/whats_new.scss
@@ -1,0 +1,3 @@
+.app-view-whats-new__last-updated {
+  color: $govuk-secondary-text-colour;
+}

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -17,7 +17,11 @@
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper" id="main-content" role="main">
-      <%= yield %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= yield %>
+        </div>
+      </div>
     </main>
   </div>
 

--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -5,7 +5,7 @@
 <section class="app-view-whats-new__section">
   <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
 
-  <p class="govuk-body app-view-whats-new__last-updated">Last updated 18 Jul 2023</p>
+  <p class="govuk-body app-view-whats-new__last-updated">Last updated 13 Jul 2023</p>
 
   <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
 

--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -2,51 +2,55 @@
 <% content_for :title, page_name %>
 <%= render "govuk_publishing_components/components/title", { title: page_name } %>
 
-<h2 class="govuk-heading-l">New Manuals Publisher features</h2>
+<section class="app-view-whats-new__section">
+  <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
 
-<p class="govuk-body app-view-whats-new__last-updated">Last updated 18 Jul 2023</p>
+  <p class="govuk-body app-view-whats-new__last-updated">Last updated 18 Jul 2023</p>
 
-<p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
+  <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
 
-<p class="govuk-body">We’re doing this because we did user research earlier this year and discovered that Manuals users are lacking some
-  of the features that other publishing apps like Whitehall already have.</p>
+  <p class="govuk-body">We’re doing this because we did user research earlier this year and discovered that Manuals users are lacking some
+    of the features that other publishing apps like Whitehall already have.</p>
 
-<p class="govuk-body">If you have any questions or feedback about publishing, you can reach us on
-  <a href="mailto:publishing-service-feedback@digital.cabinet-office.gov.uk" class="govuk-link">publishing-service-feedback@digital.cabinet-office.gov.uk</a>.
-  For any other type of support, you can <a href="https://support.publishing.service.gov.uk/" class="govuk-link">submit a request via
-  Zendesk</a>.</p>
+  <p class="govuk-body">If you have any questions or feedback about publishing, you can reach us on
+    <a href="mailto:publishing-service-feedback@digital.cabinet-office.gov.uk" class="govuk-link">publishing-service-feedback@digital.cabinet-office.gov.uk</a>.
+    For any other type of support, you can <a href="https://support.publishing.service.gov.uk/" class="govuk-link">submit a request via
+    Zendesk</a>.</p>
+</section>
 
-<h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
+<section class="app-view-whats-new__section">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
-    <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      <strong class="govuk-tag govuk-tag--blue">
+        improvement
+      </strong>
+    </div>
   </div>
-  <div class="govuk-grid-column-one-quarter">
-    <strong class="govuk-tag govuk-tag--blue">
-      improvement
-    </strong>
-  </div>
-</div>
 
-<p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
+  <p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
 
-<p class="govuk-body">You can now paste formatted text into the body field and Manuals publisher will try to convert it into GOV.UK’s
-  version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope
-  this feature will save you time when editing content.</p>
+  <p class="govuk-body">You can now paste formatted text into the body field and Manuals publisher will try to convert it into GOV.UK’s
+    version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope
+    this feature will save you time when editing content.</p>
 
-<p class="govuk-body">This works best when copying and pasting from text editing software like Word or Google Docs. It is less likely to
-  recognise formatting from PDFs.</p>
+  <p class="govuk-body">This works best when copying and pasting from text editing software like Word or Google Docs. It is less likely to
+    recognise formatting from PDFs.</p>
 
-<p class="govuk-body">It will convert:</p>
+  <p class="govuk-body">It will convert:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>headings</li>
-  <li>bullets</li>
-  <li>numbered lists</li>
-  <li>links</li>
-  <li>email links</li>
-</ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>headings</li>
+    <li>bullets</li>
+    <li>numbered lists</li>
+    <li>links</li>
+    <li>email links</li>
+  </ul>
 
-<p class="govuk-body">Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for
-  these separately.</p>
+  <p class="govuk-body">Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for
+    these separately.</p>
+</section>

--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -4,7 +4,7 @@
 
 <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
 
-<p class="govuk-body">Last updated 18 Jul 2023</p>
+<p class="govuk-body app-view-whats-new__last-updated">Last updated 18 Jul 2023</p>
 
 <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
 
@@ -16,11 +16,20 @@
   For any other type of support, you can <a href="https://support.publishing.service.gov.uk/" class="govuk-link">submit a request via
   Zendesk</a>.</p>
 
-<h2 class="govuk-heading-l">Recent changes</h2>
+<h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
 
-<h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <strong class="govuk-tag govuk-tag--blue">
+      improvement
+    </strong>
+  </div>
+</div>
 
-<p class="govuk-body">13 Jul 2023</p>
+<p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
 
 <p class="govuk-body">You can now paste formatted text into the body field and Manuals publisher will try to convert it into GOV.UK’s
   version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope


### PR DESCRIPTION
## What

Update the what's new page to be closer in appearance to the one on Whitehall.

- Structured the page content into a two-thirds column div.
- Updated the styling of the "Last updated" date.
- Put a horizontal line between sections.
- "Tagged" the change as an "improvement".

## Why

These changes are part of the same [story for the what's new page](https://trello.com/c/WabvCEXa) as [the PR that initially created the page](https://github.com/alphagov/manuals-publisher/pull/2103), the intention being to get the basic page live quicker and then iterate on it. That PR did the bulk of the work of introducing the page and pulling in the GDS design system, this PR updates the page's look to more closely align with the what's new page in Whitehall.

## Visuals

Before (integration):
![manuals-publisher integration publishing service gov uk_whats-new](https://github.com/alphagov/manuals-publisher/assets/138604938/6e63e9af-a1c3-4915-804b-4dda709fb0fc)

After (development):
![manuals-publisher dev gov uk_whats-new](https://github.com/alphagov/manuals-publisher/assets/138604938/debdf40b-f461-4f62-a102-9f81ee5f7212)

## Trello

[Trello story](https://trello.com/c/WabvCEXa).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
