### PR TITLE
Import tag component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,7 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/components/success-alert";
 @import "govuk_publishing_components/components/summary-list";
 @import "govuk_publishing_components/components/table";
+@import "govuk_publishing_components/components/tag";
 @import "govuk_publishing_components/components/textarea";
 @import "govuk_publishing_components/components/warning-text";
 


### PR DESCRIPTION
Looks like this was missed when the gem dependabot was merged.

## Before
<img width="623" height="128" alt="image" src="https://github.com/user-attachments/assets/a8b86543-b8a3-46ad-8ffd-619c97792dd9" />

## After

<img width="623" height="128" alt="image" src="https://github.com/user-attachments/assets/a233eb82-9ee0-4fef-9878-8f4b15cae514" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
