### PR TITLE
Changing the styling of three notice messages to be success messages

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -175,7 +175,7 @@ class ManualsController < ApplicationController
 
     redirect_to(
       manual_path(manual),
-      flash: { notice: "Published #{manual.title}" },
+      flash: { success: "Published #{manual.title}" },
     )
   end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -153,7 +153,7 @@ class SectionsController < ApplicationController
     redirect_to(
       manual_path(manual),
       flash: {
-        notice: "Order of sections saved for #{manual.title}",
+        success: "Order of sections saved for #{manual.title}",
       },
     )
   end
@@ -189,7 +189,7 @@ class SectionsController < ApplicationController
       redirect_to(
         manual_path(manual),
         flash: {
-          notice: "Section #{section.title} removed!",
+          success: "Section #{section.title} removed!",
         },
       )
     else


### PR DESCRIPTION
## What
Altered the type of three flash messages from 'notice' to 'success'

## Why
This is part of the migration of all of the Manuals Publisher pages to the GDS Design System.

## Visuals
### Before
<img width="1203" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/1fbd3627-01a3-43e9-9acf-c08ace9d6cdd">

### After
<img width="1194" alt="image" src="https://github.com/alphagov/manuals-publisher/assets/140532968/582f87a8-4ecd-4ab5-9d01-6363df0139fa">

## Trello
[Trello card](https://trello.com/c/3wZkNFZt)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
