### PR TITLE
Add confirmation step to reslug_organisation rake task [WHIT-1876]

### DIFF
--- a/lib/tasks/reslug_organisation.rake
+++ b/lib/tasks/reslug_organisation.rake
@@ -1,3 +1,9 @@
+require "thor"
+
+def shell
+  @shell ||= Thor::Shell::Basic.new
+end
+
 desc "Republish manuals"
 task :reslug_organisation, %i[old_slug new_slug] => :environment do |_, args|
   unless args[:old_slug] && args[:new_slug] && args.count == 2
@@ -6,6 +12,10 @@ task :reslug_organisation, %i[old_slug new_slug] => :environment do |_, args|
 
   manual_records = ManualRecord.where(organisation_slug: args[:old_slug]).to_a
   puts "Updating the `organisation_slug` of #{manual_records.count} manual records from '#{args[:old_slug]}' to '#{args[:new_slug]}'"
+  unless shell.yes?("Would you like to proceed with this? (yes/no)")
+    puts "Aborted"
+    next
+  end
   manual_records.each do |manual_record|
     puts "- Updating ManualRecord #{manual_record[:manual_id]} (#{manual_record[:slug]})"
     manual_record.update!(organisation_slug: args[:new_slug])


### PR DESCRIPTION
I have added a confirmation step, using the Thor gem, to the above rake task. 

This is to ensure that the person running these rake tasks explicitly opts in to making these changes. I have also added a stub in the before :each block in reslug_organisation_spec to prevent the rake task from waiting for actual user input during the test.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
