### PR TITLE
Introduce editing change history for gds-editors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user_can_withdraw?
 
+  def current_user_can_change_history?
+    permission_checker.can_change_history?
+  end
+  helper_method :current_user_can_change_history?
+
   def current_user_is_gds_editor?
     permission_checker.is_gds_editor?
   end

--- a/app/controllers/change_history_controller.rb
+++ b/app/controllers/change_history_controller.rb
@@ -1,0 +1,7 @@
+class ChangeHistoryController < ApplicationController
+  def index
+    manual_record = ManualRecord.find_by(manual_id: params[:manual_id])
+    @manual = Manual.build_manual_for(manual_record)
+    @publication_logs = @manual.publication_logs.reverse
+  end
+end

--- a/app/controllers/change_history_controller.rb
+++ b/app/controllers/change_history_controller.rb
@@ -6,6 +6,10 @@ class ChangeHistoryController < ApplicationController
     @publication_logs = @manual.publication_logs.reverse
   end
 
+  def confirm_destroy
+    @publication_log = PublicationLog.find(params[:id])
+  end
+
 private
 
   def find_manual

--- a/app/controllers/change_history_controller.rb
+++ b/app/controllers/change_history_controller.rb
@@ -10,6 +10,19 @@ class ChangeHistoryController < ApplicationController
     @publication_log = PublicationLog.find(params[:id])
   end
 
+  def destroy
+    @publication_log = PublicationLog.find(params[:id])
+    @publication_log.destroy!
+
+    Manual::RepublishService.call(
+      user: current_user,
+      manual_id: @manual.id,
+    )
+
+    flash[:success] = "Change note deleted."
+    redirect_to manual_change_history_index_path(manual_id: @manual.id)
+  end
+
 private
 
   def find_manual

--- a/app/controllers/change_history_controller.rb
+++ b/app/controllers/change_history_controller.rb
@@ -1,7 +1,24 @@
 class ChangeHistoryController < ApplicationController
+  before_action :find_manual
+  before_action :authorize_user_for_changing_history
+
   def index
+    @publication_logs = @manual.publication_logs.reverse
+  end
+
+private
+
+  def find_manual
     manual_record = ManualRecord.find_by(manual_id: params[:manual_id])
     @manual = Manual.build_manual_for(manual_record)
-    @publication_logs = @manual.publication_logs.reverse
+  end
+
+  def authorize_user_for_changing_history
+    unless current_user_can_change_history?
+      redirect_to(
+        manual_path(@manual.id),
+        flash: { error: "You don't have permission to change history." },
+      )
+    end
   end
 end

--- a/app/lib/manuals_republisher.rb
+++ b/app/lib/manuals_republisher.rb
@@ -12,11 +12,10 @@ class ManualsRepublisher
 
     manuals.to_a.each.with_index do |manual, i|
       logger.info("[ #{i} / #{count} ] id=#{manual.id} slug=#{manual.slug}]")
-      service = Manual::RepublishService.new(
+      Manual::RepublishService.call(
         user: User.gds_editor,
         manual_id: manual.id,
       )
-      service.call
     rescue Manual::RemovedSectionIdNotFoundError => e
       logger.error("Did not publish manual with id=#{manual.id} slug=#{manual.slug}. It has at least one removed document which was not found: #{e.message}")
       next

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -18,6 +18,10 @@ class PermissionChecker
     user.has_permission?(GDS_EDITOR_PERMISSION)
   end
 
+  def can_change_history?
+    is_gds_editor?
+  end
+
 private
 
   attr_reader :user

--- a/app/services/manual/republish_service.rb
+++ b/app/services/manual/republish_service.rb
@@ -1,10 +1,5 @@
 class Manual::RepublishService
-  def initialize(user:, manual_id:)
-    @user = user
-    @manual_id = manual_id
-  end
-
-  def call
+  def self.call(user:, manual_id:)
     manual_versions = Manual.find(manual_id, user).current_versions
 
     published_manual_version = manual_versions[:published]
@@ -21,8 +16,4 @@ class Manual::RepublishService
 
     manual_versions
   end
-
-private
-
-  attr_reader :user, :manual_id
 end

--- a/app/views/change_history/confirm_destroy.html.erb
+++ b/app/views/change_history/confirm_destroy.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title, @manual.title %>
+
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "Your manuals",
+        url: manuals_path
+      },
+      {
+        title: @manual.title,
+        url: manual_path(@manual)
+      },
+      {
+        title: "Change history",
+        url: manual_change_history_index_path(@manual)
+      },
+      {
+        title: "Delete change note",
+      },
+    ]
+  } %>
+<% end %>
+
+<% content_for :context, @manual.title %>
+<% content_for :heading, "Delete change note" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Change published at: <%= @publication_log.created_at.strftime("%B %d, %Y %-l:%M%P") %></p>
+    <p class="govuk-body">Section title: <%= @publication_log.title %></p>
+    <p class="govuk-body">Current change note: <%= @publication_log.change_note %></p>
+
+    <div class="govuk-button-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Delete",
+        destructive: true,
+      } %>
+
+      <%= link_to("Cancel", manual_change_history_index_path(manual_id: @manual.id), class: "govuk-link govuk-link--no-visited-state") %>
+    </div>
+  </div>
+</div>

