### PR TITLE
Use tracking code from components library and populate `page_view` event [WHIT-2451][WHIT-2514]

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../builds
 //= link application.js
+//= link domain-config.js
 //= link es6-components.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,3 +8,7 @@
 
 //= require govspeak-editor.js
 //= require paste-html-to-govspeak.js
+
+'use strict'
+window.GOVUK.approveAllCookieTypes()
+window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })

--- a/app/assets/javascripts/domain-config.js
+++ b/app/assets/javascripts/domain-config.js
@@ -1,0 +1,25 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.vars = window.GOVUK.vars || {}
+window.GOVUK.vars.extraDomains = [
+  {
+    name: 'production',
+    domains: ['manuals-publisher.publishing.service.gov.uk'],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    gaProperty: 'UA-26179049-6'
+  },
+  {
+    name: 'staging',
+    domains: ['manuals-publisher.staging.publishing.service.gov.uk'],
+    initialiseGA4: false
+  },
+  {
+    name: 'integration',
+    domains: ['manuals-publisher.integration.publishing.service.gov.uk'],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    auth: '8jHx-VNEguw67iX9TBC6_g',
+    preview: 'env-50'
+  }
+]

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,9 +1,0 @@
-<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-  <% content_for :head do %>
-    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
-      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
-      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
-      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
-    } %>
-  <% end %>
-<% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,6 +1,16 @@
 <% product_name = "Manuals Publisher" %>
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
-<% render "layouts/google_tag_manager" %>
+
+<% content_for :head do %>
+  <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
+  <% unless Rails.env.test? %>
+    <meta name="govuk:user-created-at" content="<%= current_user&._id&.generation_time&.to_date %>">
+    <meta name="govuk:user-id" content="<%= current_user&.anonymous_user_id %>">
+    <meta name="govuk:content-id" content="<%= params[:id] %>">
+  <% end %>
+  <%= javascript_include_tag "domain-config" %>
+  <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_admin", {
   environment: environment,


### PR DESCRIPTION
## What

- Use analytics code from govuk_publishing_components
- Add extra meta tags for populating the `page_view` event

## Why

Restores tracking that was lost as a result of GA4 configuration change and ensures consistency in analytics between different publishing applications.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
