### PR TITLE
[WHIT-3381] [WHIT-1985] Bring back rake task for redirecting multiple sections

### DIFF
--- a/app/lib/withdraw_and_redirect_to_multiple_paths.rb
+++ b/app/lib/withdraw_and_redirect_to_multiple_paths.rb
@@ -1,0 +1,85 @@
+require "csv"
+
+class WithdrawAndRedirectToMultiplePaths
+  def initialize(csv_path:, discard_drafts: false, dry_run: false)
+    @csv_path = csv_path
+    @discard_drafts = discard_drafts
+    @user = User.gds_editor
+    @dry_run = dry_run
+  end
+
+  def execute
+    if dry_run
+      missing_paths = { sections: [], manuals: [] }
+    end
+
+    grouped_sections_by_manual.each do |manual_path, children|
+      children.each do |child|
+        next if updates_page?(child["base_path"])
+
+        if manual_path == child["base_path"]
+          withdraw_and_redirect_manual(child)
+        else
+          withdraw_and_redirect_section(child, manual_path)
+        end
+      rescue WithdrawAndRedirectManual::ManualNotPublishedError
+        log("[ERROR] Manual not redirected due to not being in a published state: #{child['base_path']}")
+      rescue WithdrawAndRedirectSection::SectionNotPublishedError
+        log("[ERROR] Section not redirected due to not being in a published state: #{child['base_path']}")
+      rescue Manual::NotFoundError
+        dry_run ? missing_paths[:manuals] << child["base_path"] : raise
+      rescue Mongoid::Errors::DocumentNotFound
+        dry_run ? missing_paths[:sections] << child["base_path"] : raise
+      end
+    end
+
+    missing_paths if dry_run
+  end
+
+private
+
+  attr_reader :discard_drafts, :user, :csv_path, :dry_run
+
+  def grouped_sections_by_manual
+    CSV.read(Rails.root.join(csv_path), headers: true).group_by do |route|
+      route["base_path"].split("/")[0..1].join("/")
+    end
+  end
+
+  def updates_page?(base_path)
+    if base_path =~ /^guidance\/.*\/updates$/
+      log("Updates page '#{base_path}' will be redirected to Manual's redirect, if provided") unless dry_run
+      true
+    end
+  end
+
+  def withdraw_and_redirect_manual(child)
+    WithdrawAndRedirectManual.new(
+      user:,
+      manual_path: child["base_path"],
+      redirect: child["redirect"],
+      include_sections: false,
+      discard_drafts:,
+      dry_run:,
+    ).execute
+
+    log("Withdrawn manual '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run
+  end
+
+  def withdraw_and_redirect_section(child, manual_path)
+    WithdrawAndRedirectSection.new(
+      user:,
+      manual_path:,
+      section_path: child["base_path"],
+      redirect: child["redirect"],
+      discard_draft: discard_drafts,
+      dry_run:,
+    ).execute
+
+    log("Withdrawn section '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run
+  end
+
+  def log(str)
+    $stdout.puts(str)
+  end
+end

--- a/docs/2017-migration-project-archive/rake-tasks.md
+++ b/docs/2017-migration-project-archive/rake-tasks.md
@@ -6,10 +6,19 @@ A manual can be withdrawn and redirected to another page on www.gov.uk.
 
 There are a few rake tasks, depending on the requirements.
 
+### Withdraw the manual and all its sections as gone
+
+This rake task will unpublish the manual and all the sections as `gone`.
+
+```
+withdraw_manual[manual-id]
+```
+
 ### Withdraw and redirect a single manual which can include its sections
 
-The last two boolean arguments flag whether to include sections and discard
-drafts, respectively.
+This rake task will unpublish and redirect the manual and, optionally, all its sections. The last two boolean arguments flag whether to include sections and discard drafts, respectively.
+
+For most manuals, you will likely want to include the sections, i.e. redirect them to the same destination as the manual.
 
 ```
 withdraw_and_redirect_manual[guidance/manual,/redirect/blah,true,true]
@@ -17,7 +26,9 @@ withdraw_and_redirect_manual[guidance/manual,/redirect/blah,true,true]
 
 ### Withdraw and redirect a single section
 
-The last boolean argument flags whether to discard drafts.
+This rake task will unpublish and redirect a single section. The last boolean argument flags whether to discard drafts.
+
+Run this if a single section needs to be redirected, on a live manual. You can also use multiple calls to this task to redirect all the individual sections of a manual to different destinations, if needed, when the manual is being withdrawn.
 
 ```
 withdraw_and_redirect_section[guidance/manual,guidance/manual/section,/redirect/blah,true]
@@ -26,7 +37,7 @@ withdraw_and_redirect_section[guidance/manual,guidance/manual/section,/redirect/
 ### Bulk withdraw and redirect multiple manuals and sections
 
 If multiple manuals need to be redirected, or there are multiple redirect
-destinations within manuals, e.g sections need to redirect to different places,
+destinations within manuals, e.g. sections need to redirect to different places,
 then we can do this by uploading a CSV and running the below tasks. Example CSV
 PR: https://github.com/alphagov/manuals-publisher/pull/1895.
 

--- a/lib/tasks/withdraw_and_redirect_manual.rake
+++ b/lib/tasks/withdraw_and_redirect_manual.rake
@@ -1,8 +1,26 @@
+require "thor"
+
+def shell
+  @shell ||= Thor::Shell::Basic.new
+end
+
 desc "Withdraw and redirect manual, e.g withdraw_and_redirect_manual['guidance/manual,/redirect/blah,true,true']"
 task :withdraw_and_redirect_manual, %i[manual_path redirect include_sections discard_drafts] => :environment do |_, args|
   discard_drafts = args.fetch(:discard_drafts) == "true"
   include_sections = args.fetch(:include_sections) == "true"
   redirect = args.fetch(:redirect)
+
+  confirmation_message =
+    if include_sections
+      "You're about to redirect the manual and all its sections to '#{redirect}'. Proceed? (yes/no)"
+    else
+      "You're about to redirect the manual to '#{redirect}', but the sections will not be redirected due to `include_sections` argument passed in as false.\nYou must ensure that all of the manual's sections are redirected individually, using the `withdraw_and_redirect_section` rake task or an alternative approach such as Short URL Manager.\nProceed? (yes/no)"
+    end
+
+  unless shell.yes?(confirmation_message)
+    shell.say_error "Aborted"
+    next
+  end
 
   redirect_manual = WithdrawAndRedirectManual.new(
     user: User.gds_editor,

--- a/lib/tasks/withdraw_and_redirect_manuals_to_multiple_paths.rake
+++ b/lib/tasks/withdraw_and_redirect_manuals_to_multiple_paths.rake
@@ -1,0 +1,27 @@
+namespace :withdraw_and_redirect_manuals_to_multiple_paths  do
+  desc "Withdraw and redirect manual to multiple paths, e.g withdraw_and_redirect_manuals_to_multiple_paths['lib/tasks/tmp_redirect.csv,true']"
+  task :real, %i[csv_path discard_drafts] => :environment do |_, args|
+    discard_drafts = args.fetch(:discard_drafts) == "true"
+
+    WithdrawAndRedirectToMultiplePaths.new(
+      csv_path: args.fetch(:csv_path), discard_drafts:,
+    ).execute
+  end
+
+  desc "Dry run to check all base_paths in CSV exist"
+  task :dry_run, %i[csv_path] => :environment do |_, args|
+    missing_paths = WithdrawAndRedirectToMultiplePaths.new(
+      csv_path: args.fetch(:csv_path), dry_run: true,
+    ).execute
+
+    if missing_paths[:sections].blank? && missing_paths[:manuals].blank?
+      puts "PASS - all paths from the CSV exist"
+    else
+      puts "FAIL - some paths don't exist"
+
+      puts "Missing Manuals: #{missing_paths[:manuals]}"
+
+      puts "Missing Sections: #{missing_paths[:sections]}"
+    end
+  end
+end

--- a/spec/lib/withdraw_and_redirect_to_multiple_paths_spec.rb
+++ b/spec/lib/withdraw_and_redirect_to_multiple_paths_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+RSpec.describe WithdrawAndRedirectToMultiplePaths do
+  let(:discard_drafts) { false }
+  let(:dry_run) { false }
+
+  let(:withdraw_and_redirect_manual) { double(:withdraw_and_redirect_manual) }
+  let(:withdraw_and_redirect_section) { double(:withdraw_and_redirect_section) }
+
+  subject do
+    described_class.new(
+      csv_path: "spec/support/withdraw_and_redirect_to_multiple_paths.csv",
+      discard_drafts:,
+      dry_run:,
+    )
+  end
+
+  before do
+    allow(WithdrawAndRedirectManual).to receive(:new) { withdraw_and_redirect_manual }
+    allow(withdraw_and_redirect_manual).to receive(:execute)
+
+    allow(WithdrawAndRedirectSection).to receive(:new) { withdraw_and_redirect_section }
+    allow(withdraw_and_redirect_section).to receive(:execute)
+  end
+
+  it "withdraws and redirects a manual" do
+    expect { subject.execute }.to output.to_stdout
+
+    expect(WithdrawAndRedirectManual).to have_received(:new).with(
+      user: instance_of(User),
+      manual_path: "guidance/published",
+      redirect: "/guidance/redirect",
+      include_sections: false,
+      discard_drafts: false,
+      dry_run: false,
+    )
+
+    expect(withdraw_and_redirect_manual).to have_received(:execute)
+  end
+
+  it "withdraws and redirects section" do
+    expect { subject.execute }.to output.to_stdout
+
+    expect(WithdrawAndRedirectSection).to have_received(:new).with(
+      user: instance_of(User),
+      manual_path: "guidance/manual",
+      section_path: "guidance/manual/just-a-section",
+      redirect: "/guidance/section-blah",
+      discard_draft: false,
+      dry_run: false,
+    )
+
+    expect(withdraw_and_redirect_section).to have_received(:execute)
+  end
+
+  it "skips updates page" do
+    expect { subject.execute }.to output(
+      /Updates page 'guidance\/published\/updates' will be redirected to Manual's redirect, if provided\n/,
+    ).to_stdout
+  end
+
+  it "rescues and logs error if a manual isn't published" do
+    allow(withdraw_and_redirect_manual).to receive(:execute).and_raise(WithdrawAndRedirectManual::ManualNotPublishedError)
+
+    expect { subject.execute }.to output(
+      /\[ERROR\] Manual not redirected due to not being in a published state: guidance\/published/,
+    ).to_stdout
+  end
+
+  it "rescues and logs error if a section isn't published" do
+    allow(withdraw_and_redirect_section).to receive(:execute).and_raise(WithdrawAndRedirectSection::SectionNotPublishedError)
+
+    expect { subject.execute }.to output(
+      /\[ERROR\] Section not redirected due to not being in a published state: guidance\/manual\/just-a-section/,
+    ).to_stdout
+  end
+
+  it "raises error if manual is not found" do
+    allow(withdraw_and_redirect_section).to receive(:execute).and_raise(Manual::NotFoundError)
+    expect { subject.execute }
+      .to output.to_stdout
+      .and raise_error(Manual::NotFoundError)
+  end
+
+  it "raises error if section is not found" do
+    allow(withdraw_and_redirect_section).to receive(:execute)
+      .and_raise(Mongoid::Errors::DocumentNotFound.new(SectionEdition, anything))
+    expect { subject.execute }
+      .to output.to_stdout
+      .and raise_error(Mongoid::Errors::DocumentNotFound)
+  end
+
+  context "when a dry run is flagged" do
+    let(:dry_run) { true }
+
+    it "generates a list of missing paths" do
+      allow(withdraw_and_redirect_manual).to receive(:execute).and_raise(Manual::NotFoundError)
+      allow(withdraw_and_redirect_section).to receive(:execute).and_raise(
+        Mongoid::Errors::DocumentNotFound.new(SectionEdition, anything),
+      )
+
+      expect(subject.execute).to eq({ manuals: ["guidance/published"], sections: ["guidance/manual/just-a-section"] })
+    end
+  end
+end


### PR DESCRIPTION
Revert "Remove rake task to withdraw and redirect manual and sections to different paths via a CSV file"

This reverts commit 6bd20c6666f95bb45ed6cac2c6027c4bc2aac5f7.

Since the reversal of commits c0c3c48f and 7efdc28e, we have brought back the `include_section` flag, due to user need. Despite the commit at the time of removal (6bd20c66) suggesting alternatives, we've recently had the need for an efficient bulk approach when dealing with multiple sections that need to be redirected to different resources (such as a recent request for redirects from manuals to mainstream for 'Assured periodic tenancies: a guide for landlords').

The concern at the time of removal was that a manual could be withdrawn without its sections. A confirmation step to the manual withdraw rake task now helps prevent this (commit 1749d288).

The existing rake task uses the csv approach, which can be a bit unwieldy, but it's handy to have it discoverable in the codebase. We did not find this rake task when doing that redirect earlier in May, so we managed with the existing tasks, but it was quite labour-intensive.

Note: I did not test this, it's an old task, but we might have to use it soon, so we can verify it then. It could benefit from some checks like ensuring ALL sections are dealt with, or at least prompting the user about any sections that haven't been included (they remain live with a funny title area since their parent is missing). There was a lot of manual counting and cross-checking when doing this in May with the section rake task.

Jira:
https://gov-uk.atlassian.net/browse/WHIT-3381
https://gov-uk.atlassian.net/browse/WHIT-1985