--- a/app/views/change_history/confirm_destroy.html.erb
+++ b/app/views/change_history/confirm_destroy.html.erb
@@ -32,13 +32,15 @@
     <p class="govuk-body">Section title: <%= @publication_log.title %></p>
     <p class="govuk-body">Current change note: <%= @publication_log.change_note %></p>
 
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Delete",
-        destructive: true,
-      } %>
+    <%= form_with url: manual_change_history_path(manual_id: @manual.id, id: @publication_log.id), method: :delete do %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
 
-      <%= link_to("Cancel", manual_change_history_index_path(manual_id: @manual.id), class: "govuk-link govuk-link--no-visited-state") %>
-    </div>
+        <%= link_to("Cancel", manual_change_history_index_path(manual_id: @manual.id), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/change_history/index.html.erb
+++ b/app/views/change_history/index.html.erb
@@ -19,6 +19,7 @@
   } %>
 <% end %>
 
+<% content_for :context, @manual.title %>
 <% content_for :heading, "Change history" %>
 
 <div class="govuk-grid-row">

--- a/app/views/change_history/index.html.erb
+++ b/app/views/change_history/index.html.erb
@@ -49,7 +49,11 @@
             text: publication_log.change_note,
           },
           {
-            text: "Delete",
+            text: render("govuk_publishing_components/components/button", {
+              text: "Delete",
+              href: url_for(controller: "change_history", action: "confirm_destroy", manual_id: @manual.id, id: publication_log.id),
+              destructive: true,
+            }),
           },
         ]
       end,

--- a/app/views/change_history/index.html.erb
+++ b/app/views/change_history/index.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, @manual.title %>
+
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: "Your manuals",
+        url: manuals_path
+      },
+      {
+        title: @manual.title,
+        url: manual_path(@manual)
+      },
+      {
+        title: "Change history"
+      }
+    ]
+  } %>
+<% end %>
+
+<% content_for :heading, "Change history" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Date",
+        },
+        {
+          text: "Section title",
+        },
+        {
+          text: "Change note",
+        },
+        {},
+      ],
+      rows: @publication_logs.map do |publication_log|
+        [
+          {
+            text: publication_log.created_at.strftime('%B %d, %Y %-l:%M%P'),
+          },
+          {
+            text: publication_log.title,
+          },
+          {
+            text: publication_log.change_note,
+          },
+          {
+            text: "Delete",
+          },
+        ]
+      end,
+    } %>
+  </div>
+</div>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -48,6 +48,7 @@
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <% if content_for?(:heading) %>
         <%= render "govuk_publishing_components/components/title", {
+          context: yield(:context),
           title: yield(:heading),
           margin_top: 0
         } %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -119,7 +119,9 @@
     <% if manual.published? %>
       <div class="app-view-manuals__sidebar-actions govuk-body">
         <p><%= link_to "View on website (opens in new tab)", url_for_public_manual(manual), target: "_blank", class: "govuk-link" %></p>
-        <p><%= link_to "Change history", manual_change_history_index_path(manual) %></p>
+        <% if current_user_can_change_history? %>
+          <p><%= link_to "Change history", manual_change_history_index_path(manual) %></p>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -117,9 +117,9 @@
     <% end %>
 
     <% if manual.published? %>
-      <div class="app-view-manuals__sidebar-actions">
-        <p class="govuk-body">
-          <%= link_to "View on website (opens in new tab)", url_for_public_manual(manual), target: "_blank", class: "govuk-link" %></p>
+      <div class="app-view-manuals__sidebar-actions govuk-body">
+        <p><%= link_to "View on website (opens in new tab)", url_for_public_manual(manual), target: "_blank", class: "govuk-link" %></p>
+        <p><%= link_to "Change history", manual_change_history_index_path(manual) %></p>
       </div>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   end
 
   resources :manuals, except: :destroy do
