### PR TITLE
Consolidation migrate page headings to design system template

### DIFF
--- a/app/views/manuals/confirm_discard.html.erb
+++ b/app/views/manuals/confirm_discard.html.erb
@@ -21,16 +21,7 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: "Discard #{manual.title}",
-      margin_top: 0
-    } %>
-  </div>
-  <div class="govuk-grid-column-one-third app-grid-column--align-right">
-  </div>
-</div>
+<% content_for :heading, "Discard #{manual.title}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/manuals/confirm_publish.html.erb
+++ b/app/views/manuals/confirm_publish.html.erb
@@ -23,16 +23,7 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: "Publish #{manual.title}",
-      margin_top: 0
-    } %>
-  </div>
-  <div class="govuk-grid-column-one-third app-grid-column--align-right">
-  </div>
-</div>
+<% content_for :heading, "Publish #{manual.title}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/manuals/edit.html.erb
+++ b/app/views/manuals/edit.html.erb
@@ -19,15 +19,6 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Edit front page",
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8
-    } %>
-  </div>
-</div>
+<% content_for :heading, "Edit front page" %>
 
 <%= render 'form', manual: manual %>

--- a/app/views/manuals/edit_original_publication_date.html.erb
+++ b/app/views/manuals/edit_original_publication_date.html.erb
@@ -18,16 +18,8 @@
     ]
   } %>
 <% end %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Edit first publication date",
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8
-    } %>
-  </div>
-</div>
+
+<% content_for :heading, "Edit first publication date" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -15,16 +15,7 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: manual.title,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8
-    } %>
-  </div>
-</div>
+<% content_for :heading, manual.title %>
 
 <div class="govuk-grid-row">
   <% unless clashing_sections.empty? %>

--- a/app/views/sections/reorder.html.erb
+++ b/app/views/sections/reorder.html.erb
@@ -19,12 +19,7 @@
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Reorder sections",
-  heading_level: 1,
-  font_size: "xl",
-  margin_bottom: 8
-} %>
+<% content_for :heading, "Reorder sections" %>
 
 <%= form_tag(update_order_manual_sections_path(manual), method: :post) do %>
   <%= render "govuk_publishing_components/components/reorderable_list", {

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -19,16 +19,7 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: section.title,
-      heading_level: 1,
-      font_size: "xl",
-      margin_bottom: 8
-    } %>
-  </div>
-</div>
+<% content_for :heading, section.title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## What
The heading component has been moved to the design system layout template and yields to the individual page heading from there.

## Why
This change reduces code duplication.

## Visuals
This does not look different.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
