### PR TITLE
Allow unpublsihing when a manual state is withdrawn

### DIFF
--- a/app/lib/withdraw_and_redirect_manual.rb
+++ b/app/lib/withdraw_and_redirect_manual.rb
@@ -13,19 +13,17 @@ class WithdrawAndRedirectManual
 
     return if dry_run
 
-    published_manual = manual.current_versions[:published]
-
-    raise ManualNotPublishedError, manual.slug if published_manual.blank?
-
-    published_manual.withdraw
-    published_manual.save!(user)
+    raise ManualNotPublishedError, manual.slug unless manual.can_withdraw?
 
     Adapters.publishing.unpublish_and_redirect_manual_and_sections(
-      published_manual,
+      manual,
       redirect:,
       include_sections:,
       discard_drafts:,
     )
+
+    manual.withdraw
+    manual.save!(user)
   end
 
 private

--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -196,6 +196,10 @@ class Manual
     state == "withdrawn"
   end
 
+  def can_withdraw?
+    current_versions[:published] || withdrawn?
+  end
+
   def has_ever_been_published?
     @ever_been_published
   end


### PR DESCRIPTION
We make sure the publishing-api call succeeds before changing the state of the manual. We allow the unpublish call to execute when the manual is either published or (already) withdrawn.

We have experienced that we are unable to rerun the `withdraw_and_redirect_manual` rake task, should the unpublish api call fail. These changes ensure we can rerun.


[Trello card](https://trello.com/c/mrQPt8pw/2371-manuals-publisher-unpublish-17-manuals)