### PR TITLE
Update page title on publish confirmation page

### DIFF
--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -1,7 +1,6 @@
 <% draft_sections = manual.sections.select(&:draft?) %>
 
-<% content_for :page_title, manual.title %>
-<% content_for :title, manual.title %>
+<% content_for :title, "Publish #{manual.title}" %>
 
 <% content_for :title_margin_bottom, 6 %>
 


### PR DESCRIPTION
## What

Update the page title to provide an indication to the user that the page is not just the view page for the manual, but a page for publishing it.

Also remove the unused `:page_title` value, which was used by the old, legacy, layout but is not needed by the design system one.

## Why

To make it easier to distinguish between tabs in the browser, and for consistency with the new discard confirmation page.

## Trello

[Trello card](https://trello.com/c/1EYhkzIj) (this is for the discard page—this PR will bring the publish confirmation page in line with the [changes made for the discard confirmation page](https://github.com/alphagov/manuals-publisher/pull/2134))

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
