### PR TITLE
Update What's new page with recent updates

### DIFF
--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -5,7 +5,7 @@
 <section class="app-view-whats-new__section">
   <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
 
-  <p class="govuk-body app-view-whats-new__last-updated">Last updated 13 Jul 2023</p>
+  <p class="govuk-body app-view-whats-new__last-updated">Last updated 15 Aug 2023</p>
 
   <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
 
@@ -20,37 +20,79 @@
 
 <section class="app-view-whats-new__section">
   <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
+  <div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h3 class="govuk-heading-m">List draft sections before publishing</h3>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+        <strong class="govuk-tag govuk-tag--blue">
+          improvement
+        </strong>
+      </div>
+    </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      <strong class="govuk-tag govuk-tag--blue">
-        improvement
-      </strong>
-    </div>
+    <p class="govuk-body app-view-whats-new__last-updated">15 Aug 2023</p>
+
+    <p class="govuk-body">You will be prompted with a list of sections in draft status before final publishing of a manual.
+      This will display the sections, section editor’s name and last edited time for all the sections being edited.
+      We hope this feature will help you identify if other editors are making changes to other sections of a manual so
+      that accidental publishing of draft content is prevented.</p>
   </div>
+  <div class="govuk-!-static-margin-top-8">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h3 class="govuk-heading-m">Section status label and editor name</h3>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+        <strong class="govuk-tag govuk-tag--blue">
+          improvement
+        </strong>
+      </div>
+    </div>
 
-  <p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
+    <p class="govuk-body app-view-whats-new__last-updated">9 Aug 2023</p>
 
-  <p class="govuk-body">You can now paste formatted text into the body field and Manuals publisher will try to convert it into GOV.UK’s
-    version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope
-    this feature will save you time when editing content.</p>
+    <p class="govuk-body">You can now identify the sections in a manual that are currently being edited with a label -
+      <span class="govuk-tag govuk-tag--blue">DRAFT</span> - clearly displayed against the sections. Additionally,
+      you can also see the name of the editor who made recent changes to the sections.</p>
+    <p class="govuk-body">We hope this feature will make you aware of all the sections in a manual currently being edited
+      while you are making your changes. Further, the section editor’s name will help you identify people quickly if you
+      need to coordinate with them. We hope this awareness will help prevent accidental publishing of any draft changes
+      to the manual.</p>
+  </div>
+  <div class="govuk-!-static-margin-top-8">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+        <strong class="govuk-tag govuk-tag--blue">
+          improvement
+        </strong>
+      </div>
+    </div>
 
-  <p class="govuk-body">This works best when copying and pasting from text editing software like Word or Google Docs. It is less likely to
-    recognise formatting from PDFs.</p>
+    <p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
 
-  <p class="govuk-body">It will convert:</p>
+    <p class="govuk-body">You can now paste formatted text into the body field and Manuals Publisher will try to convert it into GOV.UK’s
+      version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope
+      this feature will save you time when editing content.</p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>headings</li>
-    <li>bullets</li>
-    <li>numbered lists</li>
-    <li>links</li>
-    <li>email links</li>
-  </ul>
+    <p class="govuk-body">This works best when copying and pasting from text editing software like Word or Google Docs. It is less likely to
+      recognise formatting from PDFs.</p>
 
-  <p class="govuk-body">Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for
-    these separately.</p>
+    <p class="govuk-body">It will convert:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>headings</li>
+      <li>bullets</li>
+      <li>numbered lists</li>
+      <li>links</li>
+      <li>email links</li>
+    </ul>
+
+    <p class="govuk-body">Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for
+      these separately.</p>
+  </div>
 </section>


### PR DESCRIPTION
## What

Inform user of improvements made to Manuals Publisher relating to draft status of sections on Manuals overview page and Publish confirmation page.

## Why

Changes that have been made to the Manuals Publisher had not been added to the Recent Updates section to let users know what's new.

## Trello

[Trello story](https://trello.com/c/JikXL4QD/372-update-whats-new-page-with-publish-confirmation-and-tagging-sections)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
