### PR TITLE
Include Publishing component stylesheets in build

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,2 +1,11 @@
+APP_STYLESHEETS = {
+  "application.scss" => "application.css",
+}.freeze
+
+all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)
+Rails.application.config.dartsass.builds = all_stylesheets
+
+Rails.application.config.dartsass.build_options << " --quiet-deps"
+
 # Maintain Rails < 7 behaviour of running yarn:install before assets:precompile
 Rake::Task["assets:precompile"].enhance(["yarn:install"]).enhance(["dartsass:build"])


### PR DESCRIPTION
Without adding the Publishing component stylesheets in the build, the component guide stylesheet was not included, leading to a broken page at "/component-guide"
