### PR TITLE
Wait for page navigation before attempting to fix links

### DIFF
--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -39,6 +39,7 @@ Given(/^a draft manual exists without any sections$/) do
   }
 
   create_manual(@manual_fields)
+  expect(page).to have_link("Discard draft")
 
   @manual = most_recently_created_manual
 
@@ -55,6 +56,7 @@ Given(/^a draft manual exists with some sections$/) do
   }
 
   create_manual(@manual_fields)
+  expect(page).to have_link("Discard draft")
 
   @attributes_for_sections = create_sections_for_manual(
     manual_fields: @manual_fields,

--- a/features/support/manual_helpers.rb
+++ b/features/support/manual_helpers.rb
@@ -424,6 +424,7 @@ module ManualHelpers
 
     attributes_for_sections.each do |attributes|
       create_section(manual_fields.fetch(:title), attributes[:fields])
+      expect(page).to have_link("Discard draft")
     end
 
     attributes_for_sections


### PR DESCRIPTION
Some features are occasionally failing because visiting the manual page fails after saving a manual or section.

According to https://github.com/rubygems/rubygems.org/pull/5542, this occurs because previous requests have not finished when the next one starts.

We therefore add an extra assert to check that we have completed navigation to the show manual page. Without having access to the original manual, the best I could think of to do was to look for the presence of the discard draft button.

Trello: https://trello.com/c/1aowdML0
