### PR TITLE
Fix Rails secrets deprecation warning

### DIFF
--- a/app/controllers/link_checker_api_callback_controller.rb
+++ b/app/controllers/link_checker_api_callback_controller.rb
@@ -39,6 +39,6 @@ private
   end
 
   def webhook_secret_token
-    Rails.application.secrets.link_checker_api_secret_token
+    Rails.application.credentials.link_checker_api_secret_token
   end
 end

--- a/config/initializers/secrets_to_credentials.rb
+++ b/config/initializers/secrets_to_credentials.rb
@@ -1,0 +1,7 @@
+# Rails 7 has begun to deprecate Rails.application.secrets in favour
+# of Rails.application.credentials, but that adds the burden of master key
+# administration without giving us any benefit (because our production
+# secrets are handled as env vars, not committed to our repo. Here we
+# load the config/secrets.YML values into Rails.application.credentials,
+# retaining the existing behaviour while dropping deprecated references.
+Rails.application.credentials.merge!(Rails.application.config_for(:secrets))

--- a/spec/controllers/link_checker_api_callback_spec.rb
+++ b/spec/controllers/link_checker_api_callback_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe LinkCheckerApiCallbackController, type: :controller do
   def set_headers
     headers = {
       "Content-Type": "application/json",
-      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.secrets.link_checker_api_secret_token),
+      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.credentials.link_checker_api_secret_token),
     }
 
     request.headers.merge! headers


### PR DESCRIPTION
Rails 7.1 deprecates the use of Rails.application.secrets in favour of Rails.application.credentials.

The credentials system introduces the burden of master encryption key administration at no benefit to us, because we manage our production secrets using environment variables instead of committing them to Git.

This commit loads the existing secret values and merges them into the credentials object. This approach was copied from commit 8937b172be530a5d91bd999f4538e5a722dcab19 on the GOV.UK account-api project.
