### PR TITLE
Set default timezone to London in config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,8 +128,7 @@ module ApplicationHelper
   end
 
   def publication_task_state(task)
-    zoned_time = time_with_local_zone(task.updated_at)
-    formatted_time = nice_time_format(zoned_time)
+    formatted_time = nice_time_format(task.updated_at)
 
     output =  case task.state
               when "queued", "processing"

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,8 +1,4 @@
 module DateTimeHelper
-  def time_with_local_zone(time)
-    ActiveSupport::TimeZone.new("London").at(time)
-  end
-
   def nice_time_format(time)
     tag.time datetime: time.iso8601 do
       time.strftime("%l:%M%P on %-d %B %Y")

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,8 +28,10 @@ module ManualsPublisher
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
+
+    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
+    config.time_zone = "London"
+
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Using a sass css compressor causes a scss file to be processed twice


### PR DESCRIPTION
## Description

 We've had a bug come in that a that was published at 12.01am is saying that it was published the previous day on the updates section.

Looking at the config I can see that a default timezone hasn't been set. This means it's using UTC. This doesn't account for BST being an hour ahead during the summer time so when the updated_at is passed to Publishing API it's passing a time of an hour earlier than it was published.

We can resolve this by setting the default timezone to London.

As this is a pre-existing bug that's basically always existed, we run into a bit of an issue with data integrity of previous manuals. We can simply republish the most recent published edition of the manual, but there could be quite a large amount of editions which have the incorrect date that won't be updated.

It might be that tackling that in Publishing API itself is the right way to go.

## Trello card

https://trello.com/c/idVD4RQT/1794-update-history-shows-the-wrong-date

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
