### PR TITLE
Update calls to textarea with the id option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (47.0.0)
+    govuk_publishing_components (50.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -250,7 +250,8 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
-    irb (1.14.3)
+    irb (1.15.1)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.9.1)
@@ -542,6 +543,9 @@ GEM
       ast (~> 2.4.1)
       racc
     plek (5.2.0)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     prometheus_exporter (2.2.0)
       webrick
     pry (0.14.2)

--- a/app/views/sections/_form.html.erb
+++ b/app/views/sections/_form.html.erb
@@ -87,7 +87,7 @@
                     text: "Change note",
                   },
                   name: "section[change_note]",
-                  id: "section_change_note",
+                  textarea_id: "section_change_note",
                   value: section.change_note,
                   rows: 5,
                 })
@@ -110,7 +110,7 @@
               },
               hint: "Adding a new section is always a major update. This will be publicly viewable on GOV.UK.",
               name: "section[change_note]",
-              id: "section_change_note",
+              textarea_id: "section_change_note",
               value: section.change_note,
               rows: 5,
             } %>

--- a/app/views/sections/withdraw.html.erb
+++ b/app/views/sections/withdraw.html.erb
@@ -52,7 +52,7 @@
                     text: "Change note",
                   },
                   name: "section[change_note]",
-                  id: "section_change_note",
+                  textarea_id: "section_change_note",
                   value: section.change_note,
                   rows: 5,
                 })

--- a/app/views/shared/_govspeak-editor.html.erb
+++ b/app/views/shared/_govspeak-editor.html.erb
@@ -65,7 +65,7 @@
   <div class="app-c-govspeak-editor__textarea">
     <%= render "govuk_publishing_components/components/textarea", {
       name: name,
-      id: id,
+      textarea_id: id,
       rows: rows,
       value: value,
       error_items: error_items,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update all uses of the textarea component to change the `id` option to `textarea_id`.

Tests in this PR are likely to fail until the changes to the textarea component are included in this PR with a new gem release.

## Why
Changes in https://github.com/alphagov/govuk_publishing_components/pull/4574 mean that this option needs to be updated.

## Visual changes
Shouldn't be any.

Trello card: https://trello.com/c/GQ1p2oSC/438-not-doing-add-component-wrapper-helper-to-form-textarea-component