### PR TITLE
Update what's new page following DS migration

### DIFF
--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -8,12 +8,11 @@
     <section class="app-view-whats-new__section">
       <h2 class="govuk-heading-l">New Manuals Publisher features</h2>
 
-      <p class="govuk-body app-view-whats-new__last-updated">Last updated 8 Sep 2023</p>
+      <p class="govuk-body app-view-whats-new__last-updated">Last updated 11 Oct 2023</p>
 
-      <p class="govuk-body">We are delivering some enhancements for Manuals Publisher over the next couple of months.</p>
+      <p class="govuk-body">We have completed the enhancements for Manuals Publisher over the last couple of months.</p>
 
-      <p class="govuk-body">We’re doing this because we did user research earlier this year and discovered that Manuals users are lacking some
-        of the features that other publishing apps like Whitehall already have.</p>
+      <p class="govuk-body">We have done this because we did user research earlier this year and discovered that Manuals users are lacking some of the features that other publishing apps like Whitehall already have.</p>
 
       <p class="govuk-body">If you have any questions or feedback about publishing, you can reach us on
         <a href="mailto:publishing-service-feedback@digital.cabinet-office.gov.uk" class="govuk-link">publishing-service-feedback@digital.cabinet-office.gov.uk</a>.
@@ -23,6 +22,25 @@
 
     <section class="app-view-whats-new__section">
       <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Recent changes</h2>
+      <div class="govuk-!-static-margin-top-8">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+            <h3 class="govuk-heading-m">Move to the GOV.UK Design System</h3>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <strong class="govuk-tag govuk-tag--blue">
+              improvement
+            </strong>
+          </div>
+        </div>
+
+        <p class="govuk-body app-view-whats-new__last-updated">11 Oct 2023</p>
+
+        <p class="govuk-body">
+          We have moved all the pages to the GOV.UK Design System, it is now consistent with other publishing
+          applications.
+        </p>
+      </div>
       <div class="govuk-!-static-margin-top-8">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION
## What

Update the "What's new" page to reflect the fact that all pages in Manuals Publisher have now been migrated to the GOV.UK Design System.

## Why

To provide an indication to users that the migration to the design system is now complete.

## Visuals

### Before

![manuals-publisher dev gov uk_whats-new](https://github.com/alphagov/manuals-publisher/assets/138604938/f5aea927-49a1-4c80-8541-d09e94a48c1b)

### After

![manuals-publisher dev gov uk_whats-new (1)](https://github.com/alphagov/manuals-publisher/assets/138604938/5c80d12a-85a5-4fff-bc93-2d3f70105cac)

### Trello

[Trello card](https://trello.com/c/ESYWmM9a).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
