### PR TITLE
Section Redirects should be publishing the redirect afterwards

### DIFF
--- a/app/adapters/publishing/redirect_adapter.rb
+++ b/app/adapters/publishing/redirect_adapter.rb
@@ -2,8 +2,9 @@ require "securerandom"
 
 class Publishing::RedirectAdapter
   def self.redirect_section(section, to:)
+    redirect_content_id = SecureRandom.uuid
     Services.publishing_api.put_content(
-      SecureRandom.uuid,
+      redirect_content_id,
       document_type: "redirect",
       schema_name: "redirect",
       publishing_app: GdsApiConstants::PublishingApi::PUBLISHING_APP,
@@ -15,6 +16,8 @@ class Publishing::RedirectAdapter
           destination: to,
         },
       ],
+      update_type: "major",
     )
+    Services.publishing_api.publish(redirect_content_id)
   end
 end

--- a/spec/adapters/publishing/redirect_adapter_spec.rb
+++ b/spec/adapters/publishing/redirect_adapter_spec.rb
@@ -22,7 +22,9 @@ describe Publishing::RedirectAdapter do
             destination: "/new-location",
           },
         ],
+        update_type: "major",
       )
+      expect(Services.publishing_api).to receive(:publish).with(redirect_content_id)
       Publishing::RedirectAdapter.redirect_section(section, to: "/new-location")
     end
 
@@ -31,6 +33,7 @@ describe Publishing::RedirectAdapter do
         redirect_content_id,
         be_valid_against_publisher_schema("redirect"),
       )
+      expect(Services.publishing_api).to receive(:publish).with(redirect_content_id)
       Publishing::RedirectAdapter.redirect_section(section, to: "/new-location")
     end
 
@@ -49,7 +52,9 @@ describe Publishing::RedirectAdapter do
             destination: "/new-location",
           },
         ],
+        update_type: "major",
       )
+      expect(Services.publishing_api).to receive(:publish).with(redirect_content_id)
       Publishing::RedirectAdapter.redirect_section(manual, to: "/new-location")
     end
   end

--- a/spec/lib/tasks/withdraw_and_redirect_section_rake_spec.rb
+++ b/spec/lib/tasks/withdraw_and_redirect_section_rake_spec.rb
@@ -34,7 +34,9 @@ describe "withdraw and redirect section rake tasks", type: :rake_task do
             destination: "/guidance/parent_path",
           },
         ],
+        update_type: "major",
       )
+      assert_publishing_api_publish("some-random-uuid")
     end
   end
 end


### PR DESCRIPTION
Testing out the rake task in integration and staging, the redirects were not applying until a publishing is made.

https://trello.com/c/AtMQQLLz/1819-stop-creating-orphaned-manual-section-pages-when-unpublishing-manuals

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
