### PR TITLE
Add confirm discard page as an extra step when discarding a draft (un…

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -161,6 +161,29 @@ class ManualsController < ApplicationController
     )
   end
 
+  def confirm_discard
+    service = Manual::ShowService.new(
+      manual_id:,
+      user: current_user,
+    )
+    manual = service.call
+
+    if !manual.has_ever_been_published?
+      render(
+        :confirm_discard,
+        layout: "design_system",
+        locals: {
+          manual:,
+        },
+      )
+    else
+      redirect_to(
+        manual_path(manual_id),
+        flash: { error: "#{manual.title} cannot be discarded as it has already been published" },
+      )
+    end
+  end
+
   def discard_draft
     service = Manual::DiscardDraftService.new(
       user: current_user,
@@ -171,12 +194,12 @@ class ManualsController < ApplicationController
     if result.successful?
       redirect_to(
         manuals_path,
-        flash: { notice: "Discarded draft of #{result.manual_title}" },
+        flash: { success: "Discarded draft of #{result.manual_title}" },
       )
     else
       redirect_to(
         manual_path(manual_id),
-        flash: { notice: "Unable to discard draft of #{result.manual_title}" },
+        flash: { error: "Unable to discard draft of #{result.manual_title}" },
       )
     end
   end

--- a/app/views/manuals/confirm_discard.html.erb
+++ b/app/views/manuals/confirm_discard.html.erb
@@ -1,0 +1,39 @@
+<% content_for :title, "Discard #{manual.title}" %>
+
+<% content_for :title_margin_bottom, 6 %>
+
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  collapse_on_mobile: true,
+  breadcrumbs: [
+    {
+      title: "Your manuals",
+      url: manuals_path
+    },
+    {
+      title: manual.title,
+      url: manual_path(manual)
+    },
+    {
+      title: "Discard"
+    },
+  ]
+} %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title: "Discard #{manual.title}"
+} %>
+
+<p class="govuk-body">You are about to discard "<%= manual.title %>".</p>
+<p class="govuk-body">Are you sure you want to discard this draft manual?</p>
+
+<%= form_tag(discard_draft_manual_path(manual), method: :delete) do %>
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Discard manual",
+      name: "submit",
+      destructive: true
+    } %>
+
+    <%= link_to("Cancel", manual_path(manual), class: "govuk-link govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -105,9 +105,7 @@
       <div class="panel panel-default">
         <div class="panel-heading"><h3>Discard draft manual</h3></div>
         <div class="panel-body">
-          <%= form_tag(discard_draft_manual_path(manual), method: :delete) do %>
-            <button name="submit" class="btn btn-danger" data-module="confirm" data-message="Are you sure you want to discard this draft manual?">Discard draft manual</button>
-          <% end -%>
+          <%= link_to 'Discard draft', confirm_discard_manual_path(manual), class: 'btn btn-danger' %>
         </div>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     delete :discard_draft, on: :member
 
     get :confirm_publish, on: :member
+    get :confirm_discard, on: :member
 
     get :original_publication_date, on: :member, action: :edit_original_publication_date
     put :original_publication_date, on: :member, action: :update_original_publication_date

--- a/features/deleting-a-manual.feature
+++ b/features/deleting-a-manual.feature
@@ -16,6 +16,7 @@ Feature: Rake task to delete a manual
     Given a draft manual exists without any sections
     And a draft section exists for the manual
     When I discard the draft manual
+    And I confirm draft deletion
     Then the manual and its sections are deleted
 
   Scenario: Deleting a published manual
@@ -23,3 +24,10 @@ Feature: Rake task to delete a manual
     When I run the deletion script
     Then the script raises an error
     And the manual and its sections still exist
+
+  Scenario: UI safeguarding against deleting a published manual
+    Given a published manual exists
+    And I am on the show page for that manual
+    Then I should not see the discard draft button
+    And I visit the confirm discard page directly
+    Then I am on the show page for that manual

--- a/features/deleting-a-manual.feature
+++ b/features/deleting-a-manual.feature
@@ -24,10 +24,3 @@ Feature: Rake task to delete a manual
     When I run the deletion script
     Then the script raises an error
     And the manual and its sections still exist
-
-  Scenario: UI safeguarding against deleting a published manual
-    Given a published manual exists
-    And I am on the show page for that manual
-    Then I should not see the discard draft button
-    And I visit the confirm discard page directly
-    Then I am on the show page for that manual

--- a/features/step_definitions/deleting_manuals_steps.rb
+++ b/features/step_definitions/deleting_manuals_steps.rb
@@ -29,3 +29,20 @@ end
 When(/^I discard the draft manual$/) do
   discard_draft_manual(@manual.title)
 end
+
+When(/^I confirm draft deletion$/) do
+  expect(page).to have_button("Discard manual")
+  click_on "Discard manual"
+end
+
+Then(/^I should not see the discard draft button$/) do
+  expect(page).not_to have_button("Discard manual")
+end
+
+When(/^I visit the confirm discard page directly$/) do
+  visit confirm_discard_manual_path(@manual)
+end
+
+Then(/^I am on the show page for that manual$/) do
+  expect(page).to have_content(@manual_fields[:summary])
+end

--- a/features/step_definitions/deleting_manuals_steps.rb
+++ b/features/step_definitions/deleting_manuals_steps.rb
@@ -34,15 +34,3 @@ When(/^I confirm draft deletion$/) do
   expect(page).to have_button("Discard manual")
   click_on "Discard manual"
 end
-
-Then(/^I should not see the discard draft button$/) do
-  expect(page).not_to have_button("Discard manual")
-end
-
-When(/^I visit the confirm discard page directly$/) do
-  visit confirm_discard_manual_path(@manual)
-end
-
-Then(/^I am on the show page for that manual$/) do
-  expect(page).to have_content(@manual_fields[:summary])
-end

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -49,7 +49,7 @@ describe ManualsController, type: :controller do
       let(:discard_success) { true }
 
       it "sets a flash message indicating success" do
-        expect(flash[:notice]).to include("Discarded draft of My manual")
+        expect(flash[:success]).to include("Discarded draft of My manual")
       end
 
       it "redirects to the manuals index" do
@@ -61,7 +61,7 @@ describe ManualsController, type: :controller do
       let(:discard_success) { false }
 
       it "sets a flash message indicating failure" do
-        expect(flash[:notice]).to include("Unable to discard draft of My manual")
+        expect(flash[:error]).to include("Unable to discard draft of My manual")
       end
 
       it "redirects to the show page for the manual" do

--- a/spec/controllers/manuals_controller_spec.rb
+++ b/spec/controllers/manuals_controller_spec.rb
@@ -34,6 +34,48 @@ describe ManualsController, type: :controller do
     end
   end
 
+  describe "#confirm_discard" do
+    let(:manual_id) { "manual-1" }
+    let(:service) { double(Manual::ShowService, call: manual) }
+    let(:manual) { instance_double(Manual, title: manual_title) }
+    let(:manual_title) { "My manual title" }
+
+    before do
+      login_as_stub_user
+      allow(Manual::ShowService).to receive(:new).and_return(service)
+    end
+
+    context "when the manual has been previously published" do
+      before do
+        allow(manual).to receive(:has_ever_been_published?).and_return(true)
+        get :confirm_discard, params: { id: manual_id }
+      end
+
+      it "sets a flash message indicating failure" do
+        expect(flash[:error]).to include("#{manual_title} cannot be discarded as it has already been published")
+      end
+
+      it "redirects to the show page for the manual" do
+        expect(response).to redirect_to manual_path(manual_id)
+      end
+    end
+
+    context "when the manual has not been previously published" do
+      before do
+        allow(manual).to receive(:has_ever_been_published?).and_return(false)
+        get :confirm_discard, params: { id: manual_id }
+      end
+
+      it "renders the discard confirmation page" do
+        expect(response).to render_template(:confirm_discard)
+      end
+
+      it "renders with the design system layout" do
+        expect(response).to render_template("design_system")
+      end
+    end
+  end
+
   describe "#discard_draft" do
     let(:manual_id) { "manual-1" }
     let(:service) { double(Manual::DiscardDraftService, call: result) }

--- a/spec/views/manuals/show.html.erb_spec.rb
+++ b/spec/views/manuals/show.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe "manuals/show", type: :view do
+  before do
+    allow(view).to receive(:current_user_is_gds_editor?).and_return(true)
+    allow(view).to receive(:current_user_can_publish?).and_return(true)
+  end
+
+  it "does not render the discard button for a published manual" do
+    manual = FactoryBot.build_stubbed(:manual, ever_been_published: true)
+    manual.publish_tasks = []
+
+    render template: "manuals/show", locals: { manual:, slug_unique: true, clashing_sections: [] }
+
+    expect(rendered).not_to match(/Discard draft/)
+  end
+
+  it "renders the discard button for an unpublished manual" do
+    manual = FactoryBot.build_stubbed(:manual, ever_been_published: false)
+    manual.publish_tasks = []
+
+    render template: "manuals/show", locals: { manual:, slug_unique: true, clashing_sections: [] }
+
+    expect(rendered).to match(/Discard draft/)
+  end
+end


### PR DESCRIPTION
…published) manual

## What

When discarding a draft (unpublished) manual, replace the existing confirmation system alert popup with a separate confirmation page.

## Why

To improve user experience and move towards the design system.

## Visuals

Clicking the Discard draft manual button

<img width="327" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/a5e51ea1-a034-4763-a7bb-44257f6c2432">

Would raise this popup

<img width="459" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/ffd26d45-a529-4c09-8010-e4163897693c">

That the user would then click OK on to confirm discard.

With the changes in this PR, it will instead take the user to a confirmation page:

<img width="1030" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/e355d0d2-d154-48ea-916d-3ca16dd606fe">

Where clicking Discard draft will actually perform the discard operation (as clicking OK on the previous alert).

Once discarded, the success message, which was appearing as an info message:

<img width="249" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/e2ac49a0-822a-4ca5-a58f-37a9516a7a96">

Will now appear styled as a success message:

<img width="199" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/5c324033-ac34-4b83-8f70-1d8e69ac6373">




[Trello card](https://trello.com/c/1EYhkzIj)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
