### PR TITLE
Remove admin link guidance from Manuals Publisher [WHIT-2455]

### DIFF
--- a/app/views/shared/_govspeak_help.html.erb
+++ b/app/views/shared/_govspeak_help.html.erb
@@ -61,10 +61,8 @@
       track_action: "Links",
     },
   } do %>
-    <p class='govuk-body'>All documents created in the publisher – publications, news, speeches, detailed guides etc – should be linked to using absolute admin paths or full public URLs:</p>
-    <pre class='govspeak-help__pre'>[an admin path](/government/admin/policies/12345)<br />[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
-    <p class='govuk-body'>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
-    <pre class='govspeak-help__pre'>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+    <p class='govuk-body'>All documents created in the publisher should be linked to using full public URLs:</p>
+    <pre class='govspeak-help__pre'>[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
     <p class='govuk-body'>For external websites, use the full URL including http://:</p>
     <pre class='govspeak-help__pre'>[link text](http://www.example.com)</pre>
     <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
This guidance was copied directly from Whitehall, but doesn't actually apply in Manuals Publisher.
