### PR TITLE
Migrate pre publish messages to design system

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -219,31 +219,29 @@ module ApplicationHelper
   end
 
   def publish_text(manual, slug_unique)
+    text = []
     if manual.state == "published"
-      text = "<p>There are no changes to publish.</p>"
+      text << "There are no changes to publish."
     elsif manual.state == "withdrawn"
-      text = "<p>The manual is withdrawn. You need to create a new draft before it can be published.</p>"
+      text << "The manual is withdrawn. You need to create a new draft before it can be published."
     elsif !current_user_can_publish?
-      text = "<p>You don't have permission to publish this manual.</p>"
+      text << "You don't have permission to publish this manual."
     elsif !slug_unique
-      text = "<p>This manual has a duplicate slug and can't be published.</p>"
+      text << "This manual has a duplicate slug and can't be published."
     else
-      text = ""
       case manual.version_type
       when :minor
-        text += "<p>You are about to publish a <strong>minor edit</strong>.</p>"
+        text << "You are about to publish a <strong>minor edit</strong>."
       when :major
-        text += "<p><strong>You are about to publish a major edit with public change notes.</strong></p>"
+        text << "<strong>You are about to publish a major edit with public change notes.</strong>"
       end
-      text += if manual.use_originally_published_at_for_public_timestamp? && manual.originally_published_at.present?
-                "<p>The updated timestamp on GOV.UK will be set to the first publication date.</p>"
+      text << if manual.use_originally_published_at_for_public_timestamp? && manual.originally_published_at.present?
+                "The updated timestamp on GOV.UK will be set to the first publication date."
               elsif manual.version_type == :minor
-                "<p>The updated timestamp on GOV.UK will not change.</p>"
+                "The updated timestamp on GOV.UK will not change."
               else
-                "<p>The updated timestamp on GOV.UK will be set to the time you press the publish button.</p>"
+                "The updated timestamp on GOV.UK will be set to the time you press the publish button."
               end
     end
-
-    (text || "").html_safe
   end
 end

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -101,6 +101,9 @@
   <div class="govuk-grid-column-one-third">
     <% if allow_publish?(manual, slug_unique) || !manual.has_ever_been_published? %>
       <div class="app-view-manuals__sidebar-actions">
+        <% publish_text(manual, slug_unique).each do |message| %>
+          <p class="govuk-body"> <%= message.html_safe %> </p>
+        <% end %>
         <ul class="govuk-list govuk-list--spaced">
           <% if allow_publish?(manual, slug_unique) %>
             <li>

--- a/features/publishing-a-manual.feature
+++ b/features/publishing-a-manual.feature
@@ -31,7 +31,8 @@ Feature: Publishing a manual
   Scenario: Add a change note
     Given a published manual exists
     When I create a section for the manual with a change note
-    And I publish the manual
+    Then I should see a pre-publish message
+    When I publish the manual
     Then the manual is published as a major update including a change note draft
 
   Scenario: Omit the change note

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -178,6 +178,10 @@ When(/^I create a section for the manual with a change note$/) do
   @section = most_recently_created_manual.sections.to_a.last
 end
 
+Then(/^I should see a pre-publish message$/) do
+  expect(page).to have_css("strong", text: "You are about to publish a major edit with public change notes.")
+end
+
 Then(/^I see the manual has the new section$/) do
   visit manuals_path
   click_on @manual_fields.fetch(:title)


### PR DESCRIPTION
## What
There is a set of 'pre publish messages' dictated by the status of a manual and its sections. These appear within the sidebar containing the publish and/or discard draft buttons on the manuals show page. These have been readded to the page and migrated to the design system font. 

## Why
This is part of the migration of all of the Manuals Publisher pages to the GDS Design System.

## Visuals
### Before
<img width="386" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/fb0e9e53-012c-49eb-a10e-d0978b222bd8">


### After
<img width="385" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/dbe4e3e7-d01a-48d2-9296-69be4d81bf5d">

## Trello
[Trello card](https://trello.com/c/xvOR2mXC)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