-    resources :change_history, only: %i[index]
+    resources :change_history, only: %i[index] do
+      get :confirm_destroy, on: :member
+    end
 
     resources :sections do
       resources :attachments, controller: :section_attachments, only: %i[new create edit update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   end
 
   resources :manuals, except: :destroy do
+    resources :change_history, only: %i[index]
+
     resources :sections do
       resources :attachments, controller: :section_attachments, only: %i[new create edit update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   end
 
   resources :manuals, except: :destroy do
-    resources :change_history, only: %i[index] do
+    resources :change_history, only: %i[index destroy] do
       get :confirm_destroy, on: :member
     end
 

--- a/features/change-history.feature
+++ b/features/change-history.feature
@@ -14,3 +14,5 @@ Feature: View and edit a manual's change history
     When I click delete on a change note
     Then I am redirected to the confirmation page
     When I delete the change note
+    Then I am redirected to the Change history page
+    And I can see that the change note has been deleted

--- a/features/change-history.feature
+++ b/features/change-history.feature
@@ -6,3 +6,11 @@ Feature: View and edit a manual's change history
     Given a published manual exists
     When I visit the change history page for the manual
     Then I see the change notes for the manual
+    When I click delete on a change note
+    Then I am redirected to the confirmation page
+    When I click the cancel button
+    Then I am redirected to the Change history page
+    And I can see that no change notes have been deleted
+    When I click delete on a change note
+    Then I am redirected to the confirmation page
+    When I delete the change note

--- a/features/change-history.feature
+++ b/features/change-history.feature
@@ -1,6 +1,6 @@
 Feature: View and edit a manual's change history
   Background:
-    Given I am logged in as an editor
+    Given I am logged in as a GDS editor
 
   Scenario: Removing a change note from a manual's change history
     Given a published manual exists

--- a/features/change-history.feature
+++ b/features/change-history.feature
@@ -1,0 +1,8 @@
+Feature: View and edit a manual's change history
+  Background:
+    Given I am logged in as an editor
+
+  Scenario: Removing a change note from a manual's change history
+    Given a published manual exists
+    When I visit the change history page for the manual
+    Then I see the change notes for the manual

--- a/features/step_definitions/change_history_steps.rb
+++ b/features/step_definitions/change_history_steps.rb
@@ -1,0 +1,15 @@
+When(/^I visit the change history page for the manual$/) do
+  go_to_manual_page(@manual.title)
+
+  click_link "Change history"
+end
+
+Then(/^I see the change notes for the manual$/) do
+  within "table" do
+    @manual.publication_logs.each do |log|
+      expect(page).to have_text(log.created_at.strftime("%B %d, %Y %-l:%M%P"))
+      expect(page).to have_text(log.title)
+      expect(page).to have_text(log.change_note)
+    end
+  end
+end

--- a/features/step_definitions/change_history_steps.rb
+++ b/features/step_definitions/change_history_steps.rb
@@ -12,4 +12,41 @@ Then(/^I see the change notes for the manual$/) do
       expect(page).to have_text(log.change_note)
     end
   end
+
+  within "tbody" do
+    @initial_publication_logs_count = @manual.publication_logs.count
+    expect(page).to have_selector "tr", count: @initial_publication_logs_count
+  end
+end
+
+When(/^I click delete on a change note$/) do
+  @publication_log = @manual.publication_logs.first
+  within page.find("td", text: @publication_log.title).ancestor("tr") do
+    click_on "Delete"
+  end
+end
+
+Then(/^I am redirected to the confirmation page$/) do
+  expect(page).to have_text("Change published at: #{@publication_log.created_at.strftime('%B %d, %Y %-l:%M%P')}")
+  expect(page).to have_text("Section title: #{@publication_log.title}")
+  expect(page).to have_text("Current change note: #{@publication_log.change_note}")
+end
+
+When(/^I click the cancel button$/) do
+  click_on "Cancel"
+end
+
+Then(/^I am redirected to the Change history page$/) do
+  expect(page).to have_selector("h1", text: "Change history")
+end
+
+And(/^I can see that no change notes have been deleted$/) do
+  within "tbody" do
+    expect(page).to have_selector "tr", count: @initial_publication_logs_count
+  end
+  expect(page).to have_text @publication_log.title
+end
+
+And(/^I delete the change note$/) do
+  click_on "Delete"
 end

--- a/features/step_definitions/change_history_steps.rb
+++ b/features/step_definitions/change_history_steps.rb
@@ -50,3 +50,10 @@ end
 And(/^I delete the change note$/) do
   click_on "Delete"
 end
+
+And(/^I can see that the change note has been deleted$/) do
+  within "tbody" do
+    expect(page).to have_selector "tr", count: @initial_publication_logs_count - 1
+  end
+  expect(page).not_to have_text @publication_log.title
+end

--- a/spec/controllers/change_history_controller_spec.rb
+++ b/spec/controllers/change_history_controller_spec.rb
@@ -26,6 +26,16 @@ describe ChangeHistoryController, type: :controller do
       expect(response.status).to eq 200
       expect(response).to render_template :confirm_destroy
     end
+
+    it "deletes a publication log" do
+      expect(Manual::RepublishService).to receive(:call).with(user: gds_editor, manual_id: manual.id)
+
+      delete :destroy, params: { manual_id: manual.id, id: publication_log1.id }
+
+      expect(manual.publication_logs.count).to eq 1
+      expect(flash[:success]).to include "Change note deleted."
+      expect(response.status).to redirect_to manual_change_history_index_path(manual.id)
+    end
   end
 
   context "user does not have permissions" do

--- a/spec/controllers/change_history_controller_spec.rb
+++ b/spec/controllers/change_history_controller_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe ChangeHistoryController, type: :controller do
+  let(:manual_record) { FactoryBot.create(:manual_record, :with_sections, state: "published") }
+  let(:manual) { Manual.build_manual_for(manual_record) }
+  let!(:publication_log1) { FactoryBot.create(:publication_log, slug: "#{manual.slug}/#{manual.sections.first.slug}", version_number: 1) }
+  let!(:publication_log2) { FactoryBot.create(:publication_log, slug: "#{manual.slug}/#{manual.sections.first.slug}", version_number: 2) }
+
+  before do
+    login_as_stub_user
+  end
+
+  it "renders index template" do
+    get :index, params: { manual_id: manual.id }
+
+    expect(response.status).to eq 200
+    expect(response).to render_template :index
+    expect(assigns(:publication_logs)).to eq [publication_log2, publication_log1]
+  end
+end

--- a/spec/controllers/change_history_controller_spec.rb
+++ b/spec/controllers/change_history_controller_spec.rb
@@ -19,6 +19,13 @@ describe ChangeHistoryController, type: :controller do
       expect(response).to render_template :index
       expect(assigns(:publication_logs)).to eq [publication_log2, publication_log1]
     end
+
+    it "renders confirm destroy template" do
+      get :confirm_destroy, params: { manual_id: manual.id, id: publication_log1.id }
+
+      expect(response.status).to eq 200
+      expect(response).to render_template :confirm_destroy
+    end
   end
 
   context "user does not have permissions" do

--- a/spec/controllers/change_history_controller_spec.rb
+++ b/spec/controllers/change_history_controller_spec.rb
@@ -5,16 +5,33 @@ describe ChangeHistoryController, type: :controller do
   let(:manual) { Manual.build_manual_for(manual_record) }
   let!(:publication_log1) { FactoryBot.create(:publication_log, slug: "#{manual.slug}/#{manual.sections.first.slug}", version_number: 1) }
   let!(:publication_log2) { FactoryBot.create(:publication_log, slug: "#{manual.slug}/#{manual.sections.first.slug}", version_number: 2) }
+  let(:gds_editor) { FactoryBot.create(:user, permissions: %w[gds_editor]) }
 
-  before do
-    login_as_stub_user
+  context "user has permissions" do
+    before do
+      login_as(gds_editor)
+    end
+
+    it "renders index template" do
+      get :index, params: { manual_id: manual.id }
+
+      expect(response.status).to eq 200
+      expect(response).to render_template :index
+      expect(assigns(:publication_logs)).to eq [publication_log2, publication_log1]
+    end
   end
 
-  it "renders index template" do
-    get :index, params: { manual_id: manual.id }
+  context "user does not have permissions" do
+    before do
+      login_as_stub_user
+    end
 
-    expect(response.status).to eq 200
-    expect(response).to render_template :index
-    expect(assigns(:publication_logs)).to eq [publication_log2, publication_log1]
+    it "redirects the user" do
+      get :index, params: { manual_id: manual.id }
+
+      expect(response.status).to eq 302
+      expect(response.status).to redirect_to manual_path(manual.id)
+      expect(flash[:error]).to include "You don't have permission to change history."
+    end
   end
 end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe PermissionChecker do
   let(:generic_writer) { FactoryBot.build(:generic_writer) }
   let(:generic_editor) { FactoryBot.build(:generic_editor) }
-  let(:gds_editor)     { FactoryBot.build(:gds_editor) }
+  let(:gds_editor) { FactoryBot.build(:gds_editor) }
 
   describe "#can_publish?" do
     context "a user who is not an editor" do
@@ -66,6 +66,24 @@ describe PermissionChecker do
     it "is false for a non-GDS editor" do
       checker = PermissionChecker.new(generic_editor)
       expect(checker.is_gds_editor?).to be false
+    end
+  end
+
+  describe "#can_change_history?" do
+    context "a user who is not a gds editor" do
+      subject(:checker) { PermissionChecker.new(generic_writer) }
+
+      it "prevents changing history" do
+        expect(checker.can_change_history?).to be false
+      end
+    end
+
+    context "a gds editor" do
+      subject(:checker) { PermissionChecker.new(gds_editor) }
+
+      it "allows changing history" do
+        expect(checker.can_change_history?).to be true
+      end
     end
   end
 end

--- a/spec/services/manual/republish_service_spec.rb
+++ b/spec/services/manual/republish_service_spec.rb
@@ -8,13 +8,6 @@ RSpec.describe Manual::RepublishService do
   let(:manual) { double(:manual) }
   let(:user) { double(:user) }
 
-  subject do
-    described_class.new(
-      user:,
-      manual_id:,
-    )
-  end
-
   before do
     allow(Adapters).to receive(:publishing) { publishing_adapter }
     allow(publishing_adapter).to receive(:save_draft)
@@ -32,17 +25,17 @@ RSpec.describe Manual::RepublishService do
     end
 
     it "calls the publishing api draft exporter" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).to have_received(:save_draft).with(published_manual_version, republish: true)
     end
 
     it "calls the new publishing api publisher" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).to have_received(:publish).with(published_manual_version, republish: true)
     end
 
     it "tells the draft listeners nothing" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).not_to have_received(:save_draft).with(draft_manual_version, republish: true)
     end
   end
