### PR TITLE
Update cache format version to 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module ManualsPublisher
     # Once this application is fully deployed to Rails 7.1 and you have no plans to rollback
     # replace the line below with config.active_support.cache_format_version = 7.1
     # This will mean that we can revert back to rails 7.0 if there is an issue
-    config.active_support.cache_format_version = 7.0
+    config.active_support.cache_format_version = 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Manuals Publisher has been running for some time now on 7.1, so it's probably safe to update the cache format.

Oddly when running RSpec I'm still seeing this deprecation warning:

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from <top (required)> at /govuk/manuals-publisher/config/application.rb:19)
```

I think the reference to cache format version 6.1 might be included from a gem somehow, as `manuals-publisher/config/application.rb:19` is

```
Bundler.require(*Rails.groups)
```
