### PR TITLE
Don't auto-merge rails

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -5,3 +5,6 @@ defaults:
     - minor
   auto_merge: true
   update_external_dependencies: true
+overrides:
+  - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
+    auto_merge: false


### PR DESCRIPTION
Rails [requires manual care when upgrading](https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails), so should not be auto-merged.

By coincidence, govuk-dependabot-merger is not auto-merging rails upgrades (because it involves a change to both Gemfile and Gemfile.lock, and the merger service only allows a change to Gemfile.lock) but it is skipping rails by coincidence rather than by design. We should play it safe and explicitly exclude Rails from the allowlist.

See [Slack thread](https://gds.slack.com/archives/CAB4Q3QBW/p1715942643914479).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
