### PR TITLE
Make /component-guide available in non-dev environments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,5 +56,5 @@ Rails.application.routes.draw do
 
   get "/whats-new" => "whats_new#index", as: :whats_new
 
-  mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
 end


### PR DESCRIPTION
As is already a convention in other apps:

- https://github.com/alphagov/collections-publisher/blob/7967d70674de3941af097315a84712b1c9e64d9e/config/routes.rb#L104
- https://github.com/alphagov/content-publisher/blob/6d19292162a0843c50156241700f8d7eb68d032a/config/routes.rb#L140
- https://github.com/alphagov/publisher/blob/a0d4481e54b2d4ee58b18735869c2834dec2650c/config/routes.rb#L132

Trello: https://trello.com/c/ITcz5b1G/3417-enable-component-guide-on-non-dev-environments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
