### PR TITLE
Update Github Actions latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
         uses: actions/github-script@v6

--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -27,13 +27,13 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/manuals-publisher
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}


### PR DESCRIPTION
## What?
- Update instances of checkout@v3 to checkout@v4 in Github actions
- Add dependabot configuration to raise PRs for updates to Github actions 

## Why?
The linting of github actions has been failing since march due to actions using checkout@v3, upgrading to checkout@v4 to fix the problem.

Adding a check in dependabot for updates to Github actions will automate this process in future

