### PR TITLE
Update links with CSS classes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
     if current_user_is_gds_editor?
       rows << {
         key: "From",
-        value: link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug)),
+        value: link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug), class: "govuk-link"),
       }
     end
 

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -41,7 +41,7 @@
         },
         {
           text: tag.span("#{time_ago_in_words(manual.updated_at)} ago") <<
-            tag.span(tag.br + link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug)), class: "govuk-link")
+            tag.span(tag.br + link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug), class: "govuk-link"))
         },
         {
           text: state_label(manual)

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -62,7 +62,7 @@
           margin_bottom: 6
         } %>
         <p class="govuk-body">
-          <%= link_to "Preview on website (opens in new tab)", content_preview_url(manual), target: "_blank" %></p>
+          <%= link_to "Preview on website (opens in new tab)", content_preview_url(manual), target: "_blank", class: "govuk-link" %></p>
       </section>
     <% end %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -176,7 +176,7 @@ describe ApplicationHelper, type: :helper do
       rows = manual_metadata_rows(manual)
 
       expect(rows).to include(
-        { key: "From", value: link_to(manual.organisation_slug, "government/organisation_slug") },
+        { key: "From", value: link_to(manual.organisation_slug, "government/organisation_slug", class: "govuk-link") },
       )
     end
 


### PR DESCRIPTION
Some links were missing the "govuk-link" CSS class, and another had the class on the surrounding "span", rather than on the "a" tag.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
