### PR TITLE
Add a confirmation step to relocate_manual rake task [WHIT-1876]

### DIFF
--- a/lib/tasks/relocate_manual.rake
+++ b/lib/tasks/relocate_manual.rake
@@ -5,5 +5,11 @@ desc <<~DESCRIPTION
   Both <from-slug> and <to-slug> need to be published manuals
 DESCRIPTION
 task :relocate_manual, %i[from_slug to_slug] => :environment do |_, args|
+  puts "You're about to relocate manual from #{args[:from_slug]} to #{args[:to_slug]}"
+  unless Thor::Shell::Basic.new.yes?("Would you like to proceed with this relocation? (yes/no)")
+    puts "Aborted"
+    exit 1
+  end
+
   ManualRelocator.move(args[:from_slug], args[:to_slug])
 end


### PR DESCRIPTION
I have added a confirmation step, using the Thor gem, to the above mentioned rake task. This is to ensure that the person running this task explicitly opts in to relocating the manual from_slug to_slug.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
