### PR TITLE
Correction to gitignore asset build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ yarn-error.log
 /node_modules
 
 # Ignore compiled assets
-/app/assets/builds
+/app/assets/builds/*
 !/app/assets/builds/.keep
 /public/assets
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,2 +1,2 @@
 # Maintain Rails < 7 behaviour of running yarn:install before assets:precompile
-Rake::Task["assets:precompile"].enhance(["yarn:install"])
+Rake::Task["assets:precompile"].enhance(["yarn:install"]).enhance(["dartsass:build"])


### PR DESCRIPTION
We think this caused an issue in integration.

Correction based on https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html#ignoring-files
