### PR TITLE
Make use of heading capability in layout template

### DIFF
--- a/app/views/sections/new.html.erb
+++ b/app/views/sections/new.html.erb
@@ -19,11 +19,6 @@
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Add section",
-  heading_level: 1,
-  font_size: "xl",
-  margin_bottom: 8
-} %>
+<% content_for :heading, "Add section" %>
 
 <%= render "form", manual: manual, section: section %>


### PR DESCRIPTION
Use the "heading" content_for block in the design system layout template, rather than custom rendering on the page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
