### PR TITLE
Add text indicating when edited original publication date will

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,9 +57,13 @@ module ApplicationHelper
     end
 
     if manual.publish_tasks.any?
+      value = publication_task_state(manual.publish_tasks.first)
+      if manual.use_originally_published_at_for_public_timestamp?
+        value += safe_join([tag.br, "This will be used as the public updated at timestamp on GOV.UK."])
+      end
       rows << {
         key: "Last published",
-        value: publication_task_state(manual.publish_tasks.first),
+        value:,
       }
     end
     rows


### PR DESCRIPTION
## What
Add text indicating when edited original publication date will be used as public timestamp when manual is published.

## Why
Original functionality on old manual show page, accidentally omitted during migration to new design system.
safe_join() used to preserve html <br> tag instead of interpreting as string literal and rubocop doesn't permit concatenating with html tags.

## Visual
<img width="569" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/6f437d0f-344d-4ec9-b94a-c224f6f9f9ac">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
