### PR TITLE
Migrate 'Your manuals' page to design system

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -9,7 +9,13 @@ class ManualsController < ApplicationController
     )
     all_manuals = service.call
 
-    render(:index, locals: { manuals: all_manuals })
+    render(
+      :index,
+      layout: "design_system",
+      locals: {
+        manuals: all_manuals,
+      },
+    )
   end
 
   def show

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -45,6 +45,13 @@
     <%= yield(:breadcrumbs) %>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
+      <% if content_for?(:heading) %>
+        <%= render "govuk_publishing_components/components/title", {
+          title: yield(:heading),
+          margin_top: 0
+        } %>
+      <% end %>
+
       <%= yield %>
       <% if content_for?(:document_ready) %>
         <script>

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -1,33 +1,56 @@
-<% content_for :page_title, "Your manuals" %>
+<% content_for :title, "Your manuals" %>
 
 <% content_for :breadcrumbs do %>
-  <li class='active'>Your manuals</li>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "Your manuals",
+      },
+    ]
+  } %>
 <% end %>
 
-<h1 class="page-header">
-  Your manuals <small>(<%= manuals.count %>)</small>
-</h1>
+<% content_for :heading, "Your manuals (#{manuals.count})" %>
 
-<div class="row">
-  <div class="sidebar col-md-3">
-    <%= link_to "New manual", new_manual_path, class: 'action-link' %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third govuk-body">
+    <%= link_to "Create new manual", new_manual_path, class: 'govuk-link govuk-link--no-visited-state' -%>
   </div>
-  <div class="col-md-9">
-    <ul class="document-list">
-      <% manuals.each do |manual| %>
-        <li class="document">
-          <%= link_to manual.title, manual_path(manual), class: 'document-title' %>
-          <ul class="metadata">
-            <li class="text-muted">Updated <%= time_ago_in_words(manual.updated_at) %> ago</li>
-            <li>
-              <%= state(manual) %>
-            </li>
-            <% if current_user_is_gds_editor? %>
-              <li class="text-muted">From <%= link_to manual.organisation_slug, url_for_public_org(manual.organisation_slug) %></li>
-            <% end %>
-          </ul>
-        </li>
-      <% end %>
-    </ul>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Title"
+        },
+        {
+          text: "Updated"
+        },
+        {
+          text: "Status"
+        },
+        {
+          text: tag.span("View", class: "govuk-visually-hidden")
+        }
+      ],
+      rows: manuals.map do |manual| [
+        {
+          text: tag.span(manual.title, class: "govuk-!-font-weight-bold")
+        },
+        {
+          text: tag.span("#{time_ago_in_words(manual.updated_at)} ago") <<
+            tag.span(tag.br + link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug)), class: "govuk-link")
+        },
+        {
+          text: state_label(manual)
+        },
+        {
+          text: link_to(sanitize("View #{tag.span(manual.title, class: 'govuk-visually-hidden')}"), manual_path(manual), class: "govuk-link"),
+        }
+      ]
+      end
+    } %>
   </div>
 </div>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -9,8 +9,7 @@
         url: manuals_path
       },
       {
-        title: manual.title,
-        url: manual_path(manual)
+        title: manual.title
       },
     ]
   } %>

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -808,8 +808,7 @@ end
 Then(/^the manual is listed as (draft|published|published with new draft)$/) do |status|
   visit manuals_path
 
-  expect(page).to have_selector(:xpath, "//li[a[.='#{@manual.title}']]//span[contains(concat(' ', normalize-space(@class), ' '), ' label ')][.='#{status}']")
-
+  expect(page).to have_selector(:xpath, "//*/tbody/tr/td/span[.='#{status}']")
   click_on @manual.title
 
   expect(page).to have_selector(:xpath, "//dt[.='Status']/following-sibling::dd[.='#{status}']")


### PR DESCRIPTION
## What
Migrate the 'Your manuals' view to the GDS Design System.

## Why
This is part of the migration of all of the Manuals Publisher pages to the GDS Design System.

## Visuals
### Before
<img width="880" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/55c36c88-4a1e-4597-8d5c-583838f1ce90">

### After
<img width="1285" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/138604938/2ac0420a-552a-47fb-848e-61654c01bd0d">

## Trello 
[Trello card](https://trello.com/c/A1nJGPUz)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
