### PR TITLE
Add rescue for general KeyError case

### DIFF
--- a/app/lib/manuals_republisher.rb
+++ b/app/lib/manuals_republisher.rb
@@ -19,6 +19,9 @@ class ManualsRepublisher
     rescue Manual::RemovedSectionIdNotFoundError => e
       logger.error("Did not publish manual with id=#{manual.id} slug=#{manual.slug}. It has at least one removed document which was not found: #{e.message}")
       next
+    rescue KeyError => e
+      logger.error("Did not publish manual with id=#{manual.id} slug=#{manual.slug}. It may be missing a published section: #{e.message}")
+      next
     end
 
     logger.info "Republishing of #{count} manuals complete."


### PR DESCRIPTION
- There are manuals in ManualsPublisher which appear published, but have no published editions, and therefore crash when trying to find the latest edition for a section during a bulk republish.

(This allows the job to complete, it still doesn't republish all the manuals but there are only three exceptions now).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
