### PR TITLE
Call WithdrawAndRedirectSection correctly

### DIFF
--- a/app/lib/withdraw_and_redirect_to_multiple_paths.rb
+++ b/app/lib/withdraw_and_redirect_to_multiple_paths.rb
@@ -20,7 +20,7 @@ class WithdrawAndRedirectToMultiplePaths
         if manual_path == child["base_path"]
           withdraw_and_redirect_manual(child)
         else
-          withdraw_and_redirect_section(child, manual_path)
+          withdraw_and_redirect_section(child)
         end
       rescue WithdrawAndRedirectManual::ManualNotPublishedError
         log("[ERROR] Manual not redirected due to not being in a published state: #{child['base_path']}")
@@ -66,10 +66,9 @@ private
     log("Withdrawn manual '#{child['base_path']}' and redirected to '#{child['redirect']}'") unless dry_run
   end
 
-  def withdraw_and_redirect_section(child, manual_path)
+  def withdraw_and_redirect_section(child)
     WithdrawAndRedirectSection.new(
       user:,
-      manual_path:,
       section_path: child["base_path"],
       redirect: child["redirect"],
       discard_draft: discard_drafts,

--- a/spec/lib/withdraw_and_redirect_to_multiple_paths_spec.rb
+++ b/spec/lib/withdraw_and_redirect_to_multiple_paths_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe WithdrawAndRedirectToMultiplePaths do
 
     expect(WithdrawAndRedirectSection).to have_received(:new).with(
       user: instance_of(User),
-      manual_path: "guidance/manual",
       section_path: "guidance/manual/just-a-section",
       redirect: "/guidance/section-blah",
       discard_draft: false,


### PR DESCRIPTION
The multiple withdraw and redirect class was incorrectly passing the `manual_path` param to the `WithdrawAndRedirectSection` class - it is not expecting or needing that param.

This change removes the `manual_path` param from the init call.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
