### PR TITLE
Highlight the "Manuals" header link on manual pages

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,7 +1,7 @@
 module NavigationHelper
   def navigation_links_internal
     links = [
-      { text: "Manuals", href: manuals_path, active: request.path == manuals_path },
+      { text: "Manuals", href: manuals_path, active: request.path.starts_with?(manuals_path) },
     ]
     if Time.zone.today < Date.new(2023, 11, 1)
       links << { text: "What's new", href: whats_new_path, active: request.path == whats_new_path }

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -17,8 +17,14 @@ describe NavigationHelper, type: :helper do
       end
     end
 
-    it "sets the link to the current page as active" do
+    it "sets the link to the manuals page as active when on the manuals index page" do
       request.path = manuals_path
+      expect(navigation_links_internal).to include(a_hash_including(text: "Manuals", active: true))
+    end
+
+    it "sets the link to the manuals page as active when on a manual's view page" do
+      manual = FactoryBot.build_stubbed(:manual)
+      request.path = manual_path(manual)
       expect(navigation_links_internal).to include(a_hash_including(text: "Manuals", active: true))
     end
   end


### PR DESCRIPTION
## What
The "Manuals" link in the header displayed on pages using the design system should be active when on any of the pages under `/manuals` (currently the only such page that uses the design system layout is the publish confirmation page).

## Why
Looking at how other apps work (e.g. Travel Advice Publisher) this is how the header navbar links should appear, so this brings Manuals Publisher in line with that.

## Visuals

### Before

![image](https://github.com/alphagov/manuals-publisher/assets/138604938/932eab08-314c-47a9-b8f3-8c47c8a31007)


### After

![image](https://github.com/alphagov/manuals-publisher/assets/138604938/b6280a1f-0a39-4b47-9190-deee2653b6f4)

### Trello

This is just a small part of working on the story to [migrate the overview page for a manual to the design system](https://trello.com/c/M0crhdKs).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