@@ -57,13 +50,13 @@ RSpec.describe Manual::RepublishService do
     end
 
     it "tells the published listeners nothing" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).not_to have_received(:publish)
       expect(publishing_adapter).not_to have_received(:save_draft).with(published_manual_version, republish: true)
     end
 
     it "tells the draft listeners to republish the draft version of the manual" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).to have_received(:save_draft).with(draft_manual_version, republish: true)
     end
   end
@@ -78,17 +71,17 @@ RSpec.describe Manual::RepublishService do
     end
 
     it "calls the publishing api draft exporter" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).to have_received(:save_draft).with(published_manual_version, republish: true)
     end
 
     it "calls the new publishing api publisher" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).to have_received(:publish).with(published_manual_version, republish: true)
     end
 
     it "tells the draft listeners to republish the draft version of the manual" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).to have_received(:save_draft).with(draft_manual_version, republish: true)
     end
   end
@@ -102,7 +95,7 @@ RSpec.describe Manual::RepublishService do
     end
 
     it "tells none of the listeners to do anything" do
-      expect { subject.call }.to raise_error arbitrary_exception
+      expect { described_class.call(user:, manual_id:) }.to raise_error arbitrary_exception
       expect(publishing_adapter).not_to have_received(:save_draft)
       expect(publishing_adapter).not_to have_received(:publish)
     end
