### PR TITLE
Change the styling on the withdraw page of some text

### DIFF
--- a/app/views/sections/withdraw.html.erb
+++ b/app/views/sections/withdraw.html.erb
@@ -66,9 +66,7 @@
               }
             ]
           } %>
-        <%= render "govuk_publishing_components/components/warning_text", {
-          text: "Are you sure you want to proceed?"
-        } %>
+          <p class="govuk-body">Are you sure you want to proceed?</p>
           <div class="govuk-button-group">
             <%= render("govuk_publishing_components/components/button", {
               text: "Withdraw section",


### PR DESCRIPTION
## What
Change the styling of some text on the withdraw page.

## Why 
To better match where that style is used in the design system.

## Visuals
### Before
![manuals-publisher integration publishing service gov uk_manuals_6ea84cee-42b7-41f4-80d6-4e2c024c54b0_sections_d9cec36e-7434-44ea-a763-47638cfb3c5c_withdraw](https://github.com/alphagov/manuals-publisher/assets/140532968/9aa18f99-5631-480e-ae02-ec5c3758203a)

### After
![manuals-publisher dev gov uk_manuals_5bd4bfa0-4cd5-4995-84f0-4dd2d5e46dfb_sections_5716f594-c035-45d7-beae-e694fa47f2c8_withdraw](https://github.com/alphagov/manuals-publisher/assets/140532968/e8041a27-bff7-4158-8877-6867d92d2a9a)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
