### PR TITLE
[WHIT-3381] Revert removing `include_sections` parameter from `withdraw_and_redirect_manual`

### DIFF
--- a/app/adapters/publishing/unpublish_adapter.rb
+++ b/app/adapters/publishing/unpublish_adapter.rb
@@ -1,5 +1,5 @@
 class Publishing::UnpublishAdapter
-  def self.unpublish_and_redirect_manual_and_sections(manual, redirect:, discard_drafts:)
+  def self.unpublish_and_redirect_manual_and_sections(manual, redirect:, include_sections:, discard_drafts:)
     Services.publishing_api.unpublish(
       manual.id,
       type: "redirect",
@@ -7,11 +7,14 @@ class Publishing::UnpublishAdapter
         { path: "/#{manual.slug}", type: "exact", destination: redirect },
         { path: "/#{manual.slug}/updates", type: "exact", destination: redirect },
       ],
+      include_sections:,
       discard_drafts:,
     )
 
-    manual.sections.each do |section|
-      unpublish_and_redirect_section(section, redirect:, discard_drafts:)
+    if include_sections
+      manual.sections.each do |section|
+        unpublish_and_redirect_section(section, redirect:, discard_drafts:)
+      end
     end
   end
 

--- a/app/lib/withdraw_and_redirect_manual.rb
+++ b/app/lib/withdraw_and_redirect_manual.rb
@@ -1,8 +1,9 @@
 class WithdrawAndRedirectManual
-  def initialize(user:, manual_path:, redirect:, discard_drafts:, dry_run: false)
+  def initialize(user:, manual_path:, redirect:, include_sections:, discard_drafts:, dry_run: false)
     @user = user
     @manual_path = manual_path
     @redirect = redirect
+    @include_sections = include_sections
     @discard_drafts = discard_drafts
     @dry_run = dry_run
   end
@@ -17,6 +18,7 @@ class WithdrawAndRedirectManual
     Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(
       manual,
       redirect:,
+      include_sections:,
       discard_drafts:,
     )
 
@@ -26,7 +28,7 @@ class WithdrawAndRedirectManual
 
 private
 
-  attr_reader :user, :manual_path, :redirect, :discard_drafts, :dry_run
+  attr_reader :user, :manual_path, :redirect, :include_sections, :discard_drafts, :dry_run
 
   class ManualNotPublishedError < StandardError; end
 end

--- a/lib/tasks/withdraw_and_redirect_manual.rake
+++ b/lib/tasks/withdraw_and_redirect_manual.rake
@@ -1,16 +1,22 @@
-desc "Withdraw and redirect manual, e.g withdraw_and_redirect_manual['guidance/manual,/redirect/blah,true']"
-task :withdraw_and_redirect_manual, %i[manual_path redirect discard_drafts] => :environment do |_, args|
+desc "Withdraw and redirect manual, e.g withdraw_and_redirect_manual['guidance/manual,/redirect/blah,true,true']"
+task :withdraw_and_redirect_manual, %i[manual_path redirect include_sections discard_drafts] => :environment do |_, args|
   discard_drafts = args.fetch(:discard_drafts) == "true"
+  include_sections = args.fetch(:include_sections) == "true"
   redirect = args.fetch(:redirect)
 
   redirect_manual = WithdrawAndRedirectManual.new(
     user: User.gds_editor,
     manual_path: args.fetch(:manual_path),
     redirect:,
+    include_sections:,
     discard_drafts:,
   )
 
   redirect_manual.execute
 
-  puts "Manual and sections withdrawn and redirected to #{redirect}"
+  if include_sections
+    puts "Manual and sections withdrawn and redirected to #{redirect}"
+  else
+    puts "Manual withdrawn and redirected to #{redirect}"
+  end
 end