@@ -118,7 +111,7 @@ RSpec.describe Manual::RepublishService do
     end
 
     it "tells none of the listeners to do anything" do
-      subject.call
+      described_class.call(user:, manual_id:)
       expect(publishing_adapter).not_to have_received(:save_draft)
       expect(publishing_adapter).not_to have_received(:publish)
     end


### PR DESCRIPTION
Introducing a UI feature to allow users to delete change notes. These requests typically came through Zendesk and required manual intervention. This change would enable users to now do it themselves. 

The implementation follows the way `Whitehall` implements change notes, but adapted to the modelling in `manuals-publisher`, which had its own `PublicationLogs` implementation. 

The feature can only be used by `gds-editors` as it is a destructive action.


[Trello](https://trello.com/c/0o6xP2vR/2282-remove-change-notes-from-page-manuals-publisher)

Link showing in the side bar
![Screenshot 2024-06-04 at 19 21 41](https://github.com/alphagov/manuals-publisher/assets/91544378/33bfd818-07be-4981-8a5c-de9ae4dae2b5)

Change notes index page
![Screenshot 2024-06-04 at 19 21 49](https://github.com/alphagov/manuals-publisher/assets/91544378/86dcb7e6-7d14-488b-b31f-b62d031f7530)

Confirmation page
![Screenshot 2024-06-04 at 19 21 57](https://github.com/alphagov/manuals-publisher/assets/91544378/e8fa4cf8-0e60-492f-a70e-84e83f62120f)


