### PR TITLE
[WHIT-3381] Remove `include_sections` from call to `publishing_api`

### DIFF
--- a/app/adapters/publishing/unpublish_adapter.rb
+++ b/app/adapters/publishing/unpublish_adapter.rb
@@ -7,7 +7,6 @@ class Publishing::UnpublishAdapter
         { path: "/#{manual.slug}", type: "exact", destination: redirect },
         { path: "/#{manual.slug}/updates", type: "exact", destination: redirect },
       ],
-      include_sections:,
       discard_drafts:,
     )
 

--- a/spec/adapters/publishing/unpublish_adapter_spec.rb
+++ b/spec/adapters/publishing/unpublish_adapter_spec.rb
@@ -21,7 +21,7 @@ describe Publishing::UnpublishAdapter do
 
     it "unpublishes and redirects manual plus sections via Publishing API with discard draft false" do
       expect(Services.publishing_api).to receive(:unpublish).with(
-        manual_id, type: "redirect", redirects:, include_sections: true, discard_drafts: false
+        manual_id, type: "redirect", redirects:, discard_drafts: false
       )
 
       expect(Services.publishing_api).to receive(:unpublish).with(
@@ -36,7 +36,7 @@ describe Publishing::UnpublishAdapter do
 
     it "unpublishes and redirects manual plus sections via Publishing API with discard_draft true" do
       expect(Services.publishing_api).to receive(:unpublish).with(
-        manual_id, type: "redirect", redirects:, include_sections: true, discard_drafts: true
+        manual_id, type: "redirect", redirects:, discard_drafts: true
       )
 
       expect(Services.publishing_api).to receive(:unpublish).with(
@@ -57,7 +57,7 @@ describe Publishing::UnpublishAdapter do
 
     it "unpublishes and redirects manual without sections via Publishing API with include_sections false" do
       expect(Services.publishing_api).to receive(:unpublish).with(
-        manual_id, type: "redirect", redirects:, include_sections: false, discard_drafts: false
+        manual_id, type: "redirect", redirects:, discard_drafts: false
       )
 
       expect(Services.publishing_api).to_not receive(:unpublish).with(


### PR DESCRIPTION
## What

Remove `include_sections` from call to `publishing_api`

## Why

Not a valid parameter for `publishing_api`. Was not caught because the tests mock the call.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3381)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
