### PR TITLE
Withdraw sections by slug should only look up published editions

### DIFF
--- a/app/lib/withdraw_and_redirect_section.rb
+++ b/app/lib/withdraw_and_redirect_section.rb
@@ -8,13 +8,11 @@ class WithdrawAndRedirectSection
   end
 
   def execute
-    section_uuid = SectionEdition.find_by(slug: section_path).section_uuid
+    section_uuid = SectionEdition.find_by(slug: section_path, state: "published").section_uuid
 
     return if dry_run
 
     section = Section.find(section_uuid)
-
-    raise SectionNotPublishedError, section.slug unless section.published?
 
     if discard_draft && section.draft?
       PublishingAdapter.unpublish_section(section, redirect:, discard_drafts: true)
@@ -26,6 +24,4 @@ class WithdrawAndRedirectSection
 private
 
   attr_reader :user, :section_path, :redirect, :discard_draft, :dry_run
-
-  class SectionNotPublishedError < StandardError; end
 end

--- a/spec/lib/withdraw_and_redirect_section_spec.rb
+++ b/spec/lib/withdraw_and_redirect_section_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe WithdrawAndRedirectSection do
     let(:state) { "draft" }
 
     it "raises an error if section is not published" do
-      expect { subject.execute }.to raise_error(WithdrawAndRedirectSection::SectionNotPublishedError)
+      expect { subject.execute }.to raise_error(Mongoid::Errors::DocumentNotFound)
     end
   end
 


### PR DESCRIPTION
There are some strange data in the database. Whilst investigating withdrawn manuals that have published sections, three of these sections failed to be withdrawn. Reason is when looking up SectionEdition by slug, there were 3 editions that were returned, the latest of which is a draft edition. This draft edition has a DIFFERENT section_uuid to its predecessors. Looking at other sections, all of the editions should be sharing a section uuid - this leads to a bug where the Section.find method can't trace back to the previous published edition via the draft, meaning edition.published? is returning an incorrect value, and the withdraw task fails.

To get around this, we should be looking up published editions only, since that's what we check for eventually anyways.


Normal expected editions of a slug, sharing the same section uuid
```
SectionEdition.where(slug: 'guidance/countryside-stewardship-2021-how-to-apply-online-for-the-wildlife-offers/annex-2-lowland-grazing-offer').pluck(:state, :section_uuid)
=> [["archived", "810e8e96-57d9-428d-8f8a-4f28c42ea38d"], 
["archived", "810e8e96-57d9-428d-8f8a-4f28c42ea38d"]]
```

Failures:
```
SectionEdition.where(slug: 'guidance/countryside-stewardship-2022-how-to-apply-by-email-or-post-for-mid-tier/print-or-download-this-guidance').pluck(:state, :section_uuid)
=> [["draft", "99cb0d31-55a8-49ed-9678-4b64773c9b7e"], 
["published", "b22f5699-7c86-4af2-a3d5-00cae2051f63"], 
["archived", "b22f5699-7c86-4af2-a3d5-00cae2051f63"]]

SectionEdition.where(slug: 'guidance/countryside-stewardship-2022-how-to-apply-by-email-or-post-for-mid-tier/be-aware-of-fraud').pluck(:state, :section_uuid)
=> [["draft", "fe37b881-db0e-4dc8-aeb0-b16d3531a74a"], 
["published", "d3c7ca20-49e2-43d1-bbd2-d3d7013c49f3"]]

SectionEdition.where(slug: 'guidance/countryside-stewardship-2022-how-to-apply-by-email-or-post-for-mid-tier/key-dates-for-countryside-stewardship-mid-tier').pluck(:state, :section_uuid)
=> [["draft", "994d2eec-0984-4ceb-a871-aabdd5c87d76"], 
["published", "0fd7cadb-63e7-4848-9ff8-08d379005860"]]
```

https://trello.com/c/AtMQQLLz/1819-stop-creating-orphaned-manual-section-pages-when-unpublishing-manuals

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
