### PR TITLE
Indicate which sections are in draft

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -36,6 +36,7 @@ class Section
            :minor_update,
            :exported_at,
            :visually_expanded,
+           :state,
            to: :latest_edition
 
   attr_reader :uuid

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -69,6 +69,9 @@
         <ul class="document-list">
          <% manual.sections.each do |section| %>
             <li class="document">
+              <% if section.state == "draft" %>
+                <span class="label label-primary">draft</span>
+              <% end %>
               <%= link_to(section.title, manual_section_path(manual, section), class: 'document-title') %>
               <ul class="metadata">
                 <li class="text-muted">Updated <%= time_ago_in_words(section.updated_at) %> ago</li>


### PR DESCRIPTION
## What

Update the manual's "show" view to indicate which sections are currently in draft. 

## Why

Enables manuals editors to see at a glance which sections are being edited (and thus will be updated when the manual is published), which is useful when multiple people are editing the same manual.

This will soon be enhanced to include the name of the person who last updated a section that is in draft status to further help coordination between manual editors.

## Visuals

![image](https://github.com/alphagov/manuals-publisher/assets/138604938/b23c3e79-398c-4b7f-9ee6-352c12bc2bd7)


## Trello

[Trello card](https://trello.com/c/cQVYqYIs)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
