### PR TITLE
Fix bug in which the edit manual page allowed saving a manual with an empty summary or title in the database

### DIFF
--- a/app/services/manual/update_service.rb
+++ b/app/services/manual/update_service.rb
@@ -12,9 +12,12 @@ class Manual::UpdateService
 
     manual.draft
     manual.assign_attributes(attributes)
-    manual.save!(user)
-    reloaded_manual = Manual.find(manual.id, user)
-    Adapters.publishing.save_draft(reloaded_manual)
+
+    if manual.valid?
+      manual.save!(user)
+      reloaded_manual = Manual.find(manual.id, user)
+      Adapters.publishing.save_draft(reloaded_manual)
+    end
 
     manual
   end

--- a/spec/services/manual/update_service_spec.rb
+++ b/spec/services/manual/update_service_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe Manual::UpdateService do
+  let(:user) { double(:user) }
+  let(:manual) { instance_double(Manual, id: "1", draft: nil, assign_attributes: nil, save!: nil) }
+  let(:publishing_api_adapter) { double(:publishing_api_adapter, save_draft: nil) }
+
+  subject do
+    described_class.new(
+      user:,
+      manual_id: "1",
+      attributes: {},
+    )
+  end
+
+  before do
+    allow(Manual).to receive(:find).and_return(manual)
+    allow(Adapters)
+      .to receive(:publishing).and_return(publishing_api_adapter)
+  end
+
+  it "does not allow saving of an invalid manual" do
+    allow(manual).to receive(:valid?).and_return(false)
+
+    subject.call
+
+    expect(manual).not_to have_received(:save!)
+    expect(publishing_api_adapter).not_to have_received(:save_draft)
+  end
+
+  it "allows saving of a valid manual" do
+    allow(manual).to receive(:valid?).and_return(true)
+
+    subject.call
+
+    expect(manual).to have_received(:save!)
+    expect(publishing_api_adapter).to have_received(:save_draft)
+  end
+end


### PR DESCRIPTION
## What
Fixing a pre existing bug:
Previous behaviour: edit manual -> delete title / summary -> click 'save' -> manual database record updated -> errors raised -> edit manual page re-rendered with errors 
If this page is exited out of (using Cancel link), the manual record in the database will have empty title / summary. This can then cause knock on effects with breadcrumbs and other items rendered.

New behaviour: edit manual -> delete title / summary -> click 'save' -> manual validity checked, manual not saved -> errors raised -> edit manual page re-rendered with errors 
Manual with empty title / summary will not be saved to database.

## Why
Prevents invalid data being saved.

## Trello
[Trello card](https://trello.com/c/hDkz7XzD)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
