### PR TITLE
Add confirm publish warning page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,8 @@
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 
+@import "govuk_publishing_components/components/breadcrumbs";
+@import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/skip-link";

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -130,14 +130,22 @@ class ManualsController < ApplicationController
       user: current_user,
     )
     manual = service.call
+    slug_unique = manual.slug_unique?(current_user)
 
-    render(
-      :confirm_publish,
-      layout: "design_system",
-      locals: {
-        manual:,
-      },
-    )
+    if helpers.allow_publish?(manual, slug_unique)
+      render(
+        :confirm_publish,
+        layout: "design_system",
+        locals: {
+          manual:,
+        },
+      )
+    else
+      redirect_to(
+        manual_path(manual),
+        flash: { error: "You may not publish this manual" },
+      )
+    end
   end
 
   def publish

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -124,6 +124,22 @@ class ManualsController < ApplicationController
     end
   end
 
+  def confirm_publish
+    service = Manual::ShowService.new(
+      manual_id:,
+      user: current_user,
+    )
+    manual = service.call
+
+    render(
+      :confirm_publish,
+      layout: "design_system",
+      locals: {
+        manual:,
+      },
+    )
+  end
+
   def publish
     service = Manual::QueuePublishService.new(
       user: current_user,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,13 +43,13 @@ module ApplicationHelper
 
   def bootstrap_class_for(flash_type)
     case flash_type
-    when :success
+    when "success"
       "alert-success" # Green
-    when :error
+    when "error"
       "alert-danger" # Red
-    when :alert
+    when "alert"
       "alert-warning" # Yellow
-    when :notice
+    when "notice"
       "alert-info" # Blue
     else
       flash_type.to_s

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,6 +84,10 @@ module ApplicationHelper
     "#{Plek.external_url_for('draft-origin')}/#{manual.slug}"
   end
 
+  def allow_publish?(manual, slug_unique)
+    manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique
+  end
+
   def publish_text(manual, slug_unique)
     if manual.state == "published"
       text = "<p>There are no changes to publish.</p>"

--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, manual.title %>
+<% content_for :title, manual.title %>
+
+<% content_for :title_margin_bottom, 6 %>
+
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  collapse_on_mobile: true,
+  breadcrumbs: [
+    {
+      title: "Your manuals",
+      url: manuals_path
+    },
+    {
+      title: manual.title,
+      url: manual_path(manual)
+    },
+    {
+      title: "Publish"
+    },
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title: "Publish #{manual.title}"
+} %>
+
+<p class="govuk-body govuk-!-margin-bottom-7">You are about to publish "<%= manual.title %>". All the sections which
+  are in draft status will be published.</p>
+
+<%= form_tag(publish_manual_path(manual), method: :post) do %>
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Publish",
+      name: "submit",
+    } %>
+
+    <%= link_to("Cancel", manual_path(manual), class: "govuk-link govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -90,7 +90,7 @@
           <div class="panel-heading"><h3>Publish manual</h3></div>
           <div class="panel-body">
             <%= publish_text(manual, slug_unique) %>
-            <% if manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique %>
+            <% if allow_publish?(manual, slug_unique) %>
               <%= link_to 'Publish manual', confirm_publish_manual_path(manual), class: 'btn btn-danger' %>
             <% end %>
           </div>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -91,9 +91,7 @@
           <div class="panel-body">
             <%= publish_text(manual, slug_unique) %>
             <% if manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique %>
-              <%= form_tag(publish_manual_path(manual), method: :post) do %>
-                <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to publish this manual?">Publish manual</button>
-              <% end -%>
+              <%= link_to 'Publish manual', confirm_publish_manual_path(manual), class: 'btn btn-danger' %>
             <% end %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     # This is for drafts that have never been published
     delete :discard_draft, on: :member
 
+    get :confirm_publish, on: :member
+
     get :original_publication_date, on: :member, action: :edit_original_publication_date
     put :original_publication_date, on: :member, action: :update_original_publication_date
   end
@@ -35,7 +37,7 @@ Rails.application.routes.draw do
 
   post "/link-checker-api-callback" => "link_checker_api_callback#callback", as: "link_checker_api_callback"
 
-  # This is for new manualss
+  # This is for new manuals
   post "manuals/preview" => "manuals#preview", as: "preview_new_manual"
   # This is for new sections
   post "manuals/:manual_id/sections/preview" => "sections#preview", as: "preview_new_section"

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -8,7 +8,9 @@ Feature: Publishing a manual
 
   Scenario: Publish a manual
     Given a draft manual exists with some sections
-    When I publish the manual
+    When I click the publish manual button
+    Then I am asked to confirm the publishing
+    When I confirm publishing the manual
     Then the manual and all its sections are published
     And I should see a link to the live manual
 

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -275,6 +275,21 @@ When(/^I publish the manual$/) do
   publish_manual
 end
 
+When(/^I click the publish manual button$/) do
+  go_to_manual_page(@manual.title) if current_path != manual_path(@manual)
+  expect(page).to have_link("Publish manual", href: confirm_publish_manual_path(@manual))
+  click_on "Publish manual"
+end
+
+Then(/^I am asked to confirm the publishing$/) do
+  expect(page).to have_content("Publish #{@manual.title}")
+  expect(page).to have_button("Publish")
+end
+
+When(/^I confirm publishing the manual$/) do
+  click_on "Publish"
+end
+
 When(/^I add another section and publish the manual later$/) do
   create_section(
     @manual.title,

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -149,6 +149,8 @@ module ManualHelpers
 
   def publish_manual
     click_on "Publish manual"
+    page.should have_button("Publish")
+    click_on "Publish"
   end
 
   def stub_manual_publication_observers(organisation_slug)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe ApplicationHelper, type: :helper do
+  describe "#allow_publish?" do
+    let(:manual) { instance_double(Manual) }
+
+    before do
+      @slug_unique = true
+      allow(manual).to receive(:draft?).and_return(true)
+      allow(manual).to receive_message_chain("sections.any?") { true }
+    end
+
+    context "when the current user can publish" do
+      def current_user_can_publish? = true
+
+      it "returns true when the manual may be published" do
+        allowed = allow_publish?(manual, @slug_unique)
+
+        expect(allowed).to be true
+      end
+
+      it "returns false when the manual is not in draft" do
+        allow(manual).to receive(:draft?).and_return(false)
+
+        allowed = allow_publish?(manual, @slug_unique)
+
+        expect(allowed).to be false
+      end
+
+      it "returns false when the manual does not contain any sections" do
+        allow(manual).to receive_message_chain("sections.any?") { false }
+
+        allowed = allow_publish?(manual, @slug_unique)
+
+        expect(allowed).to be false
+      end
+
+      it "returns false when the manual's slug is not unique" do
+        @slug_unique = false
+
+        allowed = allow_publish?(manual, @slug_unique)
+
+        expect(allowed).to be false
+      end
+    end
+
+    context "when the current user cannot publish" do
+      def current_user_can_publish? = false
+
+      it "returns false" do
+        allowed = allow_publish?(manual, @slug_unique)
+
+        expect(allowed).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
Replaces the unclear alert popup when clicking the publish manual button with a new page that checks the user is aware that all draft sections will be published.

This new page uses the GDS design system, as part of the migration of manuals publisher to using that throughout.

Also fixes the styling of the flash messages that were appearing unstyled.

## Why

This change is to help make it clearer to users that it is not just their changes that will be published, but any other draft changes to sections that may have been made by others. An enhancement to this page will follow that will display the sections that this affects.

## Visuals
Clicking the publish button:
![image](https://github.com/alphagov/manuals-publisher/assets/138604938/8300111c-cd19-4f29-bff4-53e591730f00)

Would show this uninformative pop-up:
![image](https://github.com/alphagov/manuals-publisher/assets/138604938/93ac28f0-fb48-4194-9227-9d06be41d897)

That the user would then click OK on to confirm publication.

With the changes in this PR, it will instead take the user to a confirmation page:
![manuals-publisher dev gov uk_manuals_b655b49a-6ac6-4b66-bcf4-c3f0b4510900_confirm-publish](https://github.com/alphagov/manuals-publisher/assets/138604938/5cb211d9-ab52-4f6d-a19e-cbcd4b98046e)

Where clicking publish will actually perform the publish operation (as clicking OK on the previous alert).

Once published, the success message, which was appearing as un-styled text:
![image](https://github.com/alphagov/manuals-publisher/assets/138604938/6dd39af9-34d1-47dc-bc62-fb8db0d6d488)

Will now appear styled as it was intended to be:
![image](https://github.com/alphagov/manuals-publisher/assets/138604938/bf03ee8e-cf87-4e0b-8e61-190e29dd8cac)

## Trello
[Trello story](https://trello.com/c/BS9mtCv2)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
