### PR TITLE
Replace title component with heading

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,7 +33,6 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/components/summary-list";
 @import "govuk_publishing_components/components/table";
 @import "govuk_publishing_components/components/textarea";
-@import "govuk_publishing_components/components/title";
 @import "govuk_publishing_components/components/warning-text";
 
 @import "views/manuals";

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -47,16 +47,17 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <% if content_for?(:heading) %>
-        <%= render "govuk_publishing_components/components/title", {
+        <%= render "govuk_publishing_components/components/heading", {
+          text: yield(:heading),
           context: yield(:context),
-          title: yield(:heading),
-          margin_top: 0
+          font_size: "xl",
+          heading_level: 1,
+          margin_bottom: 8
         } %>
       <% end %>
 
       <%= yield %>
     </main>
-
   </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {
@@ -76,5 +77,4 @@
       }
     ]
   } %>
-
 <% end %>

--- a/app/views/whats_new/index.html.erb
+++ b/app/views/whats_new/index.html.erb
@@ -1,6 +1,11 @@
 <% page_name = "What's new" %>
 <% content_for :title, page_name %>
-<%= render "govuk_publishing_components/components/title", { title: page_name } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: page_name,
+  font_size: "xl",
+  heading_level: 1,
+  margin_bottom: 8
+} %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace instances of the title component with the heading component.

## Why
We're aiming to retire the title component, as it duplicates what the heading component does.

## Visual changes
None. The heading component is visually identical to the title component (when configured correctly) so there should be no difference here. I've checked by deploying this branch to integration and there is no visual difference.

Trello card: https://trello.com/c/l4VyD7Nm/395-retire-page-title-component

