### PR TITLE
Improve page alignment

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -17,11 +17,7 @@
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <%= yield %>
-        </div>
-      </div>
+      <%= yield %>
     </main>
   </div>
 
@@ -42,6 +38,5 @@
       }
     ]
   } %>
-
 
 <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -16,9 +16,12 @@
   } %>
 
   <div class="govuk-width-container">
+    <%= yield(:breadcrumbs) %>
+
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <%= yield %>
     </main>
+
   </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {

--- a/app/views/manuals/confirm_discard.html.erb
+++ b/app/views/manuals/confirm_discard.html.erb
@@ -2,22 +2,24 @@
 
 <% content_for :title_margin_bottom, 6 %>
 
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  collapse_on_mobile: true,
-  breadcrumbs: [
-    {
-      title: "Your manuals",
-      url: manuals_path
-    },
-    {
-      title: manual.title,
-      url: manual_path(manual)
-    },
-    {
-      title: "Discard"
-    },
-  ]
-} %>
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "Your manuals",
+        url: manuals_path
+      },
+      {
+        title: manual.title,
+        url: manual_path(manual)
+      },
+      {
+        title: "Discard"
+      },
+    ]
+  } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/title", {
   title: "Discard #{manual.title}"

--- a/app/views/manuals/confirm_discard.html.erb
+++ b/app/views/manuals/confirm_discard.html.erb
@@ -23,17 +23,23 @@
   title: "Discard #{manual.title}"
 } %>
 
-<p class="govuk-body">You are about to discard "<%= manual.title %>".</p>
-<p class="govuk-body">Are you sure you want to discard this draft manual?</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<%= form_tag(discard_draft_manual_path(manual), method: :delete) do %>
-  <div class="govuk-button-group govuk-!-margin-bottom-6">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Discard manual",
-      name: "submit",
-      destructive: true
-    } %>
+    <p class="govuk-body">You are about to discard "<%= manual.title %>".</p>
+    <p class="govuk-body">Are you sure you want to discard this draft manual?</p>
 
-    <%= link_to("Cancel", manual_path(manual), class: "govuk-link govuk-link--no-visited-state") %>
+    <%= form_tag(discard_draft_manual_path(manual), method: :delete) do %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Discard manual",
+          name: "submit",
+          destructive: true
+        } %>
+
+        <%= link_to("Cancel", manual_path(manual), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+
   </div>
-<% end %>
+</div>

--- a/app/views/manuals/confirm_discard.html.erb
+++ b/app/views/manuals/confirm_discard.html.erb
@@ -21,9 +21,16 @@
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/title", {
-  title: "Discard #{manual.title}"
-} %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      title: "Discard #{manual.title}",
+      margin_top: 0
+    } %>
+  </div>
+  <div class="govuk-grid-column-one-third app-grid-column--align-right">
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -4,22 +4,24 @@
 
 <% content_for :title_margin_bottom, 6 %>
 
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  collapse_on_mobile: true,
-  breadcrumbs: [
-    {
-      title: "Your manuals",
-      url: manuals_path
-    },
-    {
-      title: manual.title,
-      url: manual_path(manual)
-    },
-    {
-      title: "Publish"
-    },
-  ]
-} %>
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "Your manuals",
+        url: manuals_path
+      },
+      {
+        title: manual.title,
+        url: manual_path(manual)
+      },
+      {
+        title: "Publish"
+      },
+    ]
+  } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/title", {
   title: "Publish #{manual.title}"

--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -23,9 +23,16 @@
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/title", {
-  title: "Publish #{manual.title}"
-} %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      title: "Publish #{manual.title}",
+      margin_top: 0
+    } %>
+  </div>
+  <div class="govuk-grid-column-one-third app-grid-column--align-right">
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -25,44 +25,50 @@
   title: "Publish #{manual.title}"
 } %>
 
-<p class="govuk-body">You are about to publish "<%= manual.title %>".
-  <%= if draft_sections.any? then " All the following sections, which are in draft status, will be published." end %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<% if draft_sections.any? %>
-  <p class="govuk-body"></p>
-  <%= render "govuk_publishing_components/components/table", {
-    first_cell_is_header: true,
-    head: [
-      {
-        text: "Draft"
-      },
-      {
-        text: "Details"
-      }
-    ],
-    rows: draft_sections.map do |section|
-      [
-        {
-          text: tag.span("DRAFT", class: "govuk-tag govuk-tag--s govuk-tag--blue") <<
-            tag.span(section.title, class: "govuk-!-static-margin-2")
-        },
-        {
-          text: last_updated_text(section)
-        }
-      ]
-    end
-  } %>
-<% end %>
+    <p class="govuk-body">You are about to publish "<%= manual.title %>".
+      <%= if draft_sections.any? then " All the following sections, which are in draft status, will be published." end %></p>
 