--- a/spec/adapters/publishing/unpublish_adapter_spec.rb
+++ b/spec/adapters/publishing/unpublish_adapter_spec.rb
@@ -21,7 +21,7 @@ describe Publishing::UnpublishAdapter do
 
     it "unpublishes and redirects manual plus sections via Publishing API with discard draft false" do
       expect(Services.publishing_api).to receive(:unpublish).with(
-        manual_id, type: "redirect", redirects:, discard_drafts: false
+        manual_id, type: "redirect", redirects:, include_sections: true, discard_drafts: false
       )
 
       expect(Services.publishing_api).to receive(:unpublish).with(
@@ -31,12 +31,12 @@ describe Publishing::UnpublishAdapter do
         section_two_uuid, type: "redirect", discard_drafts: false, alternative_path: redirect
       )
 
-      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, discard_drafts: false)
+      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, include_sections: true, discard_drafts: false)
     end
 
     it "unpublishes and redirects manual plus sections via Publishing API with discard_draft true" do
       expect(Services.publishing_api).to receive(:unpublish).with(
-        manual_id, type: "redirect", redirects:, discard_drafts: true
+        manual_id, type: "redirect", redirects:, include_sections: true, discard_drafts: true
       )
 
       expect(Services.publishing_api).to receive(:unpublish).with(
@@ -46,13 +46,28 @@ describe Publishing::UnpublishAdapter do
         section_two_uuid, type: "redirect", discard_drafts: true, alternative_path: redirect
       )
 
-      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, discard_drafts: true)
+      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, include_sections: true, discard_drafts: true)
     end
 
     it "does not update the state of the manual" do
       allow(Services.publishing_api).to receive(:unpublish)
-      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, discard_drafts: true)
+      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, include_sections: true, discard_drafts: true)
       expect(manual.state).to eq "published"
+    end
+
+    it "unpublishes and redirects manual without sections via Publishing API with include_sections false" do
+      expect(Services.publishing_api).to receive(:unpublish).with(
+        manual_id, type: "redirect", redirects:, include_sections: false, discard_drafts: false
+      )
+
+      expect(Services.publishing_api).to_not receive(:unpublish).with(
+        section_one_uuid, type: "redirect", discard_drafts: false, alternative_path: redirect
+      )
+      expect(Services.publishing_api).to_not receive(:unpublish).with(
+        section_two_uuid, type: "redirect", discard_drafts: false, alternative_path: redirect
+      )
+
+      Publishing::UnpublishAdapter.unpublish_and_redirect_manual_and_sections(manual, redirect:, include_sections: false, discard_drafts: false)
     end
   end
 

--- a/spec/lib/withdraw_and_redirect_manual_spec.rb
+++ b/spec/lib/withdraw_and_redirect_manual_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe WithdrawAndRedirectManual do
   let(:discard_drafts) { false }
   let(:state) { "published" }
   let(:user) { User.gds_editor }
+  let(:include_sections) { true }
   let(:dry_run) { false }
 
   let(:discard_service) { double(:discard_service) }
@@ -15,6 +16,7 @@ RSpec.describe WithdrawAndRedirectManual do
       user:,
       manual_path: manual.slug,
       redirect:,
+      include_sections:,
       discard_drafts:,
       dry_run:,
     )
@@ -35,6 +37,7 @@ RSpec.describe WithdrawAndRedirectManual do
     expect(Publishing::UnpublishAdapter).to have_received(:unpublish_and_redirect_manual_and_sections)
                                     .with(instance_of(Manual),
                                           redirect:,
+                                          include_sections:,
                                           discard_drafts:)
   end
 
@@ -58,6 +61,7 @@ RSpec.describe WithdrawAndRedirectManual do
       expect(Publishing::UnpublishAdapter).to have_received(:unpublish_and_redirect_manual_and_sections)
                                       .with(instance_of(Manual),
                                             redirect:,
+                                            include_sections:,
                                             discard_drafts:)
     end
   end


### PR DESCRIPTION
## What

Add back `include_sections` parameter to the `withdraw_and_redirect_manual` task.

## Why

The [reasoning for the removal makes sense](https://github.com/alphagov/manuals-publisher/pull/2418) but there are valid cases in which a user may want to redirect specific manual sections. Without the option to set `include_sections` to `false` the entire manual is redirected and unpublished, so it's not possible to subsequently redirect individual sections.


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3381)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
