### PR TITLE
Add a piece of logic to the view which was missed when the page was p…

### DIFF
--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -35,14 +35,17 @@
           text: tag.span("View", class: "govuk-visually-hidden")
         }
       ],
-      rows: manuals.map do |manual| [
+      rows: manuals.map do |manual|
+        updated_text = tag.span("#{time_ago_in_words(manual.updated_at)} ago")
+        if current_user_is_gds_editor?
+          updated_text << tag.br << link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug), class: "govuk-link")
+        end
+        [
         {
           text: tag.span(manual.title, class: "govuk-!-font-weight-bold")
         },
         {
-          text: tag.span("#{time_ago_in_words(manual.updated_at)} ago") <<
-            tag.br <<
-            link_to(manual.organisation_slug, url_for_public_org(manual.organisation_slug), class: "govuk-link")
+          text: updated_text
         },
         {
           text: state_label(manual)

--- a/spec/views/manuals/index.html.erb_spec.rb
+++ b/spec/views/manuals/index.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "manuals/index", type: :view do
+  it "shows the organisation slug if the user is a gds editor" do
+    manuals = [FactoryBot.build_stubbed(:manual, organisation_slug: "Test organisation", updated_at: Time.zone.now)]
+    allow(view).to receive(:current_user).and_return(FactoryBot.build_stubbed(:gds_editor))
+    allow(view).to receive(:current_user_is_gds_editor?).and_return(true)
+
+    render template: "manuals/index", layout: "layouts/design_system", locals: { manuals: }
+
+    expect(rendered).to have_text("Test organisation")
+  end
+
+  it "does not show the organisation slug if the user is not a gds editor" do
+    manuals = [FactoryBot.build_stubbed(:manual, organisation_slug: "Test organisation", updated_at: Time.zone.now)]
+    allow(view).to receive(:current_user).and_return(FactoryBot.build_stubbed(:user))
+    allow(view).to receive(:current_user_is_gds_editor?).and_return(false)
+
+    render template: "manuals/index", layout: "layouts/design_system", locals: { manuals: }
+
+    expect(rendered).not_to have_text("Test organisation")
+  end
+end


### PR DESCRIPTION
## What
Add a piece of logic to the view which was missed when the page was ported over to the design system.

 ## Why
The organisation slug should only be visible when the user is a GDS editor.

## Visuals
Both of these visuals are from the perspective of a non-GDS editor user.

### Before
<img width="1162" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/0a70c8ba-60c3-449e-9fc5-2cb81198e5f8">

### After
<img width="1159" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/26676741-f5eb-4dbd-b74c-441febdb14a0">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