-<p class="govuk-body">Are you sure you want to publish this manual?</p>
+    <% if draft_sections.any? %>
+      <p class="govuk-body"></p>
+      <%= render "govuk_publishing_components/components/table", {
+        first_cell_is_header: true,
+        head: [
+          {
+            text: "Draft"
+          },
+          {
+            text: "Details"
+          }
+        ],
+        rows: draft_sections.map do |section|
+          [
+            {
+              text: tag.span("DRAFT", class: "govuk-tag govuk-tag--s govuk-tag--blue") <<
+                tag.span(section.title, class: "govuk-!-static-margin-2")
+            },
+            {
+              text: last_updated_text(section)
+            }
+          ]
+        end
+      } %>
+    <% end %>
 
-<%= form_tag(publish_manual_path(manual), method: :post) do %>
-  <div class="govuk-button-group govuk-!-margin-bottom-6">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Publish",
-      name: "submit",
-    } %>
+    <p class="govuk-body">Are you sure you want to publish this manual?</p>
 
-    <%= link_to("Cancel", manual_path(manual), class: "govuk-link govuk-link--no-visited-state") %>
+    <%= form_tag(publish_manual_path(manual), method: :post) do %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Publish",
+          name: "submit",
+        } %>
+
+        <%= link_to("Cancel", manual_path(manual), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+
   </div>
-<% end %>
+</div>

--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -2,97 +2,103 @@
 <% content_for :title, page_name %>
 <%= render "govuk_publishing_components/components/title", { title: page_name } %>
 
-<section class="app-view-whats-new__section">
-  <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-  <p class="govuk-body app-view-whats-new__last-updated">Last updated 15 Aug 2023</p>
+    <section class="app-view-whats-new__section">
+      <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
 
-  <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
+      <p class="govuk-body app-view-whats-new__last-updated">Last updated 15 Aug 2023</p>
 
-  <p class="govuk-body">We’re doing this because we did user research earlier this year and discovered that Manuals users are lacking some
-    of the features that other publishing apps like Whitehall already have.</p>
+      <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
 
-  <p class="govuk-body">If you have any questions or feedback about publishing, you can reach us on
-    <a href="mailto:publishing-service-feedback@digital.cabinet-office.gov.uk" class="govuk-link">publishing-service-feedback@digital.cabinet-office.gov.uk</a>.
-    For any other type of support, you can <a href="https://support.publishing.service.gov.uk/" class="govuk-link">submit a request via
-    Zendesk</a>.</p>
-</section>
+      <p class="govuk-body">We’re doing this because we did user research earlier this year and discovered that Manuals users are lacking some
+        of the features that other publishing apps like Whitehall already have.</p>
 
-<section class="app-view-whats-new__section">
-  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
-  <div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <h3 class="govuk-heading-m">List draft sections before publishing</h3>
+      <p class="govuk-body">If you have any questions or feedback about publishing, you can reach us on
+        <a href="mailto:publishing-service-feedback@digital.cabinet-office.gov.uk" class="govuk-link">publishing-service-feedback@digital.cabinet-office.gov.uk</a>.
+        For any other type of support, you can <a href="https://support.publishing.service.gov.uk/" class="govuk-link">submit a request via
+        Zendesk</a>.</p>
+    </section>
+
+    <section class="app-view-whats-new__section">
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
+      <div>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+            <h3 class="govuk-heading-m">List draft sections before publishing</h3>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <strong class="govuk-tag govuk-tag--blue">
+              improvement
+            </strong>
+          </div>
+        </div>
+
+        <p class="govuk-body app-view-whats-new__last-updated">15 Aug 2023</p>
+
+        <p class="govuk-body">You will be prompted with a list of sections in draft status before final publishing of a manual.
+          This will display the sections, section editor’s name and last edited time for all the sections being edited.
+          We hope this feature will help you identify if other editors are making changes to other sections of a manual so
+          that accidental publishing of draft content is prevented.</p>
       </div>
-      <div class="govuk-grid-column-one-quarter">
-        <strong class="govuk-tag govuk-tag--blue">
-          improvement
-        </strong>
+      <div class="govuk-!-static-margin-top-8">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+            <h3 class="govuk-heading-m">Section status label and editor name</h3>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <strong class="govuk-tag govuk-tag--blue">
+              improvement
+            </strong>
+          </div>
+        </div>
+
+        <p class="govuk-body app-view-whats-new__last-updated">9 Aug 2023</p>
+
+        <p class="govuk-body">You can now identify the sections in a manual that are currently being edited with a label -
+          <span class="govuk-tag govuk-tag--blue">DRAFT</span> - clearly displayed against the sections. Additionally,
+          you can also see the name of the editor who made recent changes to the sections.</p>
+        <p class="govuk-body">We hope this feature will make you aware of all the sections in a manual currently being edited
+          while you are making your changes. Further, the section editor’s name will help you identify people quickly if you
+          need to coordinate with them. We hope this awareness will help prevent accidental publishing of any draft changes
+          to the manual.</p>
       </div>
-    </div>
+      <div class="govuk-!-static-margin-top-8">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+            <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <strong class="govuk-tag govuk-tag--blue">
+              improvement
+            </strong>
+          </div>
+        </div>
 
-    <p class="govuk-body app-view-whats-new__last-updated">15 Aug 2023</p>
+        <p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
 
-    <p class="govuk-body">You will be prompted with a list of sections in draft status before final publishing of a manual.
-      This will display the sections, section editor’s name and last edited time for all the sections being edited.
-      We hope this feature will help you identify if other editors are making changes to other sections of a manual so
-      that accidental publishing of draft content is prevented.</p>
+        <p class="govuk-body">You can now paste formatted text into the body field and Manuals Publisher will try to convert it into GOV.UK’s
+          version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope
+          this feature will save you time when editing content.</p>
+
+        <p class="govuk-body">This works best when copying and pasting from text editing software like Word or Google Docs. It is less likely to
+          recognise formatting from PDFs.</p>
+
+        <p class="govuk-body">It will convert:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>headings</li>
+          <li>bullets</li>
+          <li>numbered lists</li>
+          <li>links</li>
+          <li>email links</li>
+        </ul>
+
+        <p class="govuk-body">Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for
+          these separately.</p>
+      </div>
+    </section>
+
   </div>
-  <div class="govuk-!-static-margin-top-8">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <h3 class="govuk-heading-m">Section status label and editor name</h3>
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <strong class="govuk-tag govuk-tag--blue">
-          improvement
-        </strong>
-      </div>
-    </div>
-
-    <p class="govuk-body app-view-whats-new__last-updated">9 Aug 2023</p>
-
-    <p class="govuk-body">You can now identify the sections in a manual that are currently being edited with a label -
-      <span class="govuk-tag govuk-tag--blue">DRAFT</span> - clearly displayed against the sections. Additionally,
-      you can also see the name of the editor who made recent changes to the sections.</p>
-    <p class="govuk-body">We hope this feature will make you aware of all the sections in a manual currently being edited
-      while you are making your changes. Further, the section editor’s name will help you identify people quickly if you
-      need to coordinate with them. We hope this awareness will help prevent accidental publishing of any draft changes
-      to the manual.</p>
-  </div>
-  <div class="govuk-!-static-margin-top-8">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <h3 class="govuk-heading-m">Added Paste to Govspeak</h3>
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <strong class="govuk-tag govuk-tag--blue">
-          improvement
-        </strong>
-      </div>
-    </div>
-
-    <p class="govuk-body app-view-whats-new__last-updated">13 Jul 2023</p>
-
-    <p class="govuk-body">You can now paste formatted text into the body field and Manuals Publisher will try to convert it into GOV.UK’s
-      version of <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Markdown</a>, Govspeak. We hope
-      this feature will save you time when editing content.</p>
-
-    <p class="govuk-body">This works best when copying and pasting from text editing software like Word or Google Docs. It is less likely to
-      recognise formatting from PDFs.</p>
-
-    <p class="govuk-body">It will convert:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>headings</li>
-      <li>bullets</li>
-      <li>numbered lists</li>
-      <li>links</li>
-      <li>email links</li>
-    </ul>
-
-    <p class="govuk-body">Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for
-      these separately.</p>
-  </div>
-</section>
+</div>


### PR DESCRIPTION
## What

Improve the alignment of the breadcrumbs and page headings on pages using the design system.

## Why

To improve the look of the pages and align more closely with other applications (e.g. Travel Advice Publisher).

## Visuals

### Before

![image](https://github.com/alphagov/manuals-publisher/assets/138604938/725984d9-1e49-4795-bae4-11975f7edc79)

### After

![image](https://github.com/alphagov/manuals-publisher/assets/138604938/6101c89e-aa6a-4fbb-8f0c-8bb4db9a514b)

## Trello

This code amends the previously played stories for the [publish confirmation](https://trello.com/c/BS9mtCv2) and [discard confirmation](https://trello.com/c/1EYhkzIj) pages, but is done in preparation for the [migration of the manuals show view to the design system](https://trello.com/c/M0crhdKs/314-manuals-landing-page-move-to-govuk-design-system).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
