### PR TITLE
Stop 404 when withdrawing a section on published manual

### DIFF
--- a/features/removing-a-manual-section.feature
+++ b/features/removing-a-manual-section.feature
@@ -60,8 +60,7 @@ Feature: Removing a section from a manual
     Given I am logged in as a GDS editor
     And a published manual exists
     When I remove one of the sections from the manual
-    Then the section is removed from the manual
-    When I publish the manual
+    And I publish the manual
     Then the removed section is not published
     But the removed section is withdrawn with a redirect to the manual
     And the removed section is archived
@@ -70,8 +69,7 @@ Feature: Removing a section from a manual
     Given I am logged in as an editor
     And a published manual exists
     When I remove one of the sections from the manual
-    Then the section is removed from the manual
-    When I publish the manual
+    And I publish the manual
     Then the removed section is not published
     But the removed section is withdrawn with a redirect to the manual
     And the removed section is archived
@@ -87,14 +85,12 @@ Feature: Removing a section from a manual
     When I remove one of the sections from the manual with a major update omitting the note
     Then I see an error requesting that I provide a change note
     When I remove one of the sections from the manual with a major update
-    Then the section is removed from the manual
-    When I add another section and publish the manual later
+    And I add another section and publish the manual later
     Then the removed section change note is included
 
   Scenario: Removing a section with a minor update change notes
     Given I am logged in as a GDS editor
     And a published manual exists
     When I remove one of the sections from the manual with a minor update
-    Then the section is removed from the manual
-    When I add another section and publish the manual later
+    And I add another section and publish the manual later
     Then the removed section change note is not included


### PR DESCRIPTION
## Description 

When a manual is published all it's sections are published as well. Published sections retain a published state except in 2 circumstances.

1. they are edited at which point they come drafts
2. they are withdrawn at which point they're removed from the manual in the Manuals Publisher DB

If they are edited a draft section is pushed downstream to Publishing API and the Draft Content Store.

When this occurs and the section is withdrawn, we need to discard the draft Section from Publishing API.

There's some logic to handle this in the remove_service which checks to see if the section is a draft (i.e. has a draft edition in Publishing API) and if so it attempts to discard the draft.

However, there's an issue with this. Within the remove service `assign_attributes` is called on the section. If you go and have a look at t[he method defined in the Section model](https://github.com/alphagov/manuals-publisher/blob/f93fb57d54524ee1b973f242eaa1098ecd13d95f/app/models/section.rb#L81-L105), you can see that it actually creates a new draft
section when called on a published section. It then passes change note params to the new draft edition of the section.

This means that when `#draft?` is called on the section it will always return true. This causes an issue when the following is called:

    ```
    if section.draft?
      Adapters.publishing.discard_section(section)
    end
    ```

Publiishing API blows up as there is no draft section in the Publishing API database.

There are feature specs which explicitly cover that the section is removed when Published sections are withdrawn. The proposed fix of capturing the state prior so `assign_attributes` being called breaks these tests.

I'm pretty sure that the tests are actually testing the incorrect behaviour which is causing the bug though.

At first glance I thought it might be possible to not bother creating a new draft edition prior to removing the section from the manual, but it's actually required for capturing the change note the user inputs so that users can see why the section was removed.

When an edition is published downstream, any change notes are pulled from removed sections and added as PublicationLogs

These are then rendered on the frontend.

## Trello card

https://trello.com/c/GMy5HBPv/1830-fix-manual-section-withdrawal-error-caused-by-missing-draft-in-publishing-api


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
