### PR TITLE
Do not publish a log for a removed section which was never published

### DIFF
--- a/app/lib/publication_logger.rb
+++ b/app/lib/publication_logger.rb
@@ -14,7 +14,7 @@ class PublicationLogger
     end
 
     manual.removed_sections.each do |section|
-      next if section.withdrawn?
+      next unless section.published?
       next if section.minor_update?
       next if section.change_note.blank?
 

--- a/spec/lib/publication_logger_spec.rb
+++ b/spec/lib/publication_logger_spec.rb
@@ -1,17 +1,12 @@
 require "spec_helper"
 
 RSpec.describe PublicationLogger do
-  let(:manual) { double(:manual, slug: "manual-slug", removed_sections: []) }
-  let(:sections) { [section] }
-  let(:section) { Section.new(manual:, uuid: "section-id-1", latest_edition: section_edition) }
-  let(:section_edition) { FactoryBot.create(:section_edition) }
-
-  before do
-    allow(manual).to receive(:sections).and_return(sections)
-  end
-
   describe "call" do
     it "creates a PublicationLog for each Section" do
+      manual = Manual.new(slug: "manual-slug", removed_sections: [])
+      section_edition = FactoryBot.create(:section_edition)
+      section = Section.new(manual:, uuid: "section-id-1", latest_edition: section_edition)
+      manual.sections = [section]
       expect {
         subject.call(manual)
       }.to change(PublicationLog, :count).by(1)
@@ -20,10 +15,13 @@ RSpec.describe PublicationLogger do
     # It's possible to pass a nil change_note, this indicates that the section
     # update is not to be logged by the PublicationLogger
     context "when a section edition has no change note" do
-      let(:cloned_section) { Section.new(manual:, uuid: "section-id-2", latest_edition: cloned_section_edition) }
-      let(:cloned_section_edition) { FactoryBot.create(:section_edition, change_note: nil) }
-      let(:sections) { [section, cloned_section] }
       it "does not create a PublicationLog for a cloned Section" do
+        manual = Manual.new(slug: "manual-slug", removed_sections: [])
+        section_edition = FactoryBot.create(:section_edition)
+        section = Section.new(manual:, uuid: "section-id-1", latest_edition: section_edition)
+        cloned_section_edition = FactoryBot.create(:section_edition, change_note: nil)
+        cloned_section = Section.new(manual:, uuid: "section-id-2", latest_edition: cloned_section_edition)
+        manual.sections = [section, cloned_section]
         expect {
           subject.call(manual)
         }.to change(PublicationLog, :count).by(1)
@@ -31,6 +29,27 @@ RSpec.describe PublicationLogger do
         expect {
           PublicationLog.find_by(change_note: nil)
         }.to raise_error(Mongoid::Errors::DocumentNotFound)
+      end
+    end
+
+    context "when there are removed sections" do
+      it "creates a publication log if the section has been published before" do
+        latest_edition = FactoryBot.create(:section_edition, state: :draft)
+        previous_edition = FactoryBot.create(:section_edition, state: :published)
+        manual = Manual.new(slug: "manual-slug")
+        section = Section.new(manual:, uuid: "section-id-1", latest_edition:, previous_edition:)
+        manual.removed_sections = [section]
+
+        expect { subject.call(manual) }.to change(PublicationLog, :count).by(1)
+      end
+
+      it "does not create a publication log if the section has not ever been published" do
+        latest_edition =  FactoryBot.create(:section_edition)
+        manual = Manual.new(slug: "manual-slug")
+        section = Section.new(manual:, uuid: "section-id-1", latest_edition:, previous_edition: nil)
+        manual.removed_sections = [section]
+
+        expect { subject.call(manual) }.to change(PublicationLog, :count).by(0)
       end
     end
   end


### PR DESCRIPTION
Previously a change log entry would be created if a section was withdrawn before it was ever published. This makes sure that no publication log entries are created if the section had never been published before.

I also tweaked the test setup a little for the publication logger test to rely less on shared test state and added a missing test for the removed section which has previously been published.

Trello: https://trello.com/c/sjGHrnOw
