### PR TITLE
Remove extra parameter from `Section.find` [WHIT-2552]

### DIFF
--- a/app/services/link_check_report/find_reportable_service.rb
+++ b/app/services/link_check_report/find_reportable_service.rb
@@ -24,7 +24,7 @@ private
   def section
     raise "Not a section" unless is_for_section?
 
-    @section ||= Section.find(manual, section_id)
+    @section ||= Section.find(section_id)
   end
 
   def is_for_section?

--- a/spec/services/link_check_report/create_service_spec.rb
+++ b/spec/services/link_check_report/create_service_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe LinkCheckReport::CreateService do
 
     before do
       allow(Manual).to receive(:find).with(manual.id, user).and_return(manual)
-      allow(Section).to receive(:find).with(manual, section.id).and_return(section)
+      allow(Section).to receive(:find).with(section.id).and_return(section)
     end
 
     context "when the link checker api is called" do

--- a/spec/services/link_check_report/find_reportable_service_spec.rb
+++ b/spec/services/link_check_report/find_reportable_service_spec.rb
@@ -35,12 +35,11 @@ RSpec.describe LinkCheckReport::FindReportableService do
     end
 
     before do
-      allow(Section).to receive(:find).with(manual, section.id).and_return(section)
+      allow(Section).to receive(:find).with(section.id).and_return(section)
     end
 
     it "should look up a manual and a section" do
-      expect(Manual).to receive(:find).with(manual.id, user)
-      expect(Section).to receive(:find).with(manual, section.id)
+      expect(Section).to receive(:find).with(section.id)
       subject
     end
   end


### PR DESCRIPTION
## What

- Remove `manual` from `Section.find` in `find_reportable_service`
- Remove test expectation of `Section.find` to be called with `manual`

## Why

This function was still calling `Section.find` with `manual` which was removed in https://github.com/alphagov/manuals-publisher/commit/a9b44b4fda497a98a35e370f7ddc76a460860678. As a result, on a broken link check of a section there was an error which would prevent a new draft of a section from being saved. This issue might not have been noticed earlier as within the test suite `Section.find` is mocked and so wouldn't have thrown an error that there were too many arguments passed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
