### PR TITLE
Add dependabot cooldown and open pr limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
 
   - package-ecosystem: npm
     directory: /
@@ -13,6 +14,7 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
 
   - package-ecosystem: github-actions
     directory: /
@@ -20,3 +22,4 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25


### PR DESCRIPTION
Adds a dependabot cooldown of 3 days and increases the upper limit on dependabot PRs to 25, as agreed in https://gov-uk.atlassian.net/browse/WHIT-3369

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
