### PR TITLE
List draft sections on publish confirmation page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/skip-link

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,3 +3,4 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/skip-link
+//= require govuk_publishing_components/components/table

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/skip-link";
+@import "govuk_publishing_components/components/table";
 @import "govuk_publishing_components/components/title";
 
 @import "views/whats_new";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,6 +88,16 @@ module ApplicationHelper
     manual.draft? && manual.sections.any? && current_user_can_publish? && slug_unique
   end
 
+  def last_updated_text(section)
+    text = "Updated #{time_ago_in_words(section.updated_at)} ago"
+
+    if section.draft? && section.last_updated_by
+      text << " by #{section.last_updated_by}"
+    end
+
+    text
+  end
+
   def publish_text(manual, slug_unique)
     if manual.state == "published"
       text = "<p>There are no changes to publish.</p>"

--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -1,3 +1,5 @@
+<% draft_sections = manual.sections.select(&:draft?) %>
+
 <% content_for :page_title, manual.title %>
 <% content_for :title, manual.title %>
 
@@ -24,8 +26,36 @@
   title: "Publish #{manual.title}"
 } %>
 
-<p class="govuk-body govuk-!-margin-bottom-7">You are about to publish "<%= manual.title %>". All the sections which
-  are in draft status will be published.</p>
+<p class="govuk-body">You are about to publish "<%= manual.title %>".
+  <%= if draft_sections.any? then " All the following sections, which are in draft status, will be published." end %></p>
+
+<% if draft_sections.any? %>
+  <p class="govuk-body"></p>
+  <%= render "govuk_publishing_components/components/table", {
+    first_cell_is_header: true,
+    head: [
+      {
+        text: "Draft"
+      },
+      {
+        text: "Details"
+      }
+    ],
+    rows: draft_sections.map do |section|
+      [
+        {
+          text: tag.span("DRAFT", class: "govuk-tag govuk-tag--s govuk-tag--blue") <<
+            tag.span(section.title, class: "govuk-!-static-margin-2")
+        },
+        {
+          text: last_updated_text(section)
+        }
+      ]
+    end
+  } %>
+<% end %>
+
+<p class="govuk-body">Are you sure you want to publish this manual?</p>
 
 <%= form_tag(publish_manual_path(manual), method: :post) do %>
   <div class="govuk-button-group govuk-!-margin-bottom-6">

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -74,7 +74,7 @@
               <% end %>
               <%= link_to(section.title, manual_section_path(manual, section), class: 'document-title') %>
               <ul class="metadata">
-                <li class="text-muted">Updated <%= time_ago_in_words(section.updated_at) %> ago<%= if section.draft? and section.last_updated_by then " by #{section.last_updated_by}" end%></li>
+                <li class="text-muted"><%= last_updated_text(section) %></li>
               </ul>
             </li>
           <% end %>

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -7,9 +7,9 @@ Feature: Publishing a manual
     Given I am logged in as an editor
 
   Scenario: Publish a manual
-    Given a draft manual exists with some sections
+    Given a draft manual exists with a section titled "my test section"
     When I click the publish manual button
-    Then I am asked to confirm the publishing
+    Then I am asked to confirm the publishing of a section titled "my test section"
     When I confirm publishing the manual
     Then the manual and all its sections are published
     And I should see a link to the live manual

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -70,6 +70,30 @@ Given(/^a draft manual exists with some sections$/) do
   WebMock::RequestRegistry.instance.reset!
 end
 
+Given(/^a draft manual exists with a section titled "(.*?)"$/) do |section_title|
+  @manual_slug = "guidance/example-manual-title"
+  @manual_title = "Example Manual Title"
+
+  @manual_fields = {
+    title: "Example Manual Title",
+    summary: "Nullam quis risus eget urna mollis ornare vel eu leo.",
+  }
+
+  create_manual(@manual_fields)
+
+  @attributes_for_sections = create_sections_for_manual(
+    manual_fields: @manual_fields,
+    section_titles: [section_title],
+    count: 2,
+  )
+
+  @manual = most_recently_created_manual
+  @sections = @manual.sections.to_a
+  @section = @sections.first
+
+  WebMock::RequestRegistry.instance.reset!
+end
+
 Given(/^a draft manual exists belonging to "(.*?)"$/) do |organisation_slug|
   @manual_slug = "guidance/example-manual-title"
   @manual_title = "Example Manual Title"
@@ -281,8 +305,9 @@ When(/^I click the publish manual button$/) do
   click_on "Publish manual"
 end
 
-Then(/^I am asked to confirm the publishing$/) do
+Then(/^I am asked to confirm the publishing of a section titled "(.*?)"$/) do |section_title|
   expect(page).to have_content("Publish #{@manual.title}")
+  expect(page).to have_content(section_title)
   expect(page).to have_button("Publish")
 end
 

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -401,9 +401,13 @@ module ManualHelpers
     expect(page.body).to have_content(organisation_slug)
   end
 
-  def create_sections_for_manual(count:, manual_fields:)
+  def create_sections_for_manual(count:, manual_fields:, section_titles: [])
     attributes_for_sections = (1..count).map do |n|
-      title = "Section #{n}"
+      title = if n <= section_titles.length
+                section_titles[n - 1]
+              else
+                "Section #{n}"
+              end
 
       {
         title:,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -54,4 +54,42 @@ describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#last_updated_text" do
+    let(:section) { instance_double(Section, updated_at: Time.zone.now) }
+
+    context "when section is not in draft state" do
+      before do
+        allow(section).to receive(:draft?).and_return(false)
+      end
+
+      it "returns text without author" do
+        text = last_updated_text(section)
+
+        expect(text).to eq("Updated less than a minute ago")
+      end
+    end
+
+    context "when section is in draft state" do
+      before do
+        allow(section).to receive(:draft?).and_return(true)
+      end
+
+      it "returns text including author, when the author is known" do
+        allow(section).to receive(:last_updated_by).and_return("Test User")
+
+        text = last_updated_text(section)
+
+        expect(text).to eq("Updated less than a minute ago by Test User")
+      end
+
+      it "returns text without author, when the author is not known" do
+        allow(section).to receive(:last_updated_by).and_return(nil)
+
+        text = last_updated_text(section)
+
+        expect(text).to eq("Updated less than a minute ago")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Update the manuals publish confirmation page to include a table listing the sections that are currently in a draft state and so whose changes will be included in the manual's publication.

## Why

To help avoid sections getting published that are not ready, by making whoever is publishing aware of the changes that will be included (for example, when there are multiple people editing sections).

## Visuals

### Before

![image](https://github.com/alphagov/manuals-publisher/assets/138604938/e9083b2f-b87e-488a-9b46-59cc48e5c731)

### After (with sections in draft status)

![manuals-publisher dev gov uk_manuals_09c86be3-7100-49fd-bb40-71f806092eab_confirm_publish](https://github.com/alphagov/manuals-publisher/assets/138604938/67aad00f-407f-4de2-994a-9f7e0c4ec01d)

### After (with no sections in draft status)

![manuals-publisher integration publishing service gov uk_manuals_43c4d896-5bd0-44f3-8b73-27b7db1cfdbf_confirm_publish](https://github.com/alphagov/manuals-publisher/assets/138604938/19403ce3-5fa6-4c6a-90e7-df4cce4e8e00)

## Technical notes

The logic for the "last updated text" was already present on the manual's "show" view, so this has been extracted to a helper method and reused by the publish confirmation view.

## Trello

[Trello card](https://trello.com/c/bV43FU4G)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
